### PR TITLE
Terminal de volta no mobile

### DIFF
--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -291,8 +291,9 @@ body.speaking .bigcore .r2{animation-delay:.15s}body.speaking .bigcore .r3{anima
 @media(max-width:760px){
   .tabs{display:none}
   .mnav{display:block;flex:1 1 auto;min-width:60px}
-  /* declutter the phone header so the folder/panel toggles never get clipped */
-  #gsearch,#term,#tgl-zen{display:none}
+  /* declutter the phone header so the folder/panel toggles never get clipped
+     (keep Terminal available on mobile; only drop search + clean-mode) */
+  #gsearch,#tgl-zen{display:none}
   .tbtn.ic-txt span{display:none}
   .tbtn.ic-txt{padding:9px 10px}
   .topbar{gap:6px;padding:10px 10px}


### PR DESCRIPTION
## 🤔 Context

No fix do cabeçalho mobile eu tinha escondido o botão **Terminal**. Ele cabe junto com os toggles de pasta/painel, então voltei — continuo escondendo só a busca e o modo-limpo (que são de PC).

> [!NOTE]
> Verifiquei com Playwright a 360px: Terminal (228–266), Voz (271–309) e o toggle direito (314–350) todos dentro da tela.

## Alterações

| Área | Mudança |
|------|---------|
| `ev/interfaces/web.py` | media query `<=760px`: não esconde mais `#term` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)