### PR TITLE
Mapa v2: maior, lugares dentro da E.V., pontos próprios e conversa pelo mapa

### DIFF
--- a/ev/core/brain.py
+++ b/ev/core/brain.py
@@ -630,8 +630,8 @@ class Brain:
             return f"{head}({lat}, {lng}). Ver no mapa: {link}"
 
         def locais_proximos(tipo: str) -> str:
-            """Sugere lugares de um tipo perto da localização atual do usuário
-            (devolve um link do Google Maps já centrado onde ele está).
+            """Lista lugares reais de um tipo perto da localização atual do usuário
+            (nome + distância), buscando no OpenStreetMap.
 
             Args:
                 tipo: o que procurar, ex 'farmácia', 'mercado', 'restaurante'.
@@ -641,7 +641,18 @@ class Brain:
             if not (lat and lng):
                 return ("não sei sua localização ainda. Abra a aba Mapa e toque em "
                         "'Onde estou'.")
-            return f"{tipo} perto de você: {tools_mod.maps_search_link(lat, lng, tipo)}"
+            places = tools_mod.nearby_places(float(lat), float(lng), tipo, limit=6)
+            if not places:
+                return f"não achei '{tipo}' por perto agora."
+            lines = [f"- {p['name']} (~{p['dist']} m)" for p in places]
+            return f"{tipo.capitalize()} perto de você:\n" + "\n".join(lines)
+
+        def meus_locais() -> str:
+            """Lista os pontos de interesse que o usuário salvou no mapa da E.V."""
+            places = self._memory.list_places(user_id)
+            if not places:
+                return "você ainda não salvou nenhum ponto no mapa."
+            return "Seus pontos salvos: " + ", ".join(p["name"] for p in places)
 
         callables: dict = {
             "executar_comando": executar_comando,
@@ -649,6 +660,7 @@ class Brain:
             "sobre_pessoa": sobre_pessoa,
             "minha_localizacao": minha_localizacao,
             "locais_proximos": locais_proximos,
+            "meus_locais": meus_locais,
             "salvar_memoria": salvar_memoria,
             "listar_memorias": listar_memorias,
             "apagar_memoria": apagar_memoria,
@@ -781,10 +793,11 @@ class Brain:
             ),
             fn(
                 "locais_proximos",
-                "Sugere lugares de um tipo perto do usuário (link do Google Maps).",
+                "Lista lugares reais (nome + distância) de um tipo perto do usuário.",
                 {"tipo": {"type": s, "description": "ex: farmácia, mercado, restaurante"}},
                 ["tipo"],
             ),
+            fn("meus_locais", "Lista os pontos de interesse que o usuário salvou no mapa."),
             fn(
                 "criar_lembrete",
                 "Cria um lembrete para o usuário.",

--- a/ev/core/memory.py
+++ b/ev/core/memory.py
@@ -253,6 +253,15 @@ class Memory:
                 data     BLOB NOT NULL,
                 created  TEXT NOT NULL
             );
+
+            CREATE TABLE IF NOT EXISTS places (
+                id       INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id  TEXT NOT NULL,
+                name     TEXT NOT NULL,
+                lat      REAL NOT NULL,
+                lng      REAL NOT NULL,
+                created  TEXT NOT NULL
+            );
             """
         )
         # Migrations for older DBs.
@@ -482,6 +491,26 @@ class Memory:
         row = self._conn.execute(
             "SELECT mime, data FROM chat_images WHERE id = ?", (image_id,)).fetchone()
         return {"mime": row["mime"], "data": bytes(row["data"])} if row else None
+
+    # --- saved places / points of interest --------------------------------
+
+    def add_place(self, user_id: str, name: str, lat: float, lng: float) -> int:
+        cur = self._conn.execute(
+            "INSERT INTO places (user_id, name, lat, lng, created) VALUES (?, ?, ?, ?, ?)",
+            (user_id, (name or "ponto").strip()[:80], float(lat), float(lng), self._now()))
+        self._conn.commit()
+        return int(cur.lastrowid)
+
+    def list_places(self, user_id: str) -> list[dict]:
+        rows = self._conn.execute(
+            "SELECT id, name, lat, lng FROM places WHERE user_id = ? ORDER BY id",
+            (user_id,)).fetchall()
+        return [dict(r) for r in rows]
+
+    def delete_place(self, user_id: str, place_id: int) -> None:
+        self._conn.execute("DELETE FROM places WHERE user_id = ? AND id = ?",
+                           (user_id, place_id))
+        self._conn.commit()
 
     def mark_last_user_image(self, conv_id: str, image_id: int) -> None:
         """Embed an [img:id] marker in the most recent user message so the image

