### PR TITLE
Ler e-mail via IMAP (senha de app) em vez de escopo OAuth restrito

### DIFF
--- a/ev/config.py
+++ b/ev/config.py
@@ -82,6 +82,8 @@ class Config:
     vapid_public: str          # Web Push (VAPID) public key — sent to the browser
     vapid_private: str         # Web Push private key (server signs pushes)
     vapid_subject: str         # VAPID claims subject (mailto:...)
+    imap_address: str          # Gmail address for reading mail via IMAP
+    imap_password: str         # Gmail "app password" (not the account password)
     db_path: Path
 
     @property
@@ -94,6 +96,10 @@ class Config:
 
     def google_ready(self) -> bool:
         return bool(self.google_oauth_client and self.google_accounts)
+
+    def imap_ready(self) -> bool:
+        """True once a Gmail address + app password are configured for reading."""
+        return bool(self.imap_address and self.imap_password)
 
     def google_authorized(self, account: str | None = None) -> bool:
         """True only if an OAuth token already exists for the account (i.e. the
@@ -217,5 +223,7 @@ class Config:
             vapid_public=os.getenv("VAPID_PUBLIC", "").strip(),
             vapid_private=os.getenv("VAPID_PRIVATE", "").strip(),
             vapid_subject=os.getenv("VAPID_SUBJECT", "mailto:ev@example.com").strip(),
+            imap_address=os.getenv("EV_IMAP_ADDRESS", "").strip(),
+            imap_password=os.getenv("EV_IMAP_PASSWORD", "").strip(),
             db_path=_PROJECT_ROOT / "ev_memory.db",
         )

--- a/ev/core/brain.py
+++ b/ev/core/brain.py
@@ -447,8 +447,8 @@ class Brain:
             habitos, habitorm, diario, diariorm, link, links, linkrm, procurar,
             buscar, noticias, clima, kb, kbrm, kbweb, semana, vigiar, vigias,
             vigiarm, assinatura, assinaturas, assinaturarm, agenda, evento, email,
-            emails (ler/resumir e-mails recentes; aceita busca do Gmail como
-            argumento, ex: 'is:unread' ou 'faturas'),
+            emails (ler/resumir e-mails recentes da caixa; sem argumento traz os
+            não lidos; com um termo faz busca simples, ex: 'faturas'),
             foco, silenciar, exportar, status, resumir, limparchat, dados, limpar,
             quiz, insights, modelo, documento, transcrever, ajuda, menu.
 

--- a/ev/core/commands.py
+++ b/ev/core/commands.py
@@ -982,11 +982,12 @@ class Commands:
                     self._config, self._config.default_account, max_results=5
                 )
             )
-            unread = tools_mod.inbox_summary(
-                self._config, self._config.default_account,
-                "is:unread in:inbox", max_results=5)
+
+        if self._config.imap_ready():
+            unread = tools_mod.inbox_summary(self._config, "", "", max_results=5)
             low = unread.lower()
-            if "nenhum" not in low and "não consegui" not in low:
+            if ("nenhum" not in low and "não consegui" not in low
+                    and "não configurada" not in low):
                 parts.append("\nE-mails não lidos:")
                 parts.append(unread)
 
@@ -1178,9 +1179,7 @@ class Commands:
         return tools_mod.send_email(self._config, account, to, subject, body)
 
     def emails(self, argstr: str = "") -> str:
-        if not self._google_ready():
-            return "E-mail do Google ainda não configurado. Conecte sua conta primeiro."
-        account, rest = self._resolve_account(argstr)
-        header = f"[{account}]\n" if len(self._config.google_accounts) > 1 else ""
-        query = rest.strip() or "is:unread in:inbox"
-        return header + tools_mod.inbox_summary(self._config, account, query)
+        if not self._config.imap_ready():
+            return ("Leitura de e-mail ainda não configurada. Defina EV_IMAP_ADDRESS "
+                    "e EV_IMAP_PASSWORD (senha de app do Gmail).")
+        return tools_mod.inbox_summary(self._config, "", argstr.strip())

--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -2060,6 +2060,8 @@ def create_app(config: Config, brain: Brain | None = None):
         ("openrouter_api_key", "OPENROUTER_API_KEY", "OpenRouter (fallback)"),
         ("tavily_api_key", "TAVILY_API_KEY", "Tavily (busca web)"),
         ("brave_api_key", "BRAVE_API_KEY", "Brave (busca web)"),
+        ("imap_address", "EV_IMAP_ADDRESS", "E-mail Gmail (leitura)"),
+        ("imap_password", "EV_IMAP_PASSWORD", "Senha de app Gmail (leitura)"),
     ]
 
     def _env_write(var, value):

--- a/ev/providers/tools.py
+++ b/ev/providers/tools.py
@@ -14,11 +14,12 @@ import logging
 
 log = logging.getLogger("ev.tools")
 
-# Read/write scopes for Calendar, plus Gmail send AND read.
+# Read/write scopes for Calendar and Gmail send. Reading mail is done over IMAP
+# with an app password (gmail.readonly is a "restricted" OAuth scope that Google
+# blocks for unverified apps), so it is NOT requested here.
 _GOOGLE_SCOPES = [
     "https://www.googleapis.com/auth/calendar",
     "https://www.googleapis.com/auth/gmail.send",
-    "https://www.googleapis.com/auth/gmail.readonly",
 ]
 
 
@@ -563,57 +564,96 @@ def _clean_from(value: str) -> str:
     return value
 
 
-def list_emails(config, account: str, query: str = "is:unread in:inbox",
-                max_results: int = 8) -> list[dict]:
-    """Return recent emails matching a Gmail search `query` (metadata only).
+def _imap_query(query: str):
+    """Map a small, friendly query to an IMAP SEARCH criterion.
 
-    Each item: {id, from, subject, date, snippet, unread}. Raises on API error
-    so the caller can surface a clear message (e.g. missing read authorization).
+    "" / "unread" / "is:unread" -> only unread; anything else -> full-text TEXT
+    search across recent mail. Returns a criteria tuple for imaplib search().
     """
