### PR TITLE
Corrige CRUD por voz/chat da IA (ferramentas Google quebradas + fallback sem tools)

### DIFF
--- a/ev/core/brain.py
+++ b/ev/core/brain.py
@@ -600,7 +600,7 @@ class Brain:
         if cfg.google_oauth_client:
             def ver_agenda() -> str:
                 """Lista os próximos eventos da agenda do Google do usuário."""
-                return tools_mod.calendar_upcoming(cfg)
+                return tools_mod.calendar_upcoming(cfg, cfg.default_account)
 
             def criar_evento(titulo: str, inicio: str, fim: str) -> str:
                 """Cria um evento na agenda do Google.
@@ -610,7 +610,8 @@ class Brain:
                     inicio: início em ISO 8601.
                     fim: fim em ISO 8601.
                 """
-                return tools_mod.calendar_create(cfg, titulo, inicio, fim)
+                return tools_mod.calendar_create(
+                    cfg, cfg.default_account, titulo, inicio, fim)
 
             def enviar_email(para: str, assunto: str, corpo: str) -> str:
                 """Envia um e-mail pela conta Gmail do usuário.
@@ -620,7 +621,8 @@ class Brain:
                     assunto: assunto do e-mail.
                     corpo: corpo do e-mail.
                 """
-                return tools_mod.send_email(cfg, para, assunto, corpo)
+                return tools_mod.send_email(
+                    cfg, cfg.default_account, para, assunto, corpo)
 
             callables["ver_agenda"] = ver_agenda
             callables["criar_evento"] = criar_evento
@@ -845,8 +847,10 @@ class Brain:
     # --- fallbacks: Groq -> OpenRouter --------------------------------------
 
     def _openai_messages(self, conv_id: str, new_text: str) -> list[dict]:
+        # Keep history short on the fallback path: Groq's free tier caps tokens
+        # per minute (~8k), and a long history + tool schemas blows past it (429).
         msgs: list[dict] = []
-        for m in self._memory.recent_messages(conv_id, limit=20):
+        for m in self._memory.recent_messages(conv_id, limit=8):
             role = "assistant" if m["role"] == "model" else "user"
             msgs.append({"role": role, "content": m["content"]})
         msgs.append({"role": "user", "content": new_text})
@@ -877,22 +881,40 @@ class Brain:
             except Exception as exc:
                 log.warning("Groq fallback failed (%s).", exc)
 
-        # 2) OpenRouter — plain text (final backstop, no memory).
+        # 2) OpenRouter — also WITH tools, so CRUD still works when Groq is rate
+        #    limited. Falls back to plain text if the model can't do tool-calling.
         if cfg.openrouter_api_key and only in (None, "openrouter"):
             try:
-                answer = providers.chat_openai_compat(
+                answer = providers.chat_with_tools(
                     base_url=providers.OPENROUTER_BASE_URL,
                     api_key=cfg.openrouter_api_key,
                     model=cfg.openrouter_model,
                     system=system,
                     messages=messages,
+                    tools=self._openai_tools(),
+                    tool_functions=self._tool_callables(user_id),
+                    temperature=0.2,
                 )
                 if answer:
-                    log.info("Answered via OpenRouter (%s).", cfg.openrouter_model)
+                    log.info("Answered via OpenRouter (%s) with tools.", cfg.openrouter_model)
                     self._last_provider = "openrouter"
                     return answer
             except Exception as exc:
-                log.warning("OpenRouter fallback failed (%s).", exc)
+                log.warning("OpenRouter (tools) failed (%s); trying plain text.", exc)
+                try:
+                    answer = providers.chat_openai_compat(
+                        base_url=providers.OPENROUTER_BASE_URL,
+                        api_key=cfg.openrouter_api_key,
+                        model=cfg.openrouter_model,
+                        system=system,
+                        messages=messages,
+                    )
+                    if answer:
+                        log.info("Answered via OpenRouter (%s), plain.", cfg.openrouter_model)
+                        self._last_provider = "openrouter"
+                        return answer
+                except Exception as exc2:
+                    log.warning("OpenRouter plain failed (%s).", exc2)
 
         # 3) Ollama — local model, never rate-limited (final safety net).
         if cfg.ollama_enabled and only in (None, "ollama"):

--- a/tests/test_ai_commands.py
+++ b/tests/test_ai_commands.py
@@ -22,3 +22,34 @@ def test_no_overlap_between_data_and_interface(tmp_path):
     )
     data_cmds = set(Commands(cfg, Memory(tmp_path / "t.db")).runnable())
     assert data_cmds.isdisjoint(_INTERFACE_COMMANDS)
