### PR TITLE
Alertas proativos na central de notificações

### DIFF
--- a/ev/core/commands.py
+++ b/ev/core/commands.py
@@ -529,9 +529,13 @@ class Commands:
             spent = self._memory.category_total_since(user_id, category, since)
             pct = spent / budget * 100 if budget else 0
             if pct >= 100:
-                msg += f"\n🔴 Estourou o orçamento de {category}: R$ {spent:.2f} / R$ {budget:.2f}."
+                alert = f"Estourou o orçamento de {category}: R$ {spent:.2f} / R$ {budget:.2f}."
+                msg += f"\n🔴 {alert}"
+                self._memory.add_notification(user_id, "🔴 Orçamento estourado", alert)
             elif pct >= 80:
-                msg += f"\n🟡 Atenção: {pct:.0f}% do orçamento de {category} (R$ {spent:.2f} / R$ {budget:.2f})."
+                alert = f"{pct:.0f}% do orçamento de {category} (R$ {spent:.2f} / R$ {budget:.2f})."
+                msg += f"\n🟡 Atenção: {alert}"
+                self._memory.add_notification(user_id, "🟡 Orçamento em atenção", alert)
         return msg
 
     def gastos(self, user_id: str, argstr: str = "") -> str:

--- a/ev/interfaces/telegram_bot.py
+++ b/ev/interfaces/telegram_bot.py
@@ -1954,6 +1954,15 @@ class TelegramInterface:
             await self._bot_send(app.bot, cfg.owner_id, text, self._quick_kb())
             log.info("Sent weekly review.")
 
+    def _log_notif(self, title: str, body: str = "") -> None:
+        """Record a proactive alert in the web notification center too."""
+        if self._config.owner_id is None:
+            return
+        try:
+            self._memory.add_notification(str(self._config.owner_id), title, body, "/")
+        except Exception:
+            log.warning("notification log failed", exc_info=True)
+
     async def _maybe_send_rain(self, app: Application) -> None:
         cfg = self._config
         if cfg.rain_hour < 0 or cfg.owner_id is None or not cfg.city:
@@ -1966,6 +1975,7 @@ class TelegramInterface:
             msg = await asyncio.to_thread(tools.rain_tomorrow, cfg.city)
             if msg:
                 await self._bot_send(app.bot, cfg.owner_id, msg, self._quick_kb())
+                self._log_notif("🌧️ Alerta de chuva", msg)
                 log.info("Sent rain alert.")
 
     async def _maybe_run_recurring(self, app: Application) -> None:
@@ -2086,6 +2096,7 @@ class TelegramInterface:
                 "/diario <texto>. E não esquece dos seus hábitos — /habitos."
             )
             await self._bot_send(app.bot, cfg.owner_id, msg, self._quick_kb())
+            self._log_notif("👋 Check-in do dia", msg)
             log.info("Sent daily check-in.")
 
     async def _maybe_send_briefing(self, app: Application) -> None:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -166,6 +166,9 @@ def test_budget_alert(tmp_path):
     assert "definido" in c.orcamento("u", "comida 100")
     warn = c.gasto("u", "85 mercado #comida")  # 85% of the limit
     assert "orçamento" in warn.lower()
+    # the alert is also recorded in the notification center
+    notifs = c._memory.list_notifications("u")
+    assert notifs and "rçamento" in notifs[0]["title"]
     assert "comida" in c.orcamentos("u")
     assert "removido" in c.orcamentorm("u", "comida")
 


### PR DESCRIPTION
## 🤔 Context

A central de notificações da E.V. web (adicionada recentemente) só registrava notificações que passavam por Web Push — na prática, os lembretes disparados. Os alertas **proativos** (chuva, orçamento, check-in do dia) existiam apenas como mensagem no Telegram e nunca apareciam na central.

Este PR faz esses alertas também serem gravados na central, para que possam ser revistos, marcados como lidos e apagados por lá:

- **Orçamento** (`>=80%` / `>=100%`): registrado direto em `commands.gasto()`, então vale para qualquer interface que registre gastos (Telegram, web, IA).
- **Chuva** e **check-in do dia**: registrados via um helper `_log_notif` no bot, ao lado do envio pro Telegram.

> [!NOTE]
> Outros avisos proativos (briefing diário, revisão semanal, cutucada de hábitos, relatório mensal, assinatura lançada) continuam só no Telegram — dá pra trazer pra central depois se fizer sentido.

## Alterações

| Área | Mudança |
|------|---------|
| `ev/core/commands.py` | Alerta de orçamento também chama `memory.add_notification` |
| `ev/interfaces/telegram_bot.py` | Helper `_log_notif` + chamadas em chuva e check-in |
| `tests/test_commands.py` | Regressão: alerta de orçamento gera notificação |

148 testes passam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)