### PR TITLE
Câmera ao vivo: rotular objetos (caixas + nomes)

### DIFF
--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -1927,27 +1927,30 @@ function camSee(mode){if(_camBusy)return;_camBusy=true;if(mode==='what')camResul
       const j=await (await fetch('/api/see',{method:'POST',headers:{'Authorization':'Bearer '+token},body:fd})).json();
       const t=(j.text||'').trim();if(t){camResult(t);const od=mode!=='live';if(od||voiceOn)speak(t,od);}
     }catch(e){}finally{_camBusy=false;}});}
-async function initFaceDetector(){if(_faceDet)return _faceDet;
+let _objDet=null;
+const OBJ_PT={person:'pessoa',cup:'copo',bottle:'garrafa','cell phone':'celular',laptop:'notebook',keyboard:'teclado',mouse:'mouse',book:'livro',chair:'cadeira','dining table':'mesa',tv:'TV',remote:'controle',clock:'relógio','potted plant':'planta',backpack:'mochila',handbag:'bolsa',car:'carro',bicycle:'bicicleta',dog:'cachorro',cat:'gato',bird:'pássaro','wine glass':'taça',fork:'garfo',knife:'faca',spoon:'colher',bowl:'tigela',banana:'banana',apple:'maçã',orange:'laranja',pizza:'pizza',cake:'bolo',scissors:'tesoura',umbrella:'guarda-chuva',couch:'sofá',bed:'cama'};
+async function initDetectors(){if(_faceDet||_objDet)return;
   try{const V=await import('https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.14/vision_bundle.mjs');
     const fs=await V.FilesetResolver.forVisionTasks('https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.14/wasm');
-    _faceDet=await V.FaceDetector.createFromOptions(fs,{baseOptions:{modelAssetPath:'https://storage.googleapis.com/mediapipe-models/face_detector/blaze_face_short_range/float16/1/blaze_face_short_range.tflite'},runningMode:'VIDEO'});
-  }catch(e){_faceDet=null;}
-  return _faceDet;}
-function drawFaces(dets){const v=$('#cam-video'),cv=$('#cam-fx');if(!cv||!v)return;const W=v.clientWidth||1,H=v.clientHeight||1;if(cv.width!==W)cv.width=W;if(cv.height!==H)cv.height=H;
-  const ctx=cv.getContext('2d');ctx.clearRect(0,0,W,H);const sx=W/(v.videoWidth||W),sy=H/(v.videoHeight||H);
-  ctx.strokeStyle='#35c8ff';ctx.lineWidth=2;ctx.shadowColor='rgba(53,200,255,.9)';ctx.shadowBlur=8;
-  (dets||[]).forEach(d=>{const bb=d.boundingBox;if(!bb)return;ctx.strokeRect(bb.originX*sx,bb.originY*sy,bb.width*sx,bb.height*sy);});
-  ctx.shadowBlur=0;
-  if((dets||[]).length)$('#cam-hint').textContent=dets.length+' rosto(s) detectado(s) · movimento é narrado';}
+    try{_faceDet=await V.FaceDetector.createFromOptions(fs,{baseOptions:{modelAssetPath:'https://storage.googleapis.com/mediapipe-models/face_detector/blaze_face_short_range/float16/1/blaze_face_short_range.tflite'},runningMode:'VIDEO'});}catch(e){_faceDet=null;}
+    try{_objDet=await V.ObjectDetector.createFromOptions(fs,{baseOptions:{modelAssetPath:'https://storage.googleapis.com/mediapipe-models/object_detector/efficientdet_lite0/float16/1/efficientdet_lite0.tflite'},runningMode:'VIDEO',scoreThreshold:0.45,maxResults:6});}catch(e){_objDet=null;}
+  }catch(e){}}
+function ovCtx(){const v=$('#cam-video'),cv=$('#cam-fx');if(!cv||!v)return null;const W=v.clientWidth||1,H=v.clientHeight||1;if(cv.width!==W)cv.width=W;if(cv.height!==H)cv.height=H;const ctx=cv.getContext('2d');ctx.clearRect(0,0,W,H);ctx._sx=W/(v.videoWidth||W);ctx._sy=H/(v.videoHeight||H);return ctx;}
+function drawBox(ctx,bb,color,label){const x=bb.originX*ctx._sx,y=bb.originY*ctx._sy,w=bb.width*ctx._sx,h=bb.height*ctx._sy;
+  ctx.strokeStyle=color;ctx.lineWidth=2;ctx.shadowColor=color;ctx.shadowBlur=8;ctx.strokeRect(x,y,w,h);ctx.shadowBlur=0;
+  if(label){ctx.font='12px Inter, sans-serif';const tw=ctx.measureText(label).width+10;ctx.fillStyle='rgba(4,7,12,.82)';ctx.fillRect(x,Math.max(0,y-18),tw,18);ctx.fillStyle=color;ctx.fillText(label,x+5,Math.max(11,y-5));}}
 function faceLoop(){if(!_camLive)return;const v=$('#cam-video');
-  if(_faceDet&&v&&v.videoWidth){try{drawFaces(_faceDet.detectForVideo(v,performance.now()).detections);}catch(e){}}
+  if(v&&v.videoWidth){const ctx=ovCtx();let nf=0,no=0;const ts=performance.now();
+    if(ctx&&_faceDet){try{(_faceDet.detectForVideo(v,ts).detections||[]).forEach(d=>{if(d.boundingBox){drawBox(ctx,d.boundingBox,'#35c8ff','rosto');nf++;}});}catch(e){}}
+    if(ctx&&_objDet){try{(_objDet.detectForVideo(v,ts).detections||[]).forEach(d=>{const c=(d.categories&&d.categories[0])||{};const nm=OBJ_PT[c.categoryName]||c.categoryName||'objeto';if(nm==='pessoa')return;if(d.boundingBox){drawBox(ctx,d.boundingBox,'#7fe3ff',nm);no++;}});}catch(e){}}
+    if(ctx)$('#cam-hint').textContent=(nf?nf+' rosto(s) · ':'')+(no?no+' objeto(s) · ':'')+'movimento narrado';}
   if(v&&v.videoWidth){try{_mCtx.drawImage(v,0,0,48,36);const cur=_mCtx.getImageData(0,0,48,36).data;
     if(_motionPrev){let diff=0,n=0;for(let i=0;i<cur.length;i+=16){diff+=Math.abs(cur[i]-_motionPrev[i]);n++;}diff/=n;
       const now=performance.now();if(diff>18&&now-_lastSee>6500&&!_camBusy){_lastSee=now;camSee('live');}}
     _motionPrev=cur;}catch(e){}}
   _faceRAF=requestAnimationFrame(faceLoop);}
