### PR TITLE
Corrige latência da voz: volta pra voz rápida (multilíngue era 6-8s)

### DIFF
--- a/ev/config.py
+++ b/ev/config.py
@@ -184,9 +184,11 @@ class Config:
             embed_backend=os.getenv("EV_EMBED_BACKEND", "gemini").strip().lower(),
             owner_id=owner_id,
             voice_reply=_get_bool("EV_VOICE_REPLY", True),
-            # Multilingual pt-BR voice: base is Brazilian Portuguese, but it
-            # pronounces embedded foreign words (Spider-Man, deploy) correctly.
-            voice=os.getenv("EV_VOICE", "pt-BR-ThalitaMultilingualNeural").strip(),
+            # Fast standard pt-BR voice (~0.4-1.2s synth). The multilingual voice
+            # (pt-BR-ThalitaMultilingualNeural) pronounces foreign words better but
+            # is ~6-8s per reply — too slow for a voice assistant. Override with
+            # EV_VOICE if you prefer that accuracy over speed.
+            voice=os.getenv("EV_VOICE", "pt-BR-FranciscaNeural").strip(),
             voice_rate=os.getenv("EV_VOICE_RATE", "+0%").strip(),
             voice_pitch=os.getenv("EV_VOICE_PITCH", "+0Hz").strip(),
             voice_fixes=tuple(


### PR DESCRIPTION
## 🤔 Context

A E.V. demorava vários segundos pra "falar" a resposta no modo de voz. Medi na VM: a voz multilíngue que entrou no #26 leva **6-8s** por resposta, contra **0,4-1,2s** da voz padrão pra o mesmo texto. Era esse o atraso.

Reverto a voz padrão para **`pt-BR-FranciscaNeural`** (rápida). A multilíngue continua disponível via `EV_VOICE` pra quem preferir a pronúncia de palavras estrangeiras à velocidade. A regra de sempre-português (texto) do #26 foi mantida.

## Medição (na VM, mesmo texto)

| Voz | Síntese |
|-----|---------|
| pt-BR-ThalitaMultilingualNeural | 6,3–8,1s |
| pt-BR-FranciscaNeural | 0,4–1,2s |

## Alterações

| Área | Mudança |
|------|---------|
| `ev/config.py` | voz padrão → `pt-BR-FranciscaNeural` (multilíngue vira opt-in via `EV_VOICE`) |

156 testes passam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)