### PR TITLE
Firefox: manter as bolhas holográficas das respostas da E.V.

### DIFF
--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -143,8 +143,8 @@ body::after{content:"";position:fixed;inset:0;pointer-events:none;z-index:6;back
 /* Firefox/Zen: só o blur (backdrop-filter) e o blend travam — desligo esses e
    MANTENHO as animações holográficas (pulso do grid + barra de scan), que são baratas. */
 .ff #left,.ff #right{-webkit-backdrop-filter:none;backdrop-filter:none;background:rgba(8,15,26,.94)}
+/* só tira o blur das bolhas — mantém o degradê translúcido + borda que brilha (holográfico) */
 .ff .msg.ev,.ff #map-results,.ff #map-route{-webkit-backdrop-filter:none;backdrop-filter:none}
-.ff .msg.ev{background:var(--elev)}
 .ff #map-results{background:rgba(6,12,20,.96)}.ff #map-route{background:rgba(6,12,20,.96)}
 .ff body::after{mix-blend-mode:normal;opacity:.4}
 .rail{display:flex;flex-direction:column;min-height:0}


### PR DESCRIPTION
## 🤔 Context

No ajuste de performance do Firefox eu tinha forçado o fundo das respostas da E.V. (`.msg.ev`) para sólido — o que **achatou** o visual holográfico das bolhas (degradê translúcido + borda ciano que brilha), que você curtia.

Esse degradê e o brilho são **baratos**; só o `backdrop-filter: blur()` era pesado. Agora no Firefox/Zen as bolhas de resposta **voltam ao visual holográfico**, tirando apenas o blur.

## Alterações

| Área | Mudança |
|------|---------|
| `ev/interfaces/web.py` | remove o override que deixava `.msg.ev` com fundo sólido no Firefox |

160 testes passam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)