-async function startCamLive(){_camLive=true;$('#cam-live').classList.add('on');$('#cam-hint').textContent='Modo ao vivo: preparando detecção de rostos...';
-  await initFaceDetector();$('#cam-hint').textContent=_faceDet?'Ao vivo: rostos marcados + movimento narrado':'Ao vivo: narração por movimento (caixas de rosto indisponíveis neste navegador)';
+async function startCamLive(){_camLive=true;$('#cam-live').classList.add('on');$('#cam-hint').textContent='Modo ao vivo: preparando visão...';
+  await initDetectors();$('#cam-hint').textContent=(_faceDet||_objDet)?'Ao vivo: rostos e objetos marcados + movimento narrado':'Ao vivo: narração por movimento (detecção indisponível neste navegador)';
   _motionPrev=null;_lastSee=performance.now();cancelAnimationFrame(_faceRAF);faceLoop();}
 function stopCamLive(){_camLive=false;const lb=$('#cam-live');if(lb)lb.classList.remove('on');cancelAnimationFrame(_faceRAF);const cv=$('#cam-fx');if(cv&&cv.getContext)cv.getContext('2d').clearRect(0,0,cv.width,cv.height);camResult('');}
 $('#cam-live').onclick=()=>{_camLive?stopCamLive():startCamLive();};


### PR DESCRIPTION
O modo ao vivo agora também detecta e nomeia objetos (MediaPipe ObjectDetector, client-side) com caixas ciano + nomes em pt-BR, junto das caixas de rosto. Sem gastar cota.