-    service = _google_service(config, account, "gmail", "v1")
-    resp = (
-        service.users().messages()
-        .list(userId="me", q=query, maxResults=max_results)
-        .execute()
-    )
-    out: list[dict] = []
-    for ref in resp.get("messages", []):
-        msg = (
-            service.users().messages()
-            .get(userId="me", id=ref["id"], format="metadata",
-                 metadataHeaders=["From", "Subject", "Date"])
-            .execute()
-        )
-        headers = {h["name"].lower(): h["value"]
-                   for h in msg.get("payload", {}).get("headers", [])}
-        out.append({
-            "id": ref["id"],
-            "from": _clean_from(headers.get("from", "")),
-            "subject": headers.get("subject", "(sem assunto)"),
-            "date": headers.get("date", ""),
-            "snippet": (msg.get("snippet", "") or "").strip(),
-            "unread": "UNREAD" in msg.get("labelIds", []),
-        })
-    return out
+    q = (query or "").strip().lower()
+    if q in ("", "unread", "is:unread", "in:inbox", "is:unread in:inbox", "não lidos", "nao lidos"):
+        return ("UNSEEN",)
+    return ("TEXT", query.strip())
 
 
-def inbox_summary(config, account: str, query: str = "is:unread in:inbox",
+def _decode_header(raw: str) -> str:
+    from email.header import decode_header
+    out = []
+    for part, enc in decode_header(raw or ""):
+        if isinstance(part, bytes):
+            try:
+                out.append(part.decode(enc or "utf-8", "replace"))
+            except (LookupError, TypeError):
+                out.append(part.decode("utf-8", "replace"))
+        else:
+            out.append(part)
+    return "".join(out).strip()
+
+
+def list_emails(config, account: str = "", query: str = "",
+                max_results: int = 8) -> list[dict]:
+    """Return recent emails from the configured Gmail inbox via IMAP.
+
+    Reading uses IMAP + an app password (config.imap_address/imap_password), not
+    OAuth. Each item: {from, subject, date, snippet, unread}. `account` is
+    accepted for call-site compatibility but ignored (single mailbox).
+    """
+    import email as _email
+    import imaplib
+
+    if not config.imap_ready():
+        raise RuntimeError("imap-not-configured")
+
+    conn = imaplib.IMAP4_SSL("imap.gmail.com", 993)
+    try:
+        conn.login(config.imap_address, config.imap_password)
+        conn.select("INBOX", readonly=True)
+        typ, data = conn.search(None, *_imap_query(query))
+        ids = data[0].split() if data and data[0] else []
+        ids = ids[-max_results:][::-1]  # newest first
+        out: list[dict] = []
+        for mid in ids:
+            typ, msg_data = conn.fetch(
+                mid, "(BODY.PEEK[HEADER.FIELDS (FROM SUBJECT DATE)])")
+            if not msg_data or not msg_data[0]:
+                continue
+            msg = _email.message_from_bytes(msg_data[0][1])
+            out.append({
+                "from": _clean_from(_decode_header(msg.get("From", ""))),
+                "subject": _decode_header(msg.get("Subject", "")) or "(sem assunto)",
+                "date": msg.get("Date", ""),
+                "snippet": "",
+                "unread": True,  # default UNSEEN search; best-effort otherwise
+            })
+        return out
+    finally:
+        try:
+            conn.logout()
+        except Exception:
+            pass
+
+
+def inbox_summary(config, account: str = "", query: str = "",
                   max_results: int = 8) -> str:
     """Human-readable summary of recent emails, formatted for chat rendering."""
     try:
         items = list_emails(config, account, query, max_results)
     except Exception as exc:
-        log.warning("inbox_summary failed (%s)", exc)
         msg = str(exc)
-        if "insufficient" in msg.lower() or "scope" in msg.lower() or "403" in msg:
-            return ("não consegui ler os e-mails — falta autorizar a leitura. "
-                    "Rode authorize_google.py de novo pra conceder o acesso de leitura.")
+        if "imap-not-configured" in msg:
+            return ("leitura de e-mail ainda não configurada. Defina EV_IMAP_ADDRESS "
+                    "e EV_IMAP_PASSWORD (senha de app do Gmail) para eu ler sua caixa.")
+        log.warning("inbox_summary failed (%s)", exc)
+        low = msg.lower()
+        if "authenticationfailed" in low or "invalid credentials" in low or "login" in low:
+            return ("não consegui entrar no e-mail — confira a senha de app "
+                    "(EV_IMAP_PASSWORD) e se o IMAP está ativado no Gmail.")
         return f"não consegui ler os e-mails ({msg[:120]})"
     if not items:
         return "nenhum e-mail novo por aqui."
     lines = [f"📥 E-mails ({len(items)}):", ""]
     for i, m in enumerate(items, 1):
-        lines.append(f"#{i} {m['from']} — {m['subject']}")
-        if m["snippet"]:
-            lines.append(f"   {m['snippet'][:140]}")
+        line = f"#{i} {m['from']} — {m['subject']}"
+        when = m.get("date", "")
+        lines.append(line)
     return "\n".join(lines)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -14,6 +14,9 @@ def _commands(tmp_path):
         gemini_api_key="x",
         embed_backend="gemini",
         embed_model="m",
+        imap_address="",
+        imap_password="",
+        imap_ready=lambda: False,
     )
     return Commands(config, Memory(tmp_path / "t.db"))
 
