### PR TITLE
Corrige lentidão no Firefox/Zen (versão leve dos efeitos holográficos)

### DIFF
--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -140,6 +140,14 @@ body::after{content:"";position:fixed;inset:0;pointer-events:none;z-index:6;back
 .rail::before,.rail::after{content:"";position:absolute;width:15px;height:15px;border:1px solid var(--accent);opacity:.45;pointer-events:none;z-index:2}
 .rail::before{top:9px;left:9px;border-right:none;border-bottom:none}
 .rail::after{bottom:9px;right:9px;border-left:none;border-top:none}
+/* Firefox/Zen: desliga blur/blend/animações caras (mantém o look, sem travar) */
+.ff #left,.ff #right{-webkit-backdrop-filter:none;backdrop-filter:none;background:rgba(8,15,26,.94)}
+.ff .msg.ev,.ff #map-results,.ff #map-route{-webkit-backdrop-filter:none;backdrop-filter:none}
+.ff .msg.ev{background:var(--elev)}
+.ff #map-results{background:rgba(6,12,20,.96)}.ff #map-route{background:rgba(6,12,20,.96)}
+.ff body::after{mix-blend-mode:normal;opacity:.35}
+.ff body::before{animation:none}
+.ff #hud-scan{display:none}
 .rail{display:flex;flex-direction:column;min-height:0}
 #left{border-right:1px solid var(--line);padding:18px;gap:14px;overflow:auto}
 #right{border-left:1px solid var(--line);padding:18px;gap:12px;overflow:auto}
@@ -703,6 +711,8 @@ textarea.minput{resize:vertical;min-height:74px;font-family:var(--body);line-hei
   <div id="welcome-txt"></div>
 </div>
 <script>
+// Firefox/Zen: backdrop-filter e mix-blend-mode são muito lentos nele -> versão leve.
+try{if(/firefox/i.test(navigator.userAgent))document.documentElement.classList.add('ff');}catch(e){}
 let token=localStorage.getItem('ev_token')||'';
 let voiceOn=localStorage.getItem('ev_voice')!=='off';
 let thread=localStorage.getItem('ev_thread')||'geral';


### PR DESCRIPTION
## 🤔 Context

O site ficou lento no **Firefox / Zen** (Zen é baseado no Firefox), mas normal no Chrome/Opera. Motivo: o Firefox é **muito lento** com `backdrop-filter: blur()` e `mix-blend-mode`, e a camada holográfica usa os dois em superfícies grandes (barras laterais de vidro, scanlines).

Correção: detecto o Firefox e aplico uma **versão leve** — painéis translúcidos sólidos (sem blur), scanlines sem blend, sem o pulso do grid e sem a barra de scan. No Chromium (Chrome/Opera) o efeito completo continua.

## Alterações

| Área | Mudança |
|------|---------|
| `ev/interfaces/web.py` | detecção `html.ff` + overrides CSS que desligam blur/blend/animações caras no Firefox |

160 testes passam.

> [!NOTE]
> É só CSS/1 linha de JS; não muda nada no Chromium. Se ainda ficar pesado no Zen, dá pra desligar mais coisa (ex: o mapa/tiles) — mas o gargalo eram o blur e o blend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)