### PR TITLE
Firefox: manter a animação holográfica (só blur/blend eram o gargalo)

### DIFF
--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -140,14 +140,13 @@ body::after{content:"";position:fixed;inset:0;pointer-events:none;z-index:6;back
 .rail::before,.rail::after{content:"";position:absolute;width:15px;height:15px;border:1px solid var(--accent);opacity:.45;pointer-events:none;z-index:2}
 .rail::before{top:9px;left:9px;border-right:none;border-bottom:none}
 .rail::after{bottom:9px;right:9px;border-left:none;border-top:none}
-/* Firefox/Zen: desliga blur/blend/animações caras (mantém o look, sem travar) */
+/* Firefox/Zen: só o blur (backdrop-filter) e o blend travam — desligo esses e
+   MANTENHO as animações holográficas (pulso do grid + barra de scan), que são baratas. */
 .ff #left,.ff #right{-webkit-backdrop-filter:none;backdrop-filter:none;background:rgba(8,15,26,.94)}
 .ff .msg.ev,.ff #map-results,.ff #map-route{-webkit-backdrop-filter:none;backdrop-filter:none}
 .ff .msg.ev{background:var(--elev)}
 .ff #map-results{background:rgba(6,12,20,.96)}.ff #map-route{background:rgba(6,12,20,.96)}
-.ff body::after{mix-blend-mode:normal;opacity:.35}
-.ff body::before{animation:none}
-.ff #hud-scan{display:none}
+.ff body::after{mix-blend-mode:normal;opacity:.4}
 .rail{display:flex;flex-direction:column;min-height:0}
 #left{border-right:1px solid var(--line);padding:18px;gap:14px;overflow:auto}
 #right{border-left:1px solid var(--line);padding:18px;gap:12px;overflow:auto}


### PR DESCRIPTION
## 🤔 Context

No fix anterior de performance eu tinha desligado, no Firefox, também o **pulso do grid** e a **barra de scan** — e aí a animação holográfica sumiu. Mas essas animações são **baratas** (opacity/transform); o que travava mesmo era o `backdrop-filter: blur()` e o `mix-blend-mode`.

Agora: no Firefox/Zen a **animação holográfica volta**, mantendo apenas o blur e o blend desligados (que eram o real gargalo). Chromium segue com tudo.

## Alterações

| Área | Mudança |
|------|---------|
| `ev/interfaces/web.py` | remove os overrides `.ff` que matavam `body::before` (pulso) e `#hud-scan` (varredura) |

160 testes passam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)