--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -174,10 +174,23 @@ body.speaking .core .dot{animation:pulse .6s infinite}
 #vc-viz{position:absolute;width:480px;height:480px;max-width:92vw;max-height:92vw;pointer-events:none;opacity:0;transition:opacity .35s;filter:drop-shadow(0 0 14px var(--glow))}
 .bigcore{width:220px;height:220px;position:relative;z-index:1}
 #mapview{display:none;padding:22px;overflow:auto}
-#map{height:min(60vh,540px);border:1px solid var(--line-2);border-radius:13px;overflow:hidden;box-shadow:0 0 40px -24px var(--glow)}
+#map-wrap{position:relative;height:calc(100vh - 300px);min-height:400px}
+#map{position:absolute;inset:0;border:1px solid var(--line-2);border-radius:13px;overflow:hidden;box-shadow:0 0 40px -24px var(--glow)}
 #map .leaflet-container{background:#04070c;font-family:var(--body)}
 #map .leaflet-control-zoom a{background:var(--elev);color:var(--accent);border-color:var(--line)}
 #map .leaflet-bar{border:1px solid var(--line)}
+#map .leaflet-popup-content-wrapper,#map .leaflet-popup-tip{background:var(--elev);color:var(--fg);border:1px solid var(--line-2)}
+#map .leaflet-popup-content{margin:11px 13px;font-family:var(--body)}
+.pop-n{font-weight:600;font-size:13px;margin-bottom:2px}.pop-d{font-family:var(--mono);font-size:10px;color:var(--subtle);margin-bottom:7px}
+.pop-b{display:inline-flex;align-items:center;gap:5px;font-size:11px;color:var(--accent);background:var(--surface);border:1px solid var(--line);border-radius:7px;padding:4px 8px;cursor:pointer;margin-right:5px}
+.pop-b:hover{background:var(--fg);color:var(--ink)}
+#map-results{position:absolute;top:12px;left:12px;width:252px;max-height:calc(100% - 24px);overflow:auto;z-index:600;background:rgba(6,12,20,.86);-webkit-backdrop-filter:blur(7px);backdrop-filter:blur(7px);border:1px solid var(--line-2);border-radius:12px;padding:8px;display:none}
+#map-results.on{display:block}
+#map-results .mr-h{font-family:var(--mono);font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:var(--subtle);padding:4px 6px 6px;display:flex;align-items:center;justify-content:space-between}
+#map-results .mr-h b{cursor:pointer;color:var(--muted)}
+.mres{padding:8px 9px;border-radius:8px;cursor:pointer;border-top:1px solid var(--line)}
+.mres:first-of-type{border-top:none}.mres:hover{background:var(--elev)}
+.mres .mr-n{font-size:13px;font-weight:600}.mres .mr-d{font-family:var(--mono);font-size:10px;color:var(--subtle);margin-top:2px}
 .bigcore .ring{position:absolute;border-radius:50%;border:1px solid var(--line-2)}
 .bigcore .r1{inset:0}.bigcore .r2{inset:26px;border-color:var(--line)}.bigcore .r3{inset:60px;border-color:var(--line-2)}
 .bigcore .arc{position:absolute;inset:0;border-radius:50%;background:conic-gradient(from 0deg,transparent 0 66%,var(--accent) 84%,transparent 100%);-webkit-mask:radial-gradient(farthest-side,transparent calc(100% - 2px),#000 calc(100% - 1px));mask:radial-gradient(farthest-side,transparent calc(100% - 2px),#000 calc(100% - 1px));animation:spin 8s linear infinite}
@@ -610,10 +623,12 @@ textarea.minput{resize:vertical;min-height:74px;font-family:var(--body);line-hei
       <div class="tv-h">Mapa · você e o que tem por perto</div>
       <div id="map-status" class="eyebrow" style="margin:0 2px 8px">toque em "Onde estou" para localizar seu dispositivo</div>
       <div id="map-chips" class="mchips"></div>
-      <div id="map-search" class="tv-form" style="margin:6px 0 10px">
-        <input class="tv-search" id="map-q" placeholder="Buscar por perto: ex farmácia 24h, padaria..." autocomplete="off">
+      <div class="tv-form" style="margin:6px 0 10px;gap:8px;flex-wrap:wrap">
+        <input class="tv-search" id="map-q" placeholder="Buscar por perto: padaria, farmácia..." autocomplete="off" style="flex:1;min-width:180px">
+        <button class="mchip" id="map-add" type="button"><i data-lucide="map-pin"></i>Adicionar ponto</button>
+        <button class="mchip" id="map-ask" type="button"><i data-lucide="message-circle"></i>Perguntar à E.V.</button>
       </div>
-      <div id="map"></div>
+      <div id="map-wrap"><div id="map"></div><div id="map-results"></div></div>
     </div>
   </main>
   <aside id="right" class="rail">
@@ -1147,29 +1162,62 @@ function switchView(v){if(!VIEWS[v])v='chat';curView=v;document.querySelectorAll
   document.body.classList.remove('m-left','m-right');
   Object.entries(VIEWS).forEach(([k,sel])=>{const el2=$(sel);if(el2)el2.style.display=(k===v)?(k==='chat'?'flex':'block'):'none';});
   ({tasks:loadTasks,exp:loadExp,rem:loadRem,mem:loadMem,kb:loadKB,cal:loadCal,lnk:loadLinks,hab:loadHabits,jou:loadJournal,sub:loadSub,orc:loadOrc,mon:loadMon,act:loadAct,map:loadMap}[v]||function(){})();}
-// --- Mapa + localização (Leaflet + OSM, sem chave; tiles escuros) ---
-let _map=null,_marker=null,_loc=null;
-const MAP_CHIPS=[['Onde estou','locate-fixed'],['Farmácia','pill'],['Mercado','shopping-cart'],['Restaurante','utensils'],['Padaria','croissant'],['Café','coffee'],['Posto','fuel'],['Banco','landmark'],['Hospital','cross'],['Ônibus','bus'],['Academia','dumbbell']];
-function nearbySearch(q){const c=_loc||[-23.5505,-46.6333];
-  window.open('https://www.google.com/maps/search/'+encodeURIComponent(q)+'/@'+c[0]+','+c[1]+',15z','_blank','noopener');}
+// --- Mapa + localização (Leaflet + OSM; lugares e pontos dentro da própria E.V.) ---
+let _map=null,_marker=null,_loc=null,_nearLayer=null,_savedLayer=null,_addMode=false,_pendingNear=null;
+const MAP_CHIPS=[['Onde estou','locate-fixed'],['Farmácia','pill'],['Mercado','shopping-cart'],['Restaurante','utensils'],['Padaria','croissant'],['Café','coffee'],['Posto','fuel'],['Banco','landmark'],['Hospital','cross'],['Academia','dumbbell']];
+function esc(s){return (s||'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));}
+function askEV(name,lat,lng){switchView('chat');send('me conta sobre "'+name+'", que fica perto de mim.');}
+function poiPopup(name,lat,lng,dist){const d=document.createElement('div');
+  d.innerHTML='<div class="pop-n">'+esc(name)+'</div>'+(dist!=null?'<div class="pop-d">~'+dist+' m de você</div>':'');
+  const ask=el('span','pop-b');ask.appendChild(ficon('message-circle'));ask.appendChild(document.createTextNode('Perguntar à E.V.'));ask.onclick=()=>askEV(name,lat,lng);
+  const rot=document.createElement('a');rot.className='pop-b';rot.href='https://www.google.com/maps/dir/?api=1&destination='+lat+','+lng;rot.target='_blank';rot.rel='noopener';rot.appendChild(ficon('navigation'));rot.appendChild(document.createTextNode('Rota'));
+  d.appendChild(ask);d.appendChild(rot);window.lucide&&lucide.createIcons();return d;}
 function renderMapChips(){const box=$('#map-chips');box.textContent='';
   MAP_CHIPS.forEach(([label,ic])=>{const b=el('button','mchip');b.type='button';b.appendChild(ficon(ic));b.appendChild(document.createTextNode(label));
-    b.onclick=(e)=>{ripple(b,e);label==='Onde estou'?locateMe():nearbySearch(label);};box.appendChild(b);});window.lucide&&lucide.createIcons();}
+    b.onclick=(e)=>{ripple(b,e);label==='Onde estou'?locateMe():showNearby(label);};box.appendChild(b);});window.lucide&&lucide.createIcons();}
+async function showNearby(query){if(!_loc){_pendingNear=query;$('#map-status').textContent='Preciso da sua localização — localizando...';locateMe();return;}
+  $('#map-status').textContent='Buscando "'+query+'" por perto...';
+  let items=[];try{const r=await fetch('/api/nearby',{method:'POST',headers:H(),body:JSON.stringify({query,lat:_loc[0],lng:_loc[1]})});items=(await r.json()).items||[];}catch(e){}
+  if(_nearLayer)_nearLayer.clearLayers();else _nearLayer=L.layerGroup().addTo(_map);
+  const res=$('#map-results');res.innerHTML='';
+  if(!items.length){$('#map-status').textContent='Não achei "'+query+'" num raio de ~1,6 km.';res.classList.remove('on');return;}
+  $('#map-status').textContent=items.length+' resultado(s) para "'+query+'"';
+  const head=el('div','mr-h');head.appendChild(document.createTextNode(query.toUpperCase()));const x=document.createElement('b');x.textContent='fechar';x.onclick=()=>{res.classList.remove('on');if(_nearLayer)_nearLayer.clearLayers();};head.appendChild(x);res.appendChild(head);
+  const bounds=[_loc];
+  items.forEach(it=>{const m=L.circleMarker([it.lat,it.lng],{radius:7,weight:2,color:'#8fe0ff',fillColor:'#35c8ff',fillOpacity:.85}).addTo(_nearLayer);
+    m.bindPopup(()=>poiPopup(it.name,it.lat,it.lng,it.dist));bounds.push([it.lat,it.lng]);
+    const row=el('div','mres');row.appendChild(el('div','mr-n',it.name));row.appendChild(el('div','mr-d','~'+it.dist+' m'));
+    row.onclick=()=>{_map.setView([it.lat,it.lng],16);m.openPopup();};res.appendChild(row);});
+  res.classList.add('on');try{_map.fitBounds(bounds,{padding:[60,60],maxZoom:16});}catch(e){}}
+function addSavedMarker(p){if(!_savedLayer)_savedLayer=L.layerGroup().addTo(_map);const m=L.marker([p.lat,p.lng]).addTo(_savedLayer);
+  m.bindPopup(()=>{const d=document.createElement('div');d.innerHTML='<div class="pop-n">'+esc(p.name)+'</div><div class="pop-d">ponto salvo</div>';
+    const ask=el('span','pop-b');ask.appendChild(ficon('message-circle'));ask.appendChild(document.createTextNode('Perguntar à E.V.'));ask.onclick=()=>askEV(p.name,p.lat,p.lng);
+    const del=el('span','pop-b');del.appendChild(ficon('trash-2'));del.appendChild(document.createTextNode('Remover'));del.onclick=async()=>{await fetch('/api/places/delete',{method:'POST',headers:H(),body:JSON.stringify({id:p.id})});m.remove();};
+    d.appendChild(ask);d.appendChild(del);window.lucide&&lucide.createIcons();return d;});}
+function loadSavedPlaces(){fetch('/api/places',{headers:H()}).then(r=>r.json()).then(d=>{
+  if(_savedLayer)_savedLayer.clearLayers();(d.items||[]).forEach(addSavedMarker);}).catch(()=>{});}
 function locateMe(){const st=$('#map-status');if(!navigator.geolocation){st.textContent='Geolocalização indisponível neste navegador.';return;}
   st.textContent='Localizando seu dispositivo...';
   navigator.geolocation.getCurrentPosition(p=>{const lat=p.coords.latitude,lng=p.coords.longitude;_loc=[lat,lng];
     if(_map){_map.setView(_loc,15);
-      if(_marker)_marker.setLatLng(_loc);else _marker=L.circleMarker(_loc,{radius:9,weight:3,color:'#35c8ff',fillColor:'#35c8ff',fillOpacity:.65}).addTo(_map);
+      if(_marker)_marker.setLatLng(_loc);else _marker=L.circleMarker(_loc,{radius:9,weight:3,color:'#35c8ff',fillColor:'#35c8ff',fillOpacity:.7}).addTo(_map);
       setTimeout(()=>_map.invalidateSize(),80);}
-    st.textContent='Você está aqui · toque num lugar pra buscar por perto';
+    st.textContent='Você está aqui · toque num tipo de lugar pra ver por perto';
     fetch('/api/location',{method:'POST',headers:H(),body:JSON.stringify({lat,lng})}).catch(()=>{});
+    if(_pendingNear){const q=_pendingNear;_pendingNear=null;showNearby(q);}
   },()=>{st.textContent='Não consegui pegar sua localização — permita o acesso e tente de novo.';},{enableHighAccuracy:true,timeout:12000,maximumAge:60000});}
 function loadMap(){
   if(!window.L){$('#map').innerHTML='<div class="tv-empty" style="padding:20px">Mapa indisponível (sem conexão com o Leaflet).</div>';return;}
-  if(!_map){_map=L.map('map',{zoomControl:true,attributionControl:false}).setView([-23.5505,-46.6333],12);
+  if(!_map){_map=L.map('map',{zoomControl:false,attributionControl:false}).setView([-23.5505,-46.6333],12);
+    L.control.zoom({position:'topright'}).addTo(_map);
     L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png',{maxZoom:19,subdomains:'abcd'}).addTo(_map);
-    renderMapChips();
-    const q=$('#map-q');if(q)q.addEventListener('keydown',e=>{if(e.key==='Enter'&&q.value.trim())nearbySearch(q.value.trim());});}
+    renderMapChips();loadSavedPlaces();
+    const q=$('#map-q');if(q)q.addEventListener('keydown',e=>{if(e.key==='Enter'&&q.value.trim())showNearby(q.value.trim());});
+    $('#map-add').onclick=()=>{_addMode=!_addMode;$('#map-add').classList.toggle('on',_addMode);$('#map-status').textContent=_addMode?'Modo adicionar: toque no mapa pra criar um ponto':'Você está aqui';};
+    $('#map-ask').onclick=()=>{switchView('chat');send('E.V., o que tem de útil perto de mim agora?');};
+    _map.on('click',ev=>{if(!_addMode)return;const name=prompt('Nome do ponto (ex: Casa, Trabalho):');if(!name)return;
+      fetch('/api/places',{method:'POST',headers:H(),body:JSON.stringify({name,lat:ev.latlng.lat,lng:ev.latlng.lng})}).then(r=>r.json()).then(d=>addSavedMarker({id:d.id,name,lat:ev.latlng.lat,lng:ev.latlng.lng}));
+      _addMode=false;$('#map-add').classList.remove('on');$('#map-status').textContent='Ponto "'+name+'" salvo';});}
   setTimeout(()=>{if(_map)_map.invalidateSize();},120);
   if(!_loc)locateMe();}
 const ACT_ICON={'task.new':['plus','tarefa criada'],'task.done':['check-check','tarefa concluída'],'task.del':['trash-2','tarefa apagada'],'reminder.new':['alarm-clock','lembrete criado'],'reminder.done':['bell-ring','lembrete disparado'],'reminder.cancel':['bell-off','lembrete cancelado'],'expense.new':['wallet','gasto adicionado'],'expense.del':['trash-2','gasto apagado'],'habit.done':['repeat','hábito feito']};
@@ -2661,6 +2709,41 @@ def create_app(config: Config, brain: Brain | None = None):
         except Exception:
             pass
         return {"ok": True}
+
+    @app.post("/api/nearby")
+    async def nearby(request: Request):
+        _check(request.headers.get("authorization"))
+        d = await _body(request)
+        try:
+            lat, lng = float(d.get("lat")), float(d.get("lng"))
+        except (TypeError, ValueError):
+            return {"items": [], "msg": "sem localização"}
+        query = (d.get("query") or "").strip()
+        items = await asyncio.to_thread(tools_mod.nearby_places, lat, lng, query)
+        return {"items": items}
+
+    @app.get("/api/places")
+    async def places_list(request: Request):
+        _check(request.headers.get("authorization"))
+        return {"items": memory.list_places(owner)}
+
+    @app.post("/api/places")
+    async def places_add(request: Request):
+        _check(request.headers.get("authorization"))
+        d = await _body(request)
+        try:
+            lat, lng = float(d.get("lat")), float(d.get("lng"))
+        except (TypeError, ValueError):
+            return {"ok": False}
+        name = (d.get("name") or "Ponto").strip()
+        pid = memory.add_place(owner, name, lat, lng)
+        return {"ok": True, "id": pid, "items": memory.list_places(owner)}
+
+    @app.post("/api/places/delete")
+    async def places_delete(request: Request):
+        _check(request.headers.get("authorization"))
+        memory.delete_place(owner, int((await _body(request)).get("id") or 0))
+        return {"ok": True, "items": memory.list_places(owner)}
 
     @app.post("/api/receipt")
     async def receipt(request: Request):

--- a/ev/providers/tools.py
+++ b/ev/providers/tools.py
@@ -465,6 +465,84 @@ def reverse_geocode(lat: float, lng: float) -> str:
         return ""
 
 
+# Friendly place types -> OpenStreetMap tag filters (for Overpass queries).
+_OSM_KINDS = {
+    "farmácia": '["amenity"="pharmacy"]', "farmacia": '["amenity"="pharmacy"]',
+    "mercado": '["shop"~"supermarket|convenience|grocery"]',
+    "supermercado": '["shop"="supermarket"]',
+    "restaurante": '["amenity"="restaurant"]',
+    "padaria": '["shop"="bakery"]',
+    "café": '["amenity"="cafe"]', "cafe": '["amenity"="cafe"]',
+    "posto": '["amenity"="fuel"]', "gasolina": '["amenity"="fuel"]',
+    "banco": '["amenity"="bank"]', "caixa": '["amenity"="atm"]',
+    "hospital": '["amenity"~"hospital|clinic"]', "saúde": '["amenity"~"hospital|clinic|pharmacy"]',
+    "ônibus": '["highway"="bus_stop"]', "onibus": '["highway"="bus_stop"]',
+    "academia": '["leisure"="fitness_centre"]',
+    "escola": '["amenity"="school"]', "hotel": '["tourism"="hotel"]',
+    "estacionamento": '["amenity"="parking"]',
+}
+
+
+def _haversine_m(lat1, lng1, lat2, lng2) -> int:
+    from math import radians, sin, cos, asin, sqrt
+    dlat, dlng = radians(lat2 - lat1), radians(lng2 - lng1)
+    a = sin(dlat / 2) ** 2 + cos(radians(lat1)) * cos(radians(lat2)) * sin(dlng / 2) ** 2
+    return int(6371000 * 2 * asin(sqrt(a)))
+
+
+def nearby_places(lat: float, lng: float, query: str, radius_m: int = 1600,
+                  limit: int = 20) -> list[dict]:
+    """Find POIs near (lat,lng) via OpenStreetMap Overpass. Returns items sorted
+    by distance: {name, lat, lng, dist, kind}. Empty list on any failure."""
+    import json
+    import urllib.parse
+    import urllib.request
+
+    q = (query or "").strip().lower()
+    flt = _OSM_KINDS.get(q)
+    if flt:
+        selector = f"nwr{flt}(around:{radius_m},{lat},{lng});"
+    else:  # free text -> match by name
+        safe = re.sub(r'["\\]', "", query.strip())[:40]
+        selector = f'nwr["name"~"{safe}",i](around:{radius_m},{lat},{lng});'
+    oql = f"[out:json][timeout:20];({selector});out center {limit * 3};"
+    try:
+        data = urllib.parse.urlencode({"data": oql}).encode()
+        req = urllib.request.Request(
+            "https://overpass-api.de/api/interpreter", data=data,
+            headers={"User-Agent": "E.V.-assistant/1.0"})
+        with urllib.request.urlopen(req, timeout=25) as r:
+            res = json.loads(r.read().decode())
+    except Exception as exc:
+        log.warning("nearby_places failed (%s)", exc)
+        return []
+    out = []
+    for e in res.get("elements", []):
+        tags = e.get("tags", {})
+        name = tags.get("name")
+        if not name:
+            continue
+        plat = e.get("lat") or (e.get("center") or {}).get("lat")
+        plng = e.get("lon") or (e.get("center") or {}).get("lon")
+        if plat is None or plng is None:
+            continue
+        out.append({
+            "name": name, "lat": plat, "lng": plng,
+            "dist": _haversine_m(lat, lng, plat, plng),
+            "kind": tags.get("amenity") or tags.get("shop") or tags.get("leisure") or "",
+        })
+    out.sort(key=lambda p: p["dist"])
+    # dedupe by name, keep nearest
+    seen, uniq = set(), []
+    for p in out:
+        k = p["name"].lower()
+        if k in seen:
+            continue
+        seen.add(k)
+        uniq.append(p)
+    return uniq[:limit]
+
+
 def maps_search_link(lat, lng, query: str) -> str:
     """Google Maps search link for `query` near coordinates."""
     import urllib.parse

--- a/tests/test_ai_commands.py
+++ b/tests/test_ai_commands.py
@@ -91,7 +91,7 @@ def test_event_alert_lead_window():
     assert f("nope", now, 30) is None
 
 
-def test_location_tools(tmp_path):
+def test_location_tools(tmp_path, monkeypatch):
     from ev.core.brain import Brain
     from ev.providers import tools
     assert "google.com/maps" in tools.maps_search_link(-23.5, -46.6, "farmácia")
@@ -107,7 +107,14 @@ def test_location_tools(tmp_path):
     # no location yet -> guidance
     assert "não sei" in fns["locais_proximos"]("farmácia").lower()
     assert "não sei" in fns["minha_localizacao"]().lower() or "ainda não" in fns["minha_localizacao"]().lower()
-    # after storing location -> maps links
+    assert "não salvou" in fns["meus_locais"]().lower()
+    # with location + mocked OSM lookup -> a real list (name + distance)
     b._memory.set_setting("loc_lat", "-23.5"); b._memory.set_setting("loc_lng", "-46.6")
-    assert "google.com/maps" in fns["locais_proximos"]("mercado")
+    monkeypatch.setattr(tools, "nearby_places", lambda *a, **k: [
+        {"name": "Drogaria X", "lat": -23.5, "lng": -46.6, "dist": 120, "kind": "pharmacy"}])
+    out = fns["locais_proximos"]("farmácia")
+    assert "Drogaria X" in out and "120" in out
     assert "-23.5" in fns["minha_localizacao"]()
+    # saved places surface via meus_locais
+    b._memory.add_place("u", "Casa", -23.5, -46.6)
+    assert "Casa" in fns["meus_locais"]()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -332,3 +332,22 @@ def test_chat_image_persistence(tmp_path):
     user = [x for x in m.recent_messages(conv, 10) if x["role"] == "user"][-1]
     assert f"[img:{iid}]" in user["content"]
     assert m.get_chat_image(999999) is None
+
+
+def test_places_crud(tmp_path):
+    from ev.core.memory import Memory
+    m = Memory(tmp_path / "t.db")
+    pid = m.add_place("u", "Casa", -23.55, -46.63)
+    assert [p["name"] for p in m.list_places("u")] == ["Casa"]
+    m.add_place("u", "Trabalho", -23.56, -46.64)
+    assert len(m.list_places("u")) == 2
+    m.delete_place("u", pid)
+    assert [p["name"] for p in m.list_places("u")] == ["Trabalho"]
+
+
+def test_haversine_and_kinds(tmp_path):
+    from ev.providers import tools
+    # ~1.1 km per 0.01 deg latitude
+    d = tools._haversine_m(-23.55, -46.63, -23.56, -46.63)
+    assert 1000 < d < 1200
+    assert "farmácia" in tools._OSM_KINDS and "restaurante" in tools._OSM_KINDS


### PR DESCRIPTION
## 🤔 Context

Melhorias no Mapa pedidas:

1. **Maior** — o mapa agora ocupa a altura da tela, não fica mais naquela faixa horizontal.
2. **Sem jogar pro Google Maps** — padaria, farmácia, restaurante etc. aparecem **dentro da própria E.V.**: pins no mapa + uma lista flutuante, via OpenStreetMap (Overpass). Validei ao vivo na VM (retorna farmácias reais). Cada resultado tem "Perguntar à E.V." e um link de rota (opcional).
3. **Pontos de interesse** — botão **"Adicionar ponto"** → toque no mapa → dê um nome → fica salvo (persistido) e reaparece; remove pelo popup.
4. **Falar com a E.V. pelo mapa** — popups e o botão **"Perguntar à E.V."** mandam uma mensagem no chat; a IA ganhou `locais_proximos` (agora com resultados reais do OSM) e `meus_locais`.

## Alterações

| Área | Mudança |
|------|---------|
| `ev/providers/tools.py` | `nearby_places` (Overpass) + `_haversine_m` + `_OSM_KINDS` |
| `ev/core/memory.py` | tabela `places` + `add/list/delete_place` |
| `ev/interfaces/web.py` | mapa maior; `/api/nearby`, `/api/places[/delete]`; pins+lista; adicionar ponto; "perguntar à E.V." |
| `ev/core/brain.py` | `locais_proximos` real (OSM) + `meus_locais` |
| `tests/*` | places CRUD, haversine/kinds, ferramentas de localização |

160 testes passam; Overpass verificado ao vivo.

> [!NOTE]
> Busca num raio de ~1,6 km. Tiles OSM + dados Overpass são gratuitos; a rota ainda usa link do Google Maps (externo, sem chave).

🤖 Generated with [Claude Code](https://claude.com/claude-code)