### PR TITLE
Presença proativa: aviso antes de eventos da agenda

### DIFF
--- a/ev/config.py
+++ b/ev/config.py
@@ -65,6 +65,7 @@ class Config:
     habit_nudge_hour: int    # local hour to nudge about unmarked habits; <0 disables
     monthly_report_day: int  # day of month for the financial report; <0 disables
     monthly_report_hour: int
+    event_alert_minutes: int  # heads-up lead time before a calendar event; <=0 disables
     # Tools
     websearch_enabled: bool
     brave_api_key: str   # optional: better web search than DuckDuckGo
@@ -207,6 +208,7 @@ class Config:
             habit_nudge_hour=habit_nudge_hour,
             monthly_report_day=monthly_report_day,
             monthly_report_hour=_get_int("EV_MONTHLY_REPORT_HOUR", 9),
+            event_alert_minutes=_get_int("EV_EVENT_ALERT_MINUTES", 30),
             websearch_enabled=_get_bool("EV_WEBSEARCH_ENABLED", True),
             brave_api_key=os.getenv("BRAVE_API_KEY", "").strip(),
             tavily_api_key=os.getenv("TAVILY_API_KEY", "").strip(),

--- a/ev/interfaces/telegram_bot.py
+++ b/ev/interfaces/telegram_bot.py
@@ -69,6 +69,8 @@ class TelegramInterface:
         self._pending_images: dict[str, tuple[bytes, str]] = {}
         # short id -> parsed expense dict, for the receipt "confirmar gasto" button
         self._pending_expense: dict[str, dict] = {}
+        # calendar event ids already alerted (pre-event heads-up), to avoid repeats
+        self._alerted_events: set[str] = set()
         # short id -> reminder text, for the snooze/done buttons on a fired reminder
         self._pending_rem: dict[str, str] = {}
         self._doc_seq = 0
@@ -1993,6 +1995,7 @@ class TelegramInterface:
                 if not self._is_quiet():  # /silenciar mutes proactive pings
                     await self._maybe_send_briefing(app)
                     await self._maybe_send_checkin(app)
+                    await self._maybe_send_event_alerts(app)
                     await self._maybe_send_weekly(app)
                     await self._maybe_send_rain(app)
                     await self._maybe_habit_nudge(app)
@@ -2023,6 +2026,57 @@ class TelegramInterface:
                 text += "\n\n🧠 Insights:\n" + insights
             await self._bot_send(app.bot, cfg.owner_id, text, self._quick_kb())
             log.info("Sent weekly review.")
+
+    @staticmethod
+    def _alert_lead_minutes(start_iso: str, now, lead: int):
+        """Minutes until `start_iso` if it falls within (0, lead]; else None.
+        Tolerates tz-naive starts (assumes UTC)."""
+        from datetime import datetime, timezone
+        try:
+            start = datetime.fromisoformat(start_iso)
+        except (ValueError, TypeError):
+            return None
+        if start.tzinfo is None:
+            start = start.replace(tzinfo=timezone.utc)
+        mins = (start - now).total_seconds() / 60
+        if 0 <= mins <= lead:
+            return int(round(mins))
+        return None
+
+    async def _maybe_send_event_alerts(self, app: Application) -> None:
+        cfg = self._config
+        lead = getattr(cfg, "event_alert_minutes", 30)
+        if lead <= 0 or cfg.owner_id is None or not cfg.google_authorized():
+            return
+        from datetime import datetime, timedelta, timezone
+        now = datetime.now(timezone.utc)
+        try:
+            from ..providers import tools
+            events = await asyncio.to_thread(
+                tools.calendar_list_range, cfg, cfg.default_account,
+                now.isoformat(), (now + timedelta(minutes=lead)).isoformat())
+        except Exception:
+            log.warning("event alert fetch failed", exc_info=True)
+            return
+        for e in events:
+            eid = e.get("id")
+            if not eid or eid in self._alerted_events or e.get("all_day"):
+                continue
+            mins = self._alert_lead_minutes(e.get("start") or "", now, lead)
+            if mins is None:
+                continue
+            self._alerted_events.add(eid)
+            when = "agora" if mins <= 1 else f"em {mins} min"
+            msg = f'📅 "{e.get("summary", "(sem título)")}" começa {when}.'
+            await self._bot_send(app.bot, cfg.owner_id, msg, self._quick_kb())
+            try:  # persist to the web notification center + push to devices
+                from ..providers import push
+                await asyncio.to_thread(push.send_push, cfg, self._memory,
+                                        "📅 Evento chegando", msg, "/", str(cfg.owner_id))
+            except Exception:
+                pass
+        if len(self._alerted_events) > 500:  # keep the dedupe set bounded
+            self._alerted_events.clear()
 
     def _log_notif(self, title: str, body: str = "") -> None:
         """Record a proactive alert in the web notification center too."""

--- a/tests/test_ai_commands.py
+++ b/tests/test_ai_commands.py
@@ -72,3 +72,20 @@ def test_executar_comando_handles_inline_args(tmp_path):
     assert "adicionada" in ec("tarefa comprar pão #casa")   # args inside comando
     assert "adicionada" in ec("tarefa", "estudar #faculdade")  # normal form
     assert "comprar pão" in brain._commands.tarefas("u")
+
+
+def test_event_alert_lead_window():
+    from ev.interfaces.telegram_bot import TelegramInterface as TI
+    from datetime import datetime, timezone, timedelta
+    now = datetime(2026, 8, 1, 12, 0, tzinfo=timezone.utc)
+    f = TI._alert_lead_minutes
+    # 20 min ahead, lead 30 -> alert (20)
+    assert f((now + timedelta(minutes=20)).isoformat(), now, 30) == 20
+    # 45 min ahead, lead 30 -> out of window
+    assert f((now + timedelta(minutes=45)).isoformat(), now, 30) is None
+    # already started -> None
+    assert f((now - timedelta(minutes=5)).isoformat(), now, 30) is None
+    # tz-naive start is treated as UTC
+    assert f("2026-08-01T12:10:00", now, 30) == 10
+    # garbage -> None
+    assert f("nope", now, 30) is None


### PR DESCRIPTION
## 🤔 Context

Segunda melhoria "modo JARVIS": **presença proativa**. A agenda era passiva (só via se você abrisse). Agora a E.V. **avisa antes** de um evento do Google Calendar — *"📅 'Reunião X' começa em 30 min"* — pelo Telegram, na central de notificações e via push no navegador.

Uma passada no agendador (a cada minuto) olha a janela dos próximos `EV_EVENT_ALERT_MINUTES` (padrão 30), avisa **uma vez por evento** (deduplicado por id) e respeita o modo silencioso.

## Alterações

| Área | Mudança |
|------|---------|
| `ev/config.py` | `event_alert_minutes` (`EV_EVENT_ALERT_MINUTES`, padrão 30) |
| `ev/interfaces/telegram_bot.py` | `_maybe_send_event_alerts` + helper puro `_alert_lead_minutes` + dedupe |
| `tests/test_ai_commands.py` | testa a janela de antecedência (aware/naive/fora da janela) |

154 testes passam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)