### PR TITLE
Foto da nota → gasto lançado (com confirmação)

### DIFF
--- a/ev/core/brain.py
+++ b/ev/core/brain.py
@@ -124,6 +124,57 @@ class Brain:
         """Extract text from an image via Gemini vision (OCR)."""
         return await asyncio.to_thread(self._ocr_sync, image, mime)
 
+    async def extract_receipt(self, image: bytes, mime: str | None) -> dict | None:
+        """Read a receipt/invoice image -> {amount, description, category} or None."""
+        return await asyncio.to_thread(self._extract_receipt_sync, image, mime)
+
+    @staticmethod
+    def _parse_receipt_json(raw: str) -> dict | None:
+        """Parse the vision model's JSON reply into a validated expense dict."""
+        import json
+        import re
+        m = re.search(r"\{.*\}", raw or "", re.S)
+        if not m:
+            return None
+        try:
+            d = json.loads(m.group(0))
+        except (ValueError, TypeError):
+            return None
+        try:
+            amount = round(float(str(d.get("valor", 0)).replace(",", ".").strip()), 2)
+        except (ValueError, TypeError):
+            return None
+        if amount <= 0:
+            return None
+        desc = (str(d.get("descricao") or "").strip() or "compra")[:80]
+        cat = re.sub(r"[^a-zà-ú0-9]", "",
+                     str(d.get("categoria") or "geral").strip().lower()) or "geral"
+        return {"amount": amount, "description": desc, "category": cat}
+
+    def _extract_receipt_sync(self, image: bytes, mime: str | None) -> dict | None:
+        prompt = (
+            "Esta imagem é um comprovante, nota fiscal ou recibo. Extraia o gasto e "
+            "responda APENAS um JSON, sem texto ao redor, com as chaves: "
+            "\"valor\" (número — o TOTAL pago), "
+            "\"descricao\" (estabelecimento ou o que foi comprado, curto), "
+            "\"categoria\" (UMA palavra: mercado, comida, transporte, saude, lazer, "
+            "casa, assinatura, etc). "
+            "Se não for um comprovante ou não achar o total, responda {\"valor\": 0}."
+        )
+        try:
+            resp = self._client.models.generate_content(
+                model=self.current_model(),
+                contents=[
+                    types.Part.from_bytes(data=image, mime_type=mime or "image/jpeg"),
+                    types.Part.from_text(text=prompt),
+                ],
+                config=types.GenerateContentConfig(temperature=0.0),
+            )
+            return self._parse_receipt_json(resp.text or "")
+        except Exception as exc:
+            log.warning("receipt extraction (Gemini vision) failed (%s)", exc)
+            return None
+
     async def health_check(self) -> list[dict]:
         """Live-ping each configured provider. Returns [{name, ok, note}]."""
         return await asyncio.to_thread(self._health_check_sync)

--- a/ev/interfaces/telegram_bot.py
+++ b/ev/interfaces/telegram_bot.py
@@ -67,6 +67,8 @@ class TelegramInterface:
         self._pending_files: dict[str, tuple[str, str]] = {}
         # short id -> (image_bytes, mime) for photo OCR
         self._pending_images: dict[str, tuple[bytes, str]] = {}
+        # short id -> parsed expense dict, for the receipt "confirmar gasto" button
+        self._pending_expense: dict[str, dict] = {}
         # short id -> reminder text, for the snooze/done buttons on a fired reminder
         self._pending_rem: dict[str, str] = {}
         self._doc_seq = 0