+
+
+def test_google_tool_wrappers_pass_account(tmp_path, monkeypatch):
+    """ver_agenda / criar_evento / enviar_email must call the tools layer with the
+    account argument (a regression: they used to drop it -> TypeError at runtime)."""
+    from ev.core.brain import Brain
+    from ev.providers import tools as tools_mod
+
+    cfg = SimpleNamespace(
+        timezone="America/Sao_Paulo", google_oauth_client="client.json",
+        google_accounts=("pessoal",), default_account="pessoal",
+        gemini_api_key="x", embed_backend="gemini", embed_model="m",
+        model="gemini-flash-latest",
+        groq_api_key="", openrouter_api_key="", ollama_enabled=False,
+        tavily_api_key="", brave_api_key="", websearch_enabled=False,
+    )
+    brain = Brain(cfg, Memory(tmp_path / "t.db"))
+    calls = {}
+    monkeypatch.setattr(tools_mod, "calendar_upcoming",
+                        lambda c, acct, *a, **k: calls.update(agenda=acct) or "ok")
+    monkeypatch.setattr(tools_mod, "calendar_create",
+                        lambda c, acct, s, si, ei: calls.update(evento=(acct, s, si, ei)) or "ok")
+    monkeypatch.setattr(tools_mod, "send_email",
+                        lambda c, acct, to, subj, body: calls.update(email=(acct, to, subj, body)) or "ok")
+    fns = brain._tool_callables("u")
+    assert fns["ver_agenda"]() == "ok"
+    assert fns["criar_evento"]("Dentista", "2026-08-02T19:00", "2026-08-02T20:00") == "ok"
+    assert fns["enviar_email"]("a@b.com", "Oi", "Corpo") == "ok"
+    assert calls["agenda"] == "pessoal"
+    assert calls["evento"] == ("pessoal", "Dentista", "2026-08-02T19:00", "2026-08-02T20:00")
+    assert calls["email"] == ("pessoal", "a@b.com", "Oi", "Corpo")


### PR DESCRIPTION
## 🤔 Context

A E.V. não conseguia fazer parte dos CRUDs quando pedidos por voz/chat e dava respostas evasivas ("problemas para renderizar"). Investigando os logs da VM, achei **três causas reais**:

1. **Ferramentas Google quebradas**: `criar_evento`, `ver_agenda` e `enviar_email` chamavam a camada de tools **sem o argumento `account`** (adicionado depois) → `TypeError` em runtime. Ex. real do log: `calendar_create() missing 1 required positional argument: 'end_iso'`.
2. **Fallback sem ferramentas**: quando o Gemini (503/429) e o Groq (limite de 8k tokens/min → 429) estavam esgotados, o pedido caía no **OpenRouter, que rodava sem ferramentas** → o CRUD simplesmente não acontecia e o modelo respondia de forma evasiva.
3. **Requisição pesada em tokens** (histórico de 20 mensagens + schemas das ferramentas) estourava o TPM do Groq rápido.

## Correções

| Causa | Correção |
|------|----------|
| Tools Google sem `account` | Passa `cfg.default_account` em `criar_evento`, `ver_agenda`, `enviar_email` + teste de regressão |
| OpenRouter sem tools | Fallback do OpenRouter agora usa `chat_with_tools` (texto puro só como último recurso) |
| TPM do Groq estourando | Histórico do fallback reduzido de 20 → 8 mensagens |

> [!NOTE]
> A confiabilidade depende também de cota dos provedores. Com o histórico enxuto o Groq (que faz tool-calling bem) deve suceder muito mais; e o OpenRouter agora é um backup real pra CRUD. Se quiser robustez máxima, vale um modelo do OpenRouter com suporte a ferramentas ou o Groq Dev Tier.

152 testes passam (novo teste cobre as três ferramentas Google).

🤖 Generated with [Claude Code](https://claude.com/claude-code)