### PR TITLE
Voz: sempre português + voz multilíngue pra palavras estrangeiras

### DIFF
--- a/ev/config.py
+++ b/ev/config.py
@@ -184,7 +184,9 @@ class Config:
             embed_backend=os.getenv("EV_EMBED_BACKEND", "gemini").strip().lower(),
             owner_id=owner_id,
             voice_reply=_get_bool("EV_VOICE_REPLY", True),
-            voice=os.getenv("EV_VOICE", "pt-BR-FranciscaNeural").strip(),
+            # Multilingual pt-BR voice: base is Brazilian Portuguese, but it
+            # pronounces embedded foreign words (Spider-Man, deploy) correctly.
+            voice=os.getenv("EV_VOICE", "pt-BR-ThalitaMultilingualNeural").strip(),
             voice_rate=os.getenv("EV_VOICE_RATE", "+0%").strip(),
             voice_pitch=os.getenv("EV_VOICE_PITCH", "+0Hz").strip(),
             voice_fixes=tuple(

--- a/ev/personality.py
+++ b/ev/personality.py
@@ -30,7 +30,13 @@ na E.V. do Homem-Aranha: uma IA leal, carinhosa e cheia de personalidade, que \
   ("e aquela entrevista?"). Não force check-in em toda mensagem.
 
 ## Como você fala
-- Responda SEMPRE no mesmo idioma do usuário (padrão: português do Brasil).
+- Fale SEMPRE em **português do Brasil**, em toda e qualquer resposta — nunca \
+  responda em inglês ou espanhol, mesmo que apareçam palavras estrangeiras na \
+  conversa. Números você escreve normalmente (ex: "R$ 50", "3 tarefas"), mas a \
+  frase inteira é em português.
+- Nomes próprios e termos técnicos estrangeiros (ex: Spider-Man, deploy, e-mail) \
+  ficam na grafia original — não traduza nem "aportuguese" à força; só o resto da \
+  frase é que é em português.
 - Tom meigo e próximo, como uma amiga querida. Chame o usuário pelo nome: \
   **Ryan**. NÃO use "chefe" nem outros apelidos.
 - Seja concisa e natural. Nada de textão nem robótico. Fale como gente fala.


### PR DESCRIPTION
## 🤔 Context

A E.V. às vezes respondia/pronunciava em espanhol ou inglês (inclusive números), e palavras estrangeiras saíam estranhas.

Duas causas e correções:

1. **Texto desviava de idioma** → regra forte na personalidade: **sempre** responder em português do Brasil, nunca em inglês/espanhol; nomes próprios e termos técnicos estrangeiros ficam na grafia original, mas a frase é em português.
2. **Pronúncia estranha de palavras estrangeiras** → a voz padrão era `pt-BR-FranciscaNeural` (não multilíngue). Troquei para **`pt-BR-ThalitaMultilingualNeural`**: base em português do Brasil, mas pronuncia palavras estrangeiras (Spider-Man, deploy) corretamente, sem ficar esquisito.

## Alterações

| Área | Mudança |
|------|---------|
| `ev/personality.py` | regra de idioma reforçada (sempre pt-BR; estrangeirismos na grafia original) |
| `ev/config.py` | voz padrão → `pt-BR-ThalitaMultilingualNeural` |

> [!NOTE]
> Verifiquei na VM que a voz multilíngue sintetiza uma frase mista (pt + "Spider-Man"/"deploy" + números) sem erro. 156 testes passam. Se quiser outra voz, dá pra sobrescrever com `EV_VOICE` em Chaves/`.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)