### PR TITLE
Corrige CRUD via Gemini: anotações viravam string (PEP 563) e quebravam o function-calling

### DIFF
--- a/ev/core/brain.py
+++ b/ev/core/brain.py
@@ -16,7 +16,10 @@ Providers without a configured key are skipped. The brain also does RAG: it
 injects the user's most relevant knowledge-base chunks into the system prompt.
 """
 
-from __future__ import annotations
+# NOTE: intentionally NO `from __future__ import annotations` here. Gemini's
+# automatic function calling introspects the tool functions' annotations at
+# runtime; PEP 563 stringized annotations make it do isinstance(value, "str")
+# -> "isinstance() arg 2 must be a type..." and every tool call fails.
 
 import asyncio
 import logging
@@ -434,14 +437,14 @@ class Brain:
             self._memory.add_fact(user_id, fato, embedding=self._embed(fato))
             return "ok, memorizado"
 
-        def criar_lembrete(texto: str, quando: str | None = None) -> str:
+        def criar_lembrete(texto: str, quando: str = "") -> str:
             """Cria um lembrete para o usuário.
 
             Args:
                 texto: o que lembrar.
                 quando: data/hora em ISO 8601 (ex: 2026-07-22T09:00:00-03:00).
             """
-            rid = self._memory.add_reminder(user_id, texto, quando)
+            rid = self._memory.add_reminder(user_id, texto, quando or None)
             return f"lembrete #{rid} criado"
 
         def listar_lembretes() -> str:
@@ -550,7 +553,7 @@ class Brain:
 
         def criar_documento(
             conteudo: str,
-            titulo: str | None = None,
+            titulo: str = "",
             formato: str = "pdf",
             salvar_kb: bool = False,
         ) -> str:
@@ -811,6 +814,21 @@ class Brain:
             ),
         )
         self._last_provider = "gemini"
+        # Log what Gemini's automatic function calling actually did (it is otherwise
+        # opaque) — invaluable for debugging why a CRUD tool didn't run.
+        try:
+            for h in (getattr(response, "automatic_function_calling_history", None) or []):
+                for part in (getattr(h, "parts", None) or []):
+                    fc = getattr(part, "function_call", None)
+                    if fc:
+                        log.info("[gemini-afc] chamou %s args=%s", fc.name,
+                                 dict(fc.args or {}))
+                    fr = getattr(part, "function_response", None)
+                    if fr:
+                        log.info("[gemini-afc] resultado %s: %s", fr.name,
+                                 str(getattr(fr, "response", ""))[:160])
+        except Exception:
+            pass
         return (response.text or "").strip() or "…"
 
     def _build_contents(


### PR DESCRIPTION
## 🤔 Context

**Esta é a causa raiz** do "a E.V. não faz CRUD pelo chat/voz". O `brain.py` tinha `from __future__ import annotations`, então em runtime **toda anotação de tipo das ferramentas virava string** (`'str'`). O function-calling automático do Gemini, ao converter os argumentos que o modelo devolve, fazia `isinstance(valor, 'str')` — que lança `isinstance() arg 2 must be a type, a tuple of types, or a union`. Resultado: **toda** chamada de ferramenta falhava no caminho do Gemini (o padrão), e a E.V. dizia "probleminha técnico". Só funcionava quando caía pro Groq (que usa schemas escritos à mão).

Reproduzido ao vivo com o Gemini real:
```
[gemini-afc] chamou executar_comando args={'comando': 'tarefa', 'argumentos': 'comprar cafe #teste'}
[gemini-afc] resultado executar_comando: {'error': 'isinstance() arg 2 must be a type, a tuple of types, or a union'}
```

## Correção

- **Remove `from __future__ import annotations`** do `brain.py` → anotações voltam a ser tipos reais; confirmado que `criar_lembrete`/`executar_comando`/`criar_documento` agora têm `__annotations__` com `str`/`bool` de verdade.
- Troca `str | None` por `str = ""` nas ferramentas (higiene extra pro introspector).
- **Loga o histórico de function-calling do Gemini** (era totalmente opaco — foi o que permitiu achar a causa).

> [!NOTE]
> Não deu pra provar via API localmente porque a chave do Gemini bateu o limite diário do free tier (20/dia) no meio da investigação; a correção foi confirmada no nível da introspecção (anotações reais) + 153 testes. Vou validar de ponta a ponta na VM após o deploy.

153 testes passam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)