@@ -216,24 +219,31 @@ def test_google_disabled(tmp_path):
     c = _commands(tmp_path)
     assert "não configurada" in c.agenda()
     assert "não configurado" in c.email("a@b.com | oi | teste")
-    assert "não configurado" in c.emails()
+    # reading needs IMAP creds, not Google
+    assert "não configurada" in c.emails().lower()
 
 
 def test_inbox_summary_formatting(monkeypatch):
     from ev.providers import tools
     monkeypatch.setattr(tools, "list_emails", lambda *a, **k: [
-        {"id": "1", "from": "Banco", "subject": "Fatura", "date": "",
-         "snippet": "vence amanhã", "unread": True}])
-    out = tools.inbox_summary(None, "pessoal")
+        {"from": "Banco", "subject": "Fatura", "date": "", "snippet": "", "unread": True}])
+    out = tools.inbox_summary(None, "", "")
     assert "Fatura" in out and "Banco" in out and "#1" in out
     # empty inbox -> friendly line
     monkeypatch.setattr(tools, "list_emails", lambda *a, **k: [])
-    assert "nenhum e-mail" in tools.inbox_summary(None, "pessoal").lower()
-    # a scope/permission error -> tells the user to re-authorize
+    assert "nenhum e-mail" in tools.inbox_summary(None, "", "").lower()
+    # not-configured -> tells the user to set the IMAP creds
     def _boom(*a, **k):
-        raise RuntimeError("insufficient authentication scopes")
+        raise RuntimeError("imap-not-configured")
     monkeypatch.setattr(tools, "list_emails", _boom)
-    assert "autorizar" in tools.inbox_summary(None, "pessoal").lower()
+    assert "não configurada" in tools.inbox_summary(None, "", "").lower()
+
+
+def test_imap_query_mapping():
+    from ev.providers import tools
+    assert tools._imap_query("") == ("UNSEEN",)
+    assert tools._imap_query("is:unread") == ("UNSEEN",)
+    assert tools._imap_query("fatura") == ("TEXT", "fatura")
 
 
 def test_bad_input(tmp_path):


### PR DESCRIPTION
## 🤔 Context

O escopo `gmail.readonly` (necessário pra ler e-mail via API) é **restrito** e o Google o **bloqueia em apps não verificados**; além disso, tokens em modo "teste" expiram a cada 7 dias — inviável pra uma assistente 24/7. Confirmado ao vivo: o consentimento não concedia o escopo e o fluxo travava.

Solução: a **leitura** passa a ser feita por **IMAP com uma senha de app** do Gmail (sem OAuth, sem verificação do Google, não expira). O **envio** continua pelo escopo `gmail.send` que já funciona.

> [!NOTE]
> Requer configurar `EV_IMAP_ADDRESS` e `EV_IMAP_PASSWORD` (senha de app do Gmail) — dá pra fazer pela própria interface, em "Chaves de API". Até lá, `/emails` responde com um aviso claro e nada quebra.

## Alterações

| Área | Mudança |
|------|---------|
| `ev/config.py` | `imap_address` / `imap_password` + `imap_ready()` |
| `ev/providers/tools.py` | `list_emails`/`inbox_summary` via `imaplib`; remove escopo `gmail.readonly` |
| `ev/core/commands.py` | `/emails` e briefing passam a checar `imap_ready()` |
| `ev/core/brain.py` | descrição da ferramenta `emails` atualizada |
| `ev/interfaces/web.py` | campos IMAP no formulário "Chaves de API" |
| `tests/test_commands.py` | formatação, caixa vazia, não-configurado, mapeamento de busca |

150 testes passam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)