### PR TITLE
feat: agency mode — resolve minha manhã (plano do dia)

### DIFF
--- a/ev/core/brain.py
+++ b/ev/core/brain.py
@@ -127,6 +127,46 @@ class Brain:
         """Extract text from an image via Gemini vision (OCR)."""
         return await asyncio.to_thread(self._ocr_sync, image, mime)
 
+    async def plan_day(self, user_id: str) -> str:
+        """Agentic synthesis: an actionable plan from tasks + agenda + weather + loc."""
+        return await asyncio.to_thread(self._plan_day_sync, user_id)
+
+    def _plan_day_sync(self, user_id: str) -> str:
+        cfg = self._config
+        parts = []
+        tasks = self._memory.open_tasks(user_id)
+        if tasks:
+            parts.append("Tarefas abertas:\n" + "\n".join(
+                f"- {t['text']} ({t.get('category', 'geral')})" for t in tasks[:20]))
+        rems = self._memory.open_reminders(user_id)
+        if rems:
+            parts.append("Lembretes:\n" + "\n".join(
+                f"- {r['text']}" + (f" — {r['when_iso'][:16].replace('T', ' ')}"
+                                    if r.get("when_iso") else "") for r in rems[:15]))
+        if cfg.google_authorized():
+            try:
+                parts.append("Agenda:\n" + tools_mod.calendar_upcoming(
+                    cfg, cfg.default_account, 8))
+            except Exception:
+                pass
+        if getattr(cfg, "city", ""):
+            try:
+                parts.append("Clima:\n" + tools_mod.weather(cfg.city))
+            except Exception:
+                pass
+        addr = self._memory.get_setting("loc_addr")
+        if addr:
+            parts.append("Localização atual: " + addr)
+        context = f"(agora: {self._now_str()})\n\n" + (
+            "\n\n".join(parts) or "Sem dados no momento.")
+        system = (
+            "Você é a E.V., assistente pessoal do Ryan. Com base nos dados, monte um "
+            "PLANO curto e acionável para o dia dele, em português do Brasil: priorize "
+            "as tarefas, encaixe-as nos espaços entre os compromissos, avise sobre "
+            "conflitos de horário, clima ou trânsito, e termine com UMA sugestão do que "
+            "fazer AGORA. Use bullets curtos, direto ao ponto. Chame ele de Ryan.")
+        return self._ask_sync(system, context) or "Não consegui montar o plano agora."
+
     async def describe_image(self, image: bytes, mime: str | None, prompt: str) -> str:
         """One-off vision description (for live camera / 'what is this'). NOT
         persisted to any conversation. Returns '' on failure."""
@@ -697,8 +737,16 @@ class Brain:
             self._memory.add_place(user_id, nome, lat, lng)
             return f"ponto '{nome}' salvo no seu mapa."
 