@@ -835,6 +837,7 @@ class TelegramInterface:
         b = InlineKeyboardButton
         return InlineKeyboardMarkup([
             [b("📄 Extrair texto (OCR)", callback_data=f"ocr:{fid}")],
+            [b("💰 Lançar gasto", callback_data=f"receipt:{fid}")],
             [b("🏠 Menu", callback_data="nav:main"),
              b("➕ Tarefa", callback_data="task:add"),
              b("⏰ Lembrete", callback_data="rem:add")],
@@ -1488,6 +1491,20 @@ class TelegramInterface:
         if section == "ocr":
             await self._handle_ocr(q, uid, action)
             return
+        if section == "receipt":
+            await self._handle_receipt(q, uid, action)
+            return
+        if section == "expok":
+            await self._confirm_expense(q, uid, action)
+            return
+        if section == "expno":
+            self._pending_expense.pop(action, None)
+            await q.answer("Cancelado.")
+            try:
+                await q.edit_message_reply_markup(reply_markup=None)
+            except Exception:
+                pass
+            return
         if section == "export":
             if action == "menu":
                 await q.edit_message_text(
@@ -1776,6 +1793,55 @@ class TelegramInterface:
             q.message, summary or "Não consegui resumir agora, tenta de novo?",
             self._quick_kb(),
         )
+
+    async def _handle_receipt(self, q, uid: str, fid: str) -> None:
+        entry = self._pending_images.get(fid)
+        if entry is None:
+            await q.answer("Essa imagem expirou. Envia de novo, por favor.", show_alert=True)
+            return
+        image, mime = entry
+        await q.answer("Lendo o comprovante...")
+        try:
+            await q.edit_message_reply_markup(reply_markup=None)
+        except Exception:
+            pass
+        exp = await self._brain.extract_receipt(image, mime)
+        if not exp:
+            await q.message.reply_text(
+                "Não consegui identificar um valor nesse comprovante. "
+                "Você pode lançar na mão: /gasto 50 mercado #casa",
+                reply_markup=self._quick_kb(),
+            )
+            return
+        self._pending_images.pop(fid, None)
+        eid = self._stash(self._pending_expense, exp)
+        self._trim(self._pending_expense, 20)
+        b = InlineKeyboardButton
+        kb = InlineKeyboardMarkup([
+            [b(f"✅ Confirmar R$ {exp['amount']:.2f}", callback_data=f"expok:{eid}")],
+            [b("❌ Cancelar", callback_data=f"expno:{eid}")],
+        ])
+        await q.message.reply_text(
+            f"Identifiquei este gasto:\n\n"
+            f"💰 R$ {exp['amount']:.2f}\n"
+            f"📝 {exp['description']}\n"
+            f"🏷️ #{exp['category']}\n\nConfirma o lançamento?",
+            reply_markup=kb,
+        )
+
+    async def _confirm_expense(self, q, uid: str, eid: str) -> None:
+        exp = self._pending_expense.pop(eid, None)
+        if exp is None:
+            await q.answer("Esse lançamento expirou. Manda a foto de novo.", show_alert=True)
+            return
+        await q.answer("Lançando...")
+        try:
+            await q.edit_message_reply_markup(reply_markup=None)
+        except Exception:
+            pass
+        argstr = f"{exp['amount']:.2f} {exp['description']} #{exp['category']}"
+        result = self._commands.gasto(uid, argstr)
+        await q.message.reply_text(result, reply_markup=self._quick_kb())
 
     async def _handle_ocr(self, q, uid: str, fid: str) -> None:
         entry = self._pending_images.get(fid)

--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -351,7 +351,9 @@ body.term #txt::placeholder{color:#4a4a4a}
 #imgprev{display:none;align-items:center;gap:12px;padding:9px 18px;border-top:1px solid var(--line);background:var(--surface)}
 #imgprev img{width:48px;height:48px;object-fit:cover;border-radius:9px;border:1px solid var(--line)}
 #imgprev .ip-name{flex:1;min-width:0;font-size:12px;color:var(--muted);font-family:var(--mono);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-#imgprev .ip-x{background:var(--elev);border:1px solid var(--line);color:var(--fg);width:30px;height:30px;flex:none;border-radius:8px;cursor:pointer;font-size:17px;line-height:1}
+#imgprev .ip-x{background:var(--elev);border:1px solid var(--line);color:var(--fg);width:30px;height:30px;flex:none;border-radius:8px;cursor:pointer;font-size:17px;line-height:1;display:inline-flex;align-items:center;justify-content:center}
+#imgprev .ip-x:hover{background:var(--fg);color:var(--ink)}
+#imgprev .ip-x svg{width:16px;height:16px}
 .msg-img{max-width:230px;max-height:230px;border-radius:11px;display:block}
 #audprev{display:none;align-items:center;gap:10px;padding:9px 18px;border-top:1px solid var(--line);background:var(--surface)}
 #audprev .ap-info{flex:1;min-width:0;font-size:12.5px;color:var(--muted);font-family:var(--mono)}
@@ -1364,8 +1366,17 @@ function youImg(caption,url){const d=el('div','msg you');const img=document.crea
 let _pendingImg=null;
 function setPendingImg(f){_pendingImg=f;const p=$('#imgprev');p.innerHTML='';if(!f){p.style.display='none';return;}
   const img=document.createElement('img');img.src=URL.createObjectURL(f);
+  const rc=el('button','ip-x');rc.title='Lançar como gasto';rc.appendChild(ficon('wallet'));rc.onclick=()=>receiptFromImage(f);
   const x=el('button','ip-x','×');x.title='remover';x.onclick=()=>setPendingImg(null);
-  p.appendChild(img);p.appendChild(el('span','ip-name',f.name+' — escreva algo (opcional) e envie'));p.appendChild(x);p.style.display='flex';if(txt)txt.focus();}
+  p.appendChild(img);p.appendChild(el('span','ip-name',f.name+' — envie, ou toque na carteira pra lançar gasto'));p.appendChild(rc);p.appendChild(x);p.style.display='flex';window.lucide&&lucide.createIcons();if(txt)txt.focus();}
+async function receiptFromImage(file){if(!file)return;const p=thinking();setState('thinking');
+  try{const fd=new FormData();fd.append('image',file);
+    const j=await (await fetch('/api/receipt',{method:'POST',headers:{'Authorization':'Bearer '+token},body:fd})).json();
+    p.remove();
+    if(!j.ok){sys(j.msg||'Não consegui identificar um valor nesse comprovante.');return;}
+    const ok=await confirmDialog('Lançar R$ '+Number(j.amount).toFixed(2)+' — '+j.description+' (#'+j.category+')?');
+    if(ok){setPendingImg(null);switchView('chat');runCmd('gasto '+Number(j.amount).toFixed(2)+' '+j.description+' #'+j.category);}
+  }catch(e){p.remove();sys('Falha ao ler o comprovante.');}finally{setState();}}
 async function sendImage(file,caption){if(!file)return;youImg(caption,URL.createObjectURL(file));const p=thinking();setState('thinking');
   try{const fd=new FormData();fd.append('image',file);if(caption)fd.append('text',caption);fd.append('thread',thread);
     const j=await (await fetch('/api/vision',{method:'POST',headers:{'Authorization':'Bearer '+token},body:fd})).json();
@@ -2423,6 +2434,25 @@ def create_app(config: Config, brain: Brain | None = None):
         except Exception as exc:
             return {"reply": f"Não consegui analisar a imagem: {exc}"}
         return {"reply": reply}
+
+    @app.post("/api/receipt")
+    async def receipt(request: Request):
+        _check(request.headers.get("authorization"))
+        form = await request.form()
+        f = form.get("image")
+        if f is None or isinstance(f, str) or not hasattr(f, "read"):
+            return {"ok": False, "msg": "Nenhuma imagem enviada."}
+        data = await f.read()
+        if not data:
+            return {"ok": False, "msg": "Imagem vazia."}
+        try:
+            exp = await brain.extract_receipt(data, f.content_type or "image/jpeg")
+        except Exception as exc:
+            return {"ok": False, "msg": f"Não consegui ler o comprovante: {exc}"}
+        if not exp:
+            return {"ok": False,
+                    "msg": "Não consegui identificar um valor nesse comprovante."}
+        return {"ok": True, **exp}
 
     @app.post("/api/stt")
     async def stt(request: Request):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -279,3 +279,16 @@ def test_rotina(tmp_path):
     assert "Rotina" in out and "todo dia" in out
     assert "[todo dia]" in c.lembretes("u")
     assert "inválida" in c.rotina("u", "anual 08:00 x").lower()
+
+
+def test_receipt_json_parsing():
+    from ev.core.brain import Brain
+    p = Brain._parse_receipt_json
+    assert p('{"valor": 42.5, "descricao": "Mercado X", "categoria": "Mercado"}') == {
+        "amount": 42.5, "description": "Mercado X", "category": "mercado"}
+    # comma decimal + text around the JSON
+    r = p('claro! {"valor":"19,90","descricao":"Uber","categoria":"transporte"} pronto')
+    assert r["amount"] == 19.9 and r["category"] == "transporte"
+    # not a receipt / zero / garbage -> None
+    assert p('{"valor": 0}') is None
+    assert p('sem json') is None


### PR DESCRIPTION
## 🤔 Context

A E.V. já enxergava imagens (visão/OCR) e já registrava gastos — mas faltava juntar as duas coisas. Agora dá pra **fotografar um comprovante** e ela lê o **valor total**, o **estabelecimento** e sugere uma **categoria**, e lança como gasto **após você confirmar** (sem digitar nada).

Fluxo com confirmação de propósito: nada é lançado sem seu ok, e o lançamento passa por `commands.gasto`, então continua valendo o **alerta de orçamento** e o registro na **central de notificações**.

```mermaid
sequenceDiagram
    participant U as Você
    participant EV as E.V. (visão)
    participant DB as Gastos
    U->>EV: foto do comprovante
    EV->>EV: lê valor / estabelecimento / categoria
    EV->>U: "R$ 42,50 — Mercado X (#mercado). Confirmar?"
    U->>EV: Confirmar
    EV->>DB: lança gasto (+ alerta de orçamento)
```

## Alterações

| Área | Mudança |
|------|---------|
| `ev/core/brain.py` | `extract_receipt` + `_parse_receipt_json` (visão → dict validado) |
| `ev/interfaces/telegram_bot.py` | botão "Lançar gasto" na foto → confirmar → `commands.gasto` |
| `ev/interfaces/web.py` | botão carteira no preview de imagem → `/api/receipt` → confirmar → lança |
| `tests/test_commands.py` | parsing do JSON do recibo (vírgula decimal, ruído, valor zero) |

151 testes passam. A extração usa o modelo de visão do Gemini; se ele não achar um valor, responde com aviso e nada é lançado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)