### PR TITLE
Ler e resumir e-mails (Gmail), não só enviar

### DIFF
--- a/ev/core/brain.py
+++ b/ev/core/brain.py
@@ -447,6 +447,8 @@ class Brain:
             habitos, habitorm, diario, diariorm, link, links, linkrm, procurar,
             buscar, noticias, clima, kb, kbrm, kbweb, semana, vigiar, vigias,
             vigiarm, assinatura, assinaturas, assinaturarm, agenda, evento, email,
+            emails (ler/resumir e-mails recentes; aceita busca do Gmail como
+            argumento, ex: 'is:unread' ou 'faturas'),
             foco, silenciar, exportar, status, resumir, limparchat, dados, limpar,
             quiz, insights, modelo, documento, transcrever, ajuda, menu.
 

--- a/ev/core/commands.py
+++ b/ev/core/commands.py
@@ -85,6 +85,7 @@ COMMAND_LIST = [
     ("agenda", "Agenda do Google: /agenda [conta]"),
     ("evento", "Criar evento: /evento [conta] amanhã 15:00 Dentista"),
     ("email", "E-mail: /email [conta] fulano@x.com | Assunto | Corpo"),
+    ("emails", "Ver e-mails recentes: /emails [conta] [busca]"),
 ]
 
 
@@ -228,6 +229,7 @@ class Commands:
             "agenda": lambda u, a: self.agenda(a),
             "evento": lambda u, a: self.evento(a),
             "email": lambda u, a: self.email(a),
+            "emails": lambda u, a: self.emails(a),
         }
 
     def runnable(self) -> list[str]:
@@ -980,6 +982,13 @@ class Commands:
                     self._config, self._config.default_account, max_results=5
                 )
             )
+            unread = tools_mod.inbox_summary(
+                self._config, self._config.default_account,
+                "is:unread in:inbox", max_results=5)
+            low = unread.lower()
+            if "nenhum" not in low and "não consegui" not in low:
+                parts.append("\nE-mails não lidos:")
+                parts.append(unread)
 
         if len(parts) == 1:
             parts.append("Nada na lista. Dia livre — aproveita!")
@@ -1167,3 +1176,11 @@ class Commands:
             return "Uso: /email [conta] destinatário | assunto | corpo"
         to, subject, body = parts
         return tools_mod.send_email(self._config, account, to, subject, body)
+
+    def emails(self, argstr: str = "") -> str:
+        if not self._google_ready():
+            return "E-mail do Google ainda não configurado. Conecte sua conta primeiro."
+        account, rest = self._resolve_account(argstr)
+        header = f"[{account}]\n" if len(self._config.google_accounts) > 1 else ""
+        query = rest.strip() or "is:unread in:inbox"
+        return header + tools_mod.inbox_summary(self._config, account, query)

--- a/ev/interfaces/telegram_bot.py
+++ b/ev/interfaces/telegram_bot.py
@@ -1357,6 +1357,10 @@ class TelegramInterface:
         if self._authorized(update):
             await self._cmd_out(update, self._commands.email(self._args(c)))
 
+    async def cmd_emails(self, update: Update, c: ContextTypes.DEFAULT_TYPE) -> None:
+        if self._authorized(update):
+            await self._cmd_out(update, self._commands.emails(self._args(c)))
+
     # --- interactive menu (buttons) ----------------------------------------
 
     # Sections with a simple "list / add" shape.
@@ -2301,6 +2305,7 @@ class TelegramInterface:
         app.add_handler(CommandHandler("agenda", self.cmd_agenda))
         app.add_handler(CommandHandler("evento", self.cmd_evento))
         app.add_handler(CommandHandler("email", self.cmd_email))
+        app.add_handler(CommandHandler("emails", self.cmd_emails))
         # Document upload (PDF) -> knowledge base
         app.add_handler(MessageHandler(filters.Document.ALL, self.on_document))
         # Photo -> multimodal (Gemini vision)

