### PR TITLE
Corrige executar_comando quando o modelo embute args no nome do comando

### DIFF
--- a/ev/core/brain.py
+++ b/ev/core/brain.py
@@ -508,14 +508,28 @@ class Brain:
                 argumentos: os argumentos no mesmo formato do comando
                     (ex: '50 mercado #casa' para gasto; 'estudar #faculdade' para tarefa).
             """
-            key = (comando or "").strip().lower().lstrip("/")
+            # The model sometimes stuffs the args into `comando`
+            # (e.g. comando="tarefa comprar pão", argumentos=""). Split so the
+            # command name is just the first token and the rest becomes args.
+            raw = (comando or "").strip().lstrip("/")
+            tokens = raw.split(None, 1)
+            key = (tokens[0] if tokens else "").lower()
+            argumentos = (argumentos or "").strip()
+            if len(tokens) > 1 and not argumentos:
+                argumentos = tokens[1]
+            log.info("[executar_comando] comando=%r -> key=%r args=%r",
+                     comando, key, argumentos)
             if key in self._commands.runnable():
-                return self._commands.run(user_id, key, argumentos)  # runs now (text)
+                out = self._commands.run(user_id, key, argumentos)  # runs now (text)
+                log.info("[executar_comando] %s -> %s", key, str(out)[:160])
+                return out
             if key in _INTERFACE_COMMANDS:
                 # Needs the chat context — queue it for the interface to run.
-                self._last_actions.append({"command": key, "args": argumentos or ""})
+                self._last_actions.append({"command": key, "args": argumentos})
                 return f"ok, executando '{key}' agora"
-            return self._commands.run(user_id, key, argumentos)  # -> "não conheço"
+            out = self._commands.run(user_id, key, argumentos)  # -> "não conheço"
+            log.info("[executar_comando] unknown %r -> %s", key, str(out)[:120])
+            return out
 
         def consultar_clima(cidade: str) -> str:
             """Consulta a previsão do tempo real (hoje e próximos dias) de uma cidade.

--- a/tests/test_ai_commands.py
+++ b/tests/test_ai_commands.py
@@ -53,3 +53,22 @@ def test_google_tool_wrappers_pass_account(tmp_path, monkeypatch):
     assert calls["agenda"] == "pessoal"
     assert calls["evento"] == ("pessoal", "Dentista", "2026-08-02T19:00", "2026-08-02T20:00")
     assert calls["email"] == ("pessoal", "a@b.com", "Oi", "Corpo")
+
+
+def test_executar_comando_handles_inline_args(tmp_path):
+    """The model sometimes puts args in `comando` ("tarefa comprar pão"); that
+    must still route to the right command instead of "não conheço"."""
+    from ev.core.brain import Brain
+
+    cfg = SimpleNamespace(
+        timezone="America/Sao_Paulo", google_oauth_client="", google_accounts=(),
+        default_account="", gemini_api_key="x", embed_backend="gemini",
+        embed_model="m", model="gemini-flash-latest", groq_api_key="",
+        openrouter_api_key="", ollama_enabled=False, tavily_api_key="",
+        brave_api_key="", websearch_enabled=False,
+    )
+    brain = Brain(cfg, Memory(tmp_path / "t.db"))
+    ec = brain._tool_callables("u")["executar_comando"]
+    assert "adicionada" in ec("tarefa comprar pão #casa")   # args inside comando
+    assert "adicionada" in ec("tarefa", "estudar #faculdade")  # normal form
+    assert "comprar pão" in brain._commands.tarefas("u")


### PR DESCRIPTION
## 🤔 Context

Continuação da investigação do CRUD por voz/chat. Testando ao vivo, o Gemini **chamava a ferramenta**, mas a tarefa não era criada e a E.V. dizia que "o comando deu erro".

Causa: o modelo às vezes coloca tudo no parâmetro `comando` (ex: `comando="tarefa verificacao #teste"`, `argumentos=""`). Como a chave inteira não é um comando conhecido, caía no "não conheço" → resposta de erro e nada criado.

Correção: `executar_comando` agora usa o **primeiro token** como nome do comando e o **resto como argumentos**. Também passei a **logar cada chamada** de `executar_comando` (o caminho de function-calling nativo do Gemini não tinha log — por isso o problema estava invisível).

## Alterações

| Área | Mudança |
|------|---------|
| `ev/core/brain.py` | `executar_comando` separa nome/args + logging |
| `tests/test_ai_commands.py` | teste: args embutidos no `comando` roteiam certo |

153 testes passam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)