+        def planejar_dia() -> str:
+            """Monta um plano acionável para o dia do usuário, juntando as tarefas
+            abertas, os lembretes, a agenda, o clima e a localização atual, e
+            priorizando tudo. Use quando ele pedir 'resolve minha manhã', 'plano do
+            dia', 'organiza meu dia', 'o que eu faço hoje'."""
+            return self._plan_day_sync(user_id)
+
         callables: dict = {
             "executar_comando": executar_comando,
+            "planejar_dia": planejar_dia,
             "anotar_pessoa": anotar_pessoa,
             "sobre_pessoa": sobre_pessoa,
             "minha_localizacao": minha_localizacao,
@@ -784,6 +832,12 @@ class Brain:
 
         s = "string"
         schemas = [
+            fn(
+                "planejar_dia",
+                "Monta um plano acionável do dia do usuário juntando tarefas, "
+                "lembretes, agenda, clima e localização. Use para 'resolve minha "
+                "manhã', 'plano do dia', 'organiza meu dia', 'o que faço hoje'.",
+            ),
             fn(
                 "executar_comando",
                 "Executa QUALQUER comando da E.V. em nome do usuário (hands-free por "

--- a/ev/core/commands.py
+++ b/ev/core/commands.py
@@ -26,6 +26,7 @@ from .timeparse import add_months, parse_when
 COMMAND_LIST = [
     ("menu", "Abre o menu interativo com botões"),
     ("ev", "Falar com a IA (útil em grupos): /ev sua mensagem"),
+    ("plano", "Resolve minha manhã: plano do dia (tarefas + agenda + clima)"),
     ("ajuda", "Lista os comandos disponíveis"),
     ("status", "Diagnóstico: VM, banco, chaves de API"),
     ("silenciar", "Não perturbe: /silenciar 2h (ou off)"),

--- a/ev/interfaces/telegram_bot.py
+++ b/ev/interfaces/telegram_bot.py
@@ -869,6 +869,13 @@ class TelegramInterface:
             ),
         )
 
+    async def cmd_plano(self, update: Update, _c: ContextTypes.DEFAULT_TYPE) -> None:
+        """Agentic day plan: 'resolve minha manhã'."""
+        if not self._authorized(update):
+            return
+        await self._reply(
+            update, await self._brain.plan_day(str(update.effective_user.id)))
+
     async def cmd_lembrete(self, update: Update, c: ContextTypes.DEFAULT_TYPE) -> None:
         if self._authorized(update):
             uid = str(update.effective_user.id)
@@ -2373,6 +2380,7 @@ class TelegramInterface:
         app.add_handler(CommandHandler("start", self.on_start))
         app.add_handler(CommandHandler("menu", self.cmd_menu))
         app.add_handler(CommandHandler("ev", self.cmd_ev))
+        app.add_handler(CommandHandler("plano", self.cmd_plano))
         app.add_handler(CallbackQueryHandler(self.on_callback))
         # Deterministic commands (no LLM)
         app.add_handler(CommandHandler("ajuda", self.cmd_ajuda))

--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -1023,11 +1023,11 @@ f.onsubmit=e=>{e.preventDefault();if(slash.style.display==='block'&&slSel>=0){pi
   txt.value='';hideSlash();if(!m)return;
   if(m.startsWith('/'))runCmd(m.slice(1));else send(m);};
 
-const CAT={tarefas:['Tarefas','list-checks'],lembretes:['Lembretes','alarm-clock'],gastos:['Gastos','wallet'],memorias:['Memórias','brain'],kb:['Base','book-open'],map:['Mapa','map'],graf:['Gráficos','bar-chart-3'],brain:['Cérebro','brain-circuit'],cam:['Câmera','camera'],buscar:['Buscar web','search'],noticias:['Notícias','newspaper'],clima:['Clima','cloud-sun'],relatorio:['Relatório','bar-chart-3'],status:['Status','activity'],semana:['Semana','calendar-days'],foco:['Pomodoro','timer'],procurar:['Procurar','file-search'],calendario:['Agenda','calendar'],habitos:['Hábitos','repeat'],diario:['Diário','notebook-pen'],orcamentos:['Orçamentos','piggy-bank'],assinaturas:['Assinaturas','credit-card'],dados:['Meus dados','database'],insights:['Insights','sparkles'],quiz:['Quiz','graduation-cap']};
+const CAT={plano:['Plano do dia','sunrise'],tarefas:['Tarefas','list-checks'],lembretes:['Lembretes','alarm-clock'],gastos:['Gastos','wallet'],memorias:['Memórias','brain'],kb:['Base','book-open'],map:['Mapa','map'],graf:['Gráficos','bar-chart-3'],brain:['Cérebro','brain-circuit'],cam:['Câmera','camera'],buscar:['Buscar web','search'],noticias:['Notícias','newspaper'],clima:['Clima','cloud-sun'],relatorio:['Relatório','bar-chart-3'],status:['Status','activity'],semana:['Semana','calendar-days'],foco:['Pomodoro','timer'],procurar:['Procurar','file-search'],calendario:['Agenda','calendar'],habitos:['Hábitos','repeat'],diario:['Diário','notebook-pen'],orcamentos:['Orçamentos','piggy-bank'],assinaturas:['Assinaturas','credit-card'],dados:['Meus dados','database'],insights:['Insights','sparkles'],quiz:['Quiz','graduation-cap']};
 const SM={tasks:['Tarefas','list-checks','tarefas'],reminders:['Lembretes','alarm-clock','lembretes'],expenses:['Gastos · mês','wallet','gastos'],memories:['Memórias','brain','memorias'],kb:['Base','book-open','kb'],kbfiles:['Arquivos','file-text','kb'],links:['Links','link','links'],habits:['Hábitos','repeat','habitos'],journal:['Diário','notebook-pen','diario'],subscriptions:['Assinaturas','credit-card','assinaturas'],budgets:['Orçamentos','piggy-bank','orcamentos'],watches:['Monitores','radar','monitores'],agenda:['Agenda · 7d','calendar','calendario'],activity:['Histórico · 24h','history','status'],provider:['Provedor','cpu','status'],model:['Modelo','box','modelo'],disk:['Disco','hard-drive','status'],ram:['RAM','memory-stick','status'],uptime:['Uptime','clock','status']};
 const RECUR=[{v:'',l:'Uma vez'},{v:'daily',l:'Diário'},{v:'weekly',l:'Semanal'},{v:'monthly',l:'Mensal'}];
 const RECUR_LBL={daily:'repete diário',weekly:'repete semanal',monthly:'repete mensal'};
-let config={actions:['buscar','noticias','clima','relatorio','status','semana'],stats:['tasks','reminders','expenses','memories','kb']};let _counts={};
+let config={actions:['plano','buscar','noticias','clima','relatorio','semana'],stats:['tasks','reminders','expenses','memories','kb']};let _counts={};
 function renderStats(){const box=$('#stats');box.textContent='';config.stats.forEach(k=>{const m=SM[k];if(!m)return;
   const VMAP={tasks:'tasks',reminders:'rem',expenses:'exp',memories:'mem',kb:'kb',kbfiles:'kb',links:'lnk',habits:'hab',journal:'jou',subscriptions:'sub',budgets:'orc',watches:'mon',agenda:'cal',activity:'act'};
   const s=el('div','stat');s.onclick=()=>{if(VMAP[k])switchView(VMAP[k]);else runCmd(m[2]);};const lbl=el('span','lbl');lbl.appendChild(ficon(m[1]));lbl.appendChild(document.createTextNode(m[0]));
@@ -2143,6 +2143,8 @@ def create_app(config: Config, brain: Brain | None = None):
         if name in ("limpar", "limparchat"):  # clear THIS folder's conversation
             memory.clear_conversation(_conv(thread))
             return "Conversa limpa nesta pasta."
+        if name in ("plano", "manha", "manhã"):  # agentic day plan
+            return await brain.plan_day(owner)
         if name in commands.runnable():
             return commands.run(owner, name, rest)
         if name == "provedor":
@@ -2413,7 +2415,7 @@ def create_app(config: Config, brain: Brain | None = None):
                 memory.set_setting("web_folders", json.dumps(out))
         return {"threads": _folders()}
 
-    _DEF_ACTIONS = ["buscar", "noticias", "clima", "relatorio", "status", "semana"]
+    _DEF_ACTIONS = ["plano", "buscar", "noticias", "clima", "relatorio", "semana"]
     _DEF_STATS = ["tasks", "reminders", "expenses", "memories", "kb"]
 
     def _cfg_list(key, default):


### PR DESCRIPTION
## 🤔 Context

A E.V. já respondia bem, mas era **reativa**: executava comandos isolados. Faltava **agência** — juntar sinais e agir com um objetivo. Esta PR adiciona a primeira capacidade genuinamente agêntica: o **plano do dia**.

Ao pedir *"resolve minha manhã"* / *"plano do dia"* (voz, chat, `/plano` ou a ação rápida), a E.V.:
1. Reúne **tarefas abertas + lembretes + agenda do Google + clima + localização atual**;
2. Pede ao cérebro para **priorizar, encaixar as tarefas nos vãos entre compromissos, avisar de conflitos** e terminar com **uma sugestão do que fazer agora**.

A síntese usa `_ask_sync` (fallback-aware), então funciona mesmo com o Gemini fora do ar.

```mermaid
flowchart LR
  P["/plano · voz · ação rápida"] --> B[plan_day]
  B --> T[tarefas] & R[lembretes] & A[agenda] & W[clima] & L[localização]
  T & R & A & W & L --> S[LLM prioriza + encaixa] --> O[plano acionável]
```

## Notas
- Novos pontos de entrada: tool `planejar_dia`, `/plano` (web + Telegram), ação rápida **Plano do dia** (agora no default).
- 52 testes (`test_ai_commands`, `test_web`) verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)