--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -717,6 +717,7 @@ const MENU=[
     {c:'/habitos',l:'Hábitos',i:'repeat'},{c:'/diario',l:'Diário',i:'notebook-pen'},
     {c:'/memorias',l:'Memórias',i:'brain'},{c:'/links',l:'Links',i:'link'},
     {c:'/relatorio',l:'Relatório',i:'bar-chart-3'},{c:'/semana',l:'Semana',i:'calendar-days'},
+    {c:'/emails',l:'E-mails',i:'mail'},
     {c:'/status',l:'Status',i:'activity'},{c:'/dados',l:'Meus dados',i:'database'}]},
   {h:'Criar',gi:'plus-circle',items:[
     {c:'/tarefa',l:'Tarefa',i:'plus',fill:1},{c:'/lembrete',l:'Lembrete',i:'alarm-clock',fill:1},

--- a/ev/providers/tools.py
+++ b/ev/providers/tools.py
@@ -14,10 +14,11 @@ import logging
 
 log = logging.getLogger("ev.tools")
 
-# Read/write scopes for Calendar and Gmail send.
+# Read/write scopes for Calendar, plus Gmail send AND read.
 _GOOGLE_SCOPES = [
     "https://www.googleapis.com/auth/calendar",
     "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/gmail.readonly",
 ]
 
 
@@ -546,3 +547,68 @@ def send_email(config, account: str, to: str, subject: str, body: str) -> str:
     except Exception as exc:
         log.warning("send_email failed (%s)", exc)
         return f"não consegui enviar o e-mail ({exc})"
+
+
+def _clean_from(value: str) -> str:
+    """'Fulano <a@b.com>' -> 'Fulano'; bare address -> the address."""
+    value = (value or "").strip()
+    if "<" in value:
+        name = value.split("<", 1)[0].strip().strip('"')
+        return name or value.split("<", 1)[1].rstrip(">").strip()
+    return value
+
+
+def list_emails(config, account: str, query: str = "is:unread in:inbox",
+                max_results: int = 8) -> list[dict]:
+    """Return recent emails matching a Gmail search `query` (metadata only).
+
+    Each item: {id, from, subject, date, snippet, unread}. Raises on API error
+    so the caller can surface a clear message (e.g. missing read authorization).
+    """
+    service = _google_service(config, account, "gmail", "v1")
+    resp = (
+        service.users().messages()
+        .list(userId="me", q=query, maxResults=max_results)
+        .execute()
+    )
+    out: list[dict] = []
+    for ref in resp.get("messages", []):
+        msg = (
+            service.users().messages()
+            .get(userId="me", id=ref["id"], format="metadata",
+                 metadataHeaders=["From", "Subject", "Date"])
+            .execute()
+        )
+        headers = {h["name"].lower(): h["value"]
+                   for h in msg.get("payload", {}).get("headers", [])}
+        out.append({
+            "id": ref["id"],
+            "from": _clean_from(headers.get("from", "")),
+            "subject": headers.get("subject", "(sem assunto)"),
+            "date": headers.get("date", ""),
+            "snippet": (msg.get("snippet", "") or "").strip(),
+            "unread": "UNREAD" in msg.get("labelIds", []),
+        })
+    return out
+
+
+def inbox_summary(config, account: str, query: str = "is:unread in:inbox",
+                  max_results: int = 8) -> str:
+    """Human-readable summary of recent emails, formatted for chat rendering."""
+    try:
+        items = list_emails(config, account, query, max_results)
+    except Exception as exc:
+        log.warning("inbox_summary failed (%s)", exc)
+        msg = str(exc)
+        if "insufficient" in msg.lower() or "scope" in msg.lower() or "403" in msg:
+            return ("não consegui ler os e-mails — falta autorizar a leitura. "
+                    "Rode authorize_google.py de novo pra conceder o acesso de leitura.")
+        return f"não consegui ler os e-mails ({msg[:120]})"
+    if not items:
+        return "nenhum e-mail novo por aqui."
+    lines = [f"📥 E-mails ({len(items)}):", ""]
+    for i, m in enumerate(items, 1):
+        lines.append(f"#{i} {m['from']} — {m['subject']}")
+        if m["snippet"]:
+            lines.append(f"   {m['snippet'][:140]}")
+    return "\n".join(lines)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -216,6 +216,24 @@ def test_google_disabled(tmp_path):
     c = _commands(tmp_path)
     assert "não configurada" in c.agenda()
     assert "não configurado" in c.email("a@b.com | oi | teste")
+    assert "não configurado" in c.emails()
+
+
+def test_inbox_summary_formatting(monkeypatch):
+    from ev.providers import tools
+    monkeypatch.setattr(tools, "list_emails", lambda *a, **k: [
+        {"id": "1", "from": "Banco", "subject": "Fatura", "date": "",
+         "snippet": "vence amanhã", "unread": True}])
+    out = tools.inbox_summary(None, "pessoal")
+    assert "Fatura" in out and "Banco" in out and "#1" in out
+    # empty inbox -> friendly line
+    monkeypatch.setattr(tools, "list_emails", lambda *a, **k: [])
+    assert "nenhum e-mail" in tools.inbox_summary(None, "pessoal").lower()
+    # a scope/permission error -> tells the user to re-authorize
+    def _boom(*a, **k):
+        raise RuntimeError("insufficient authentication scopes")
+    monkeypatch.setattr(tools, "list_emails", _boom)
+    assert "autorizar" in tools.inbox_summary(None, "pessoal").lower()
 
 
 def test_bad_input(tmp_path):


### PR DESCRIPTION
## 🤔 Context

A E.V. só sabia **enviar** e-mail (escopo `gmail.send`). Este PR dá a ela a capacidade de **ler e resumir** a caixa de entrada — o passo que a transforma de "assistente de tarefas" em assistente de verdade.

O que foi adicionado:
- Escopo `gmail.readonly` na autorização Google.
- `tools.list_emails` / `tools.inbox_summary` (busca por metadados: remetente, assunto, trecho).
- Comando `/emails [conta] [busca]` — disponível no Telegram, na web e como ferramenta da IA (ex: "tem e-mail novo?", "resume meus e-mails de fatura").
- Seção de **e-mails não lidos** no briefing diário.

> [!WARNING]
> A leitura só passa a funcionar depois de **reautorizar** o Google (rodar `authorize_google.py` de novo num PC com navegador) para conceder o escopo de leitura. Até lá, a E.V. responde com um aviso claro pedindo essa autorização — nada quebra. Vale conferir depois da reautorização que agenda e envio de e-mail continuam funcionando.

## Alterações

| Área | Mudança |
|------|---------|
| `ev/providers/tools.py` | Escopo `gmail.readonly` + `list_emails` / `inbox_summary` |
| `ev/core/commands.py` | Comando `emails` + seção no briefing diário |
| `ev/interfaces/telegram_bot.py` | Handler `/emails` |
| `ev/core/brain.py` | `emails` documentado na ferramenta `executar_comando` |
| `ev/interfaces/web.py` | Chip "E-mails" no menu interativo |
| `tests/test_commands.py` | Formatação do resumo, caixa vazia, erro de escopo |

149 testes passam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)