### PR TITLE
Corrige: token do Google quebrava ao adicionar escopo

### DIFF
--- a/ev/providers/tools.py
+++ b/ev/providers/tools.py
@@ -423,7 +423,12 @@ def _google_service(config, account: str, api: str, version: str, allow_interact
     token_path = config.token_path_for(account)
     creds = None
     if token_path.exists():
-        creds = Credentials.from_authorized_user_file(str(token_path), _GOOGLE_SCOPES)
+        # Load with the scopes ALREADY granted in the token file (not the full
+        # _GOOGLE_SCOPES list). Otherwise adding a new scope makes refresh request
+        # a scope the token never had -> Google returns invalid_scope and breaks
+        # even the previously-working calls. New scopes take effect only after a
+        # re-authorization (authorize_google.py), which rewrites the token file.
+        creds = Credentials.from_authorized_user_file(str(token_path))
 
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:


### PR DESCRIPTION
## 🤔 Context

O PR #13 (ler e-mail) adicionou o escopo `gmail.readonly`. Só que o token em cache era carregado com a lista **completa** de escopos — então o *refresh* passou a pedir um escopo que o token nunca teve, e o Google respondeu `invalid_scope`, derrubando inclusive a **agenda e o envio de e-mail** que já funcionavam.

Correção: carregar o token com os escopos que ele **já possui** (lidos do próprio arquivo). Assim agenda/envio voltam imediatamente; o escopo de leitura só passa a valer depois da reautorização, que reescreve o token com o novo escopo.

> [!NOTE]
> Verificado na VM: antes do fix, `calendar_upcoming` retornava `invalid_scope`. Este PR restaura o comportamento e mantém a degradação suave da leitura ("falta autorizar") até a reautorização.

## Alterações

| Área | Mudança |
|------|---------|
| `ev/providers/tools.py` | `from_authorized_user_file` sem forçar `_GOOGLE_SCOPES` |

149 testes passam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)