### PR TITLE
Colar imagem no chat + manter a imagem na conversa

### DIFF
--- a/ev/core/memory.py
+++ b/ev/core/memory.py
@@ -245,6 +245,14 @@ class Memory:
                 birthday TEXT,   -- 'MM-DD' or 'YYYY-MM-DD'
                 created  TEXT NOT NULL
             );
+
+            CREATE TABLE IF NOT EXISTS chat_images (
+                id       INTEGER PRIMARY KEY AUTOINCREMENT,
+                conv_id  TEXT NOT NULL,
+                mime     TEXT,
+                data     BLOB NOT NULL,
+                created  TEXT NOT NULL
+            );
             """
         )
         # Migrations for older DBs.
@@ -455,6 +463,41 @@ class Memory:
             if b and b[-5:] == mmdd:
                 out.append(p)
         return out
+
+    # --- chat images (pasted/sent images kept in the conversation) ---------
+
+    def add_chat_image(self, conv_id: str, data: bytes, mime: str = "image/png") -> int:
+        cur = self._conn.execute(
+            "INSERT INTO chat_images (conv_id, mime, data, created) VALUES (?, ?, ?, ?)",
+            (conv_id, mime or "image/png", sqlite3.Binary(data), self._now()),
+        )
+        # bound the store — keep only the newest 80 images overall
+        self._conn.execute(
+            "DELETE FROM chat_images WHERE id NOT IN "
+            "(SELECT id FROM chat_images ORDER BY id DESC LIMIT 80)")
+        self._conn.commit()
+        return int(cur.lastrowid)
+
+    def get_chat_image(self, image_id: int) -> dict | None:
+        row = self._conn.execute(
+            "SELECT mime, data FROM chat_images WHERE id = ?", (image_id,)).fetchone()
+        return {"mime": row["mime"], "data": bytes(row["data"])} if row else None
+
+    def mark_last_user_image(self, conv_id: str, image_id: int) -> None:
+        """Embed an [img:id] marker in the most recent user message so the image
+        can be re-rendered when the conversation is reloaded. (The messages table
+        stores the conversation id in the user_id column.)"""
+        row = self._conn.execute(
+            "SELECT id, content FROM messages WHERE user_id = ? AND role = 'user' "
+            "ORDER BY id DESC LIMIT 1", (conv_id,)).fetchone()
+        if not row:
+            return
+        content = (row["content"] or "").strip()
+        marker = f"[img:{image_id}]"
+        content = marker if content in ("", "[imagem]") else f"{content}\n{marker}"
+        self._conn.execute(
+            "UPDATE messages SET content = ? WHERE id = ?", (content, row["id"]))
+        self._conn.commit()
         self._conn.commit()
 
     def activity_categories(self, user_id: str) -> list[str]:

--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -1000,7 +1000,7 @@ async function switchThread(name){thread=name;localStorage.setItem('ev_thread',n
   loadFolders();log.textContent='';await loadHistory();}
 async function loadHistory(){try{const r=await fetch('/api/history?thread='+encodeURIComponent(thread),{headers:H()});const d=await r.json();
   if(!d.messages.length){sys('Pasta "'+thread+'" — comece a conversa.');return;}
-  d.messages.forEach(m=>m.role==='user'?you(m.content):ev(m.content));}catch(e){}}
+  d.messages.forEach(m=>m.role==='user'?youHistory(m.content):ev(m.content));}catch(e){}}
 $('#newf').onclick=()=>openForm('Nova pasta',[{key:'name',label:'Nome',placeholder:'ex: projetos'}],async v=>{
   const name=(v.name||'').toLowerCase().replace(/\s+/g,'-').replace(/\//g,'-');if(!name)return;
   await fetch('/api/threads',{method:'POST',headers:H(),body:JSON.stringify({name})});await switchThread(name);});
@@ -1482,6 +1482,18 @@ function startEvents(){try{if(_es)_es.close();
 }catch(e){}}
 // --- Batch C: image in chat, global search, undo ---
 function youImg(caption,url){const d=el('div','msg you');const img=document.createElement('img');img.className='msg-img';img.src=url;d.appendChild(img);if(caption){const c=el('div','',caption);c.style.marginTop='6px';d.appendChild(c);}log.appendChild(d);log.scrollTop=log.scrollHeight;}
+// render a persisted user message that may carry [img:ID] markers
+const IMGMARK=/\[img:(\d+)\]/g;
+function youHistory(content){const ids=[];let m;IMGMARK.lastIndex=0;while((m=IMGMARK.exec(content||'')))ids.push(m[1]);
+  if(!ids.length){you(content);return;}
+  let txt=(content||'').replace(IMGMARK,'').trim();if(txt==='O que há nesta imagem?')txt='';
+  const d=el('div','msg you');
+  ids.forEach(id=>{const img=document.createElement('img');img.className='msg-img';img.src='/api/chat/image?id='+id+'&k='+encodeURIComponent(token);d.appendChild(img);});
+  if(txt){const c=el('div','',txt);c.style.marginTop='6px';d.appendChild(c);}
+  log.appendChild(d);log.scrollTop=log.scrollHeight;}
+// paste an image straight from the clipboard (no need to save it first)
+window.addEventListener('paste',e=>{const items=(e.clipboardData&&e.clipboardData.items)||[];
+  for(const it of items){if(it.type&&it.type.indexOf('image/')===0){const f=it.getAsFile();if(f){setPendingImg(f);e.preventDefault();break;}}}});
 let _pendingImg=null;
 function setPendingImg(f){_pendingImg=f;const p=$('#imgprev');p.innerHTML='';if(!f){p.style.display='none';return;}
   const img=document.createElement('img');img.src=URL.createObjectURL(f);
@@ -2561,13 +2573,33 @@ def create_app(config: Config, brain: Brain | None = None):
             return {"reply": "Imagem vazia."}
         prompt = (form.get("text") or "").strip() or "O que há nesta imagem?"
         thread = (form.get("thread") or "geral").strip()
+        conv = _conv(thread)
         try:
             reply = await brain.respond(
-                owner, conv_id=_conv(thread), text=prompt,
+                owner, conv_id=conv, text=prompt,
                 image=data, image_mime=(f.content_type or "image/jpeg"))
         except Exception as exc:
             return {"reply": f"Não consegui analisar a imagem: {exc}"}
-        return {"reply": reply}
+        # keep the image in the conversation so it re-appears on reload
+        img_id = None
+        try:
+            img_id = memory.add_chat_image(conv, data, f.content_type or "image/png")
+            memory.mark_last_user_image(conv, img_id)
+        except Exception:
+            pass
+        return {"reply": reply, "img_id": img_id}
+
+    @app.get("/api/chat/image")
+    async def chat_image(request: Request):
+        tok = request.query_params.get("k", "")
+        if not config.web_token or not hmac.compare_digest(tok, config.web_token):
+            raise HTTPException(status_code=401, detail="unauthorized")
+        img = memory.get_chat_image(int(request.query_params.get("id") or 0))
+        if not img:
+            raise HTTPException(status_code=404, detail="não encontrada")
+        return Response(content=img["data"],
+                        media_type=img["mime"] or "image/png",
+                        headers={"Cache-Control": "private, max-age=86400"})
 
     @app.post("/api/receipt")
     async def receipt(request: Request):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -317,3 +317,18 @@ def test_birthday_normalization(tmp_path):
     assert m._norm_bday("12/03/1998") == "1998-03-12"
     assert m._norm_bday("1998-03-12") == "1998-03-12"
     assert m._norm_bday("") == ""
+
+
+def test_chat_image_persistence(tmp_path):
+    from ev.core.memory import Memory
+    m = Memory(tmp_path / "t.db")
+    conv = "web:geral"
+    m.add_message(conv, "user", "O que há nesta imagem?")
+    m.add_message(conv, "model", "é um gato")
+    iid = m.add_chat_image(conv, b"\x89PNG-fake-bytes", "image/png")
+    m.mark_last_user_image(conv, iid)
+    got = m.get_chat_image(iid)
+    assert got and got["data"] == b"\x89PNG-fake-bytes" and got["mime"] == "image/png"
+    user = [x for x in m.recent_messages(conv, 10) if x["role"] == "user"][-1]
+    assert f"[img:{iid}]" in user["content"]
+    assert m.get_chat_image(999999) is None


### PR DESCRIPTION
## 🤔 Context

Dois comportamentos pedidos pra imagens:

1. **Colar direto** (Ctrl/Cmd+V) uma imagem da área de transferência, sem precisar salvá-la no PC antes — ela cai no preview, pronta pra enviar (com legenda opcional).
2. **Persistência**: a imagem enviada/colada **continua na conversa** quando você volta pra aquela pasta. Antes o preview era um blob temporário e sumia no reload.

Como funciona: o `/api/vision` guarda a imagem (`chat_images`) e marca a última mensagem do usuário com `[img:id]`; ao recarregar, o histórico renderiza a imagem via `/api/chat/image` (auth por token na query). O store é limitado (últimas 80 imagens) pra não inchar o banco.

## Alterações

| Área | Mudança |
|------|---------|
| `ev/core/memory.py` | tabela `chat_images` + `add/get_chat_image`, `mark_last_user_image` |
| `ev/interfaces/web.py` | `/api/vision` persiste + marca; `GET /api/chat/image`; `paste` handler; `youHistory` renderiza imagens do histórico |
| `tests/test_commands.py` | persistência de imagem (guardar, marcar, recuperar) |

157 testes passam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)