### PR TITLE
Assinatura de presença: orbe pulsa enquanto a E.V. fala

### DIFF
--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -135,7 +135,9 @@ body::before{content:"";position:fixed;inset:0;pointer-events:none;z-index:0;bac
 .core .dot{position:absolute;inset:0;margin:auto;width:8px;height:8px;border-radius:50%;background:var(--fg);box-shadow:0 0 20px 4px rgba(244,243,241,.45)}
 @keyframes spin{to{transform:rotate(360deg)}}
 body.listening .core .arc{animation-duration:1.8s}body.thinking .core .arc{animation-duration:2.6s}
+body.speaking .core .arc{animation-duration:1.1s}
 body.listening .core .dot{animation:pulse 1s infinite}@keyframes pulse{50%{transform:scale(1.9);opacity:.55}}
+body.speaking .core .dot{animation:pulse .6s infinite}
 .state{font-family:var(--mono);font-size:10px;letter-spacing:.2em;text-transform:uppercase;color:var(--muted);text-align:center}
 .folder{display:flex;align-items:center;gap:9px;font-size:14px;color:var(--muted);padding:9px 11px;border:1px solid transparent;border-radius:10px;cursor:pointer;transition:.15s}
 .folder:hover{background:var(--surface);color:var(--fg)}
@@ -154,8 +156,8 @@ body.listening .core .dot{animation:pulse 1s infinite}@keyframes pulse{50%{trans
 .bigcore .r1{inset:0}.bigcore .r2{inset:26px;border-color:var(--line)}.bigcore .r3{inset:60px;border-color:var(--line-2)}
 .bigcore .arc{position:absolute;inset:0;border-radius:50%;background:conic-gradient(from 0deg,transparent 0 66%,rgba(244,243,241,.95) 84%,transparent 100%);-webkit-mask:radial-gradient(farthest-side,transparent calc(100% - 2px),#000 calc(100% - 1px));mask:radial-gradient(farthest-side,transparent calc(100% - 2px),#000 calc(100% - 1px));animation:spin 8s linear infinite}
 .bigcore .bdot{position:absolute;inset:0;margin:auto;width:14px;height:14px;border-radius:50%;background:var(--fg);box-shadow:0 0 40px 10px rgba(244,243,241,.4)}
-body.listening .bigcore .arc{animation-duration:1.6s}
-body.listening .bigcore .bdot{animation:pulse .9s infinite}
+body.listening .bigcore .arc{animation-duration:1.6s}body.speaking .bigcore .arc{animation-duration:1s}
+body.listening .bigcore .bdot{animation:pulse .9s infinite}body.speaking .bigcore .bdot{animation:pulse .55s infinite}
 #vc-txt{font-family:var(--disp);font-size:22px;text-align:center;max-width:640px;padding:0 24px;line-height:1.4;min-height:60px}
 #vc-sub{font-family:var(--mono);font-size:11px;letter-spacing:.24em;text-transform:uppercase;color:var(--subtle)}
 #vc-actions{display:flex;gap:12px}
@@ -715,10 +717,10 @@ function ripple(b,e){const r=el('span','ripple');const q=b.getBoundingClientRect
   r.style.width=r.style.height=s+'px';r.style.left=((e?e.clientX:q.left+q.width/2)-q.left-s/2)+'px';
   r.style.top=((e?e.clientY:q.top+q.height/2)-q.top-s/2)+'px';b.appendChild(r);setTimeout(()=>r.remove(),500);}
 let _audio=null,_audioMsg=false,_speaking=false;
-function stopSpeaking(){try{if(_audio){_audio.pause();_audio.currentTime=0;}}catch(e){}_speaking=false;}
+function stopSpeaking(){try{if(_audio){_audio.pause();_audio.currentTime=0;}}catch(e){}_speaking=false;document.body.classList.remove('speaking');}
 function unlockAudio(){if(!_audio)_audio=new Audio();try{_audio.play().catch(()=>{});}catch(e){}}
 window.addEventListener('pointerdown',unlockAudio,{once:true});
-async function speak(t,force){if((!voiceOn&&!force)||!t)return;try{const r=await fetch('/api/tts',{method:'POST',headers:H(),body:JSON.stringify({text:t})});if(!r.ok)return;const url=URL.createObjectURL(await r.blob());if(!_audio)_audio=new Audio();_audio.src=url;_speaking=true;_audio.onended=()=>{_speaking=false;};await _audio.play().catch(()=>{_speaking=false;if(!_audioMsg){_audioMsg=true;sys('O navegador bloqueou o áudio automático. Toque uma vez na tela e a E.V. volta a falar.');}});}catch(e){_speaking=false;}}
+async function speak(t,force){if((!voiceOn&&!force)||!t)return;try{const r=await fetch('/api/tts',{method:'POST',headers:H(),body:JSON.stringify({text:t})});if(!r.ok)return;const url=URL.createObjectURL(await r.blob());if(!_audio)_audio=new Audio();_audio.src=url;_speaking=true;document.body.classList.add('speaking');_audio.onended=()=>{_speaking=false;document.body.classList.remove('speaking');};await _audio.play().catch(()=>{_speaking=false;document.body.classList.remove('speaking');if(!_audioMsg){_audioMsg=true;sys('O navegador bloqueou o áudio automático. Toque uma vez na tela e a E.V. volta a falar.');}});}catch(e){_speaking=false;document.body.classList.remove('speaking');}}
 
 async function send(msg){if(!msg)return;you(msg);const p=thinking();setState('thinking');
   try{const r=await fetch('/api/chat/stream',{method:'POST',headers:H(),body:JSON.stringify({message:msg,thread})});


### PR DESCRIPTION
## 🤔 Context

Fecha o conjunto "modo JARVIS". A E.V. já tinha a saudação de boot ("Sistemas online") e a orbe reativa (estados ouvindo/processando). Faltava o estado **"falando"**: agora a orbe (na barra lateral e nas telas de voz/foco) pulsa mais rápido enquanto ela responde por voz — dando a sensação de uma presença viva que fala com você.

## Alterações

| Área | Mudança |
|------|---------|
| `ev/interfaces/web.py` | estado `body.speaking` (CSS da `.core`/`.bigcore`) ligado a `speak()`/`stopSpeaking()` |

156 testes passam; markup + JS validados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)