### PR TITLE
feat: proactive nudges — E.V. cobra pendências sozinha

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,8 @@ EV_WEEKLY_HOUR=20
 EV_RAIN_HOUR=21
 # Habit nudge: local hour to remind about habits not marked yet. Empty disables.
 EV_HABIT_NUDGE_HOUR=20
+# Proactive nudge: local hour E.V. cobra tarefas atrasadas/vencendo + assinaturas. <0 disables.
+EV_NUDGE_HOUR=9
 # Monthly financial report: day of month + hour. Empty day disables.
 EV_MONTHLY_REPORT_DAY=1
 EV_MONTHLY_REPORT_HOUR=9

--- a/ev/config.py
+++ b/ev/config.py
@@ -66,6 +66,7 @@ class Config:
     monthly_report_day: int  # day of month for the financial report; <0 disables
     monthly_report_hour: int
     event_alert_minutes: int  # heads-up lead time before a calendar event; <=0 disables
+    nudge_hour: int  # local hour for the proactive open-loops nudge; <0 disables
     # Tools
     websearch_enabled: bool
     brave_api_key: str   # optional: better web search than DuckDuckGo
@@ -213,6 +214,7 @@ class Config:
             monthly_report_day=monthly_report_day,
             monthly_report_hour=_get_int("EV_MONTHLY_REPORT_HOUR", 9),
             event_alert_minutes=_get_int("EV_EVENT_ALERT_MINUTES", 30),
+            nudge_hour=_get_int("EV_NUDGE_HOUR", 9),
             websearch_enabled=_get_bool("EV_WEBSEARCH_ENABLED", True),
             brave_api_key=os.getenv("BRAVE_API_KEY", "").strip(),
             tavily_api_key=os.getenv("TAVILY_API_KEY", "").strip(),

--- a/ev/core/commands.py
+++ b/ev/core/commands.py
@@ -27,6 +27,7 @@ COMMAND_LIST = [
     ("menu", "Abre o menu interativo com botões"),
     ("ev", "Falar com a IA (útil em grupos): /ev sua mensagem"),
     ("plano", "Resolve minha manhã: plano do dia (tarefas + agenda + clima)"),
+    ("pendencias", "O que está atrasado/vencendo — a E.V. te cobra"),
     ("ajuda", "Lista os comandos disponíveis"),
     ("status", "Diagnóstico: VM, banco, chaves de API"),
     ("silenciar", "Não perturbe: /silenciar 2h (ou off)"),
@@ -1025,6 +1026,56 @@ class Commands:
             if tab:
                 parts.append("\nTabNews (tech):")
                 parts.append(tab)
+        return "\n".join(parts)
+
+    def open_loops(self, user_id: str, now=None) -> dict:
+        """Deterministic 'things slipping' detector for the proactive nudge:
+        overdue tasks, tasks due today, and subscriptions charging soon.
+        Cheap (no LLM) and safe to call often."""
+        now = now or datetime.now(timezone.utc)
+        today = now.date()
+        overdue: list[str] = []
+        due_today: list[str] = []
+        for t in self._memory.open_tasks(user_id):
+            raw = t.get("due")
+            if not raw:
+                continue
+            try:
+                d = datetime.fromisoformat(raw)
+            except (ValueError, TypeError):
+                continue
+            if d.tzinfo is None:
+                d = d.replace(tzinfo=timezone.utc)
+            if d.date() < today:
+                overdue.append(t["text"])
+            elif d.date() == today:
+                due_today.append(t["text"])
+        subs: list[str] = []
+        for r in self._memory.list_recurring(user_id):
+            day = r.get("day")
+            if not day:
+                continue
+            days_until = (int(day) - today.day) % 31  # heads-up within 2 days
+            if 0 <= days_until <= 2:
+                subs.append(f"{r['description']} (R$ {r['amount']:.2f}, dia {day})")
+        return {"overdue": overdue, "due_today": due_today, "subs": subs}
+
+    def nudge_text(self, user_id: str, now=None) -> str:
+        """Human-readable proactive nudge, or '' when nothing is slipping."""
+        loops = self.open_loops(user_id, now)
+        if not (loops["overdue"] or loops["due_today"] or loops["subs"]):
+            return ""
+        parts = ["👋 Ryan, deixa eu te cobrar algumas coisas:"]
+        if loops["overdue"]:
+            parts.append("\n⏰ Tarefas atrasadas:")
+            parts += [f"- {t}" for t in loops["overdue"][:10]]
+        if loops["due_today"]:
+            parts.append("\n📌 Vence hoje:")
+            parts += [f"- {t}" for t in loops["due_today"][:10]]
+        if loops["subs"]:
+            parts.append("\n💳 Assinatura debitando em breve:")
+            parts += [f"- {s}" for s in loops["subs"][:10]]
+        parts.append("\nConcluir: /concluir <nome>. Quer que eu te ajude com alguma?")
         return "\n".join(parts)
 
     # --- links (named, categorized) ----------------------------------------

--- a/ev/interfaces/telegram_bot.py
+++ b/ev/interfaces/telegram_bot.py
@@ -86,6 +86,7 @@ class TelegramInterface:
         self._last_tg_backup: str | None = None  # date backup was sent to Telegram
         self._last_habit_nudge: str | None = None  # date of the last habit nudge
         self._last_monthly: str | None = None      # month of the last financial report
+        self._last_nudge: str | None = None        # date of the last open-loops nudge
         # Keep references to background tasks so they aren't garbage-collected
         # (a GC'd task would silently kill the scheduler).
         self._bg_tasks: list = []
@@ -875,6 +876,13 @@ class TelegramInterface:
             return
         await self._reply(
             update, await self._brain.plan_day(str(update.effective_user.id)))
+
+    async def cmd_pendencias(self, update: Update, _c: ContextTypes.DEFAULT_TYPE) -> None:
+        """Proactive open loops on demand: what's overdue / due / charging soon."""
+        if not self._authorized(update):
+            return
+        msg = self._commands.nudge_text(str(update.effective_user.id))
+        await self._cmd_out(update, msg or "Tudo em dia — nada atrasado. 👌")
 
     async def cmd_lembrete(self, update: Update, c: ContextTypes.DEFAULT_TYPE) -> None:
         if self._authorized(update):
@@ -2016,6 +2024,7 @@ class TelegramInterface:
                     await self._maybe_send_weekly(app)
                     await self._maybe_send_rain(app)
                     await self._maybe_habit_nudge(app)
+                    await self._maybe_nudge(app)
                     await self._maybe_monthly_report(app)
             except Exception:
                 log.exception("Briefing loop error")
@@ -2159,6 +2168,30 @@ class TelegramInterface:
             msg = "👀 Ainda falta hoje: " + ", ".join(pend) + ".\nMarque com /feito <nome>."
             await self._bot_send(app.bot, cfg.owner_id, msg, self._quick_kb())
             log.info("Sent habit nudge.")
+
+    async def _maybe_nudge(self, app: Application) -> None:
+        """Proactive open-loops nudge: overdue/due tasks + upcoming subscriptions.
+        Deterministic (no LLM), fired once/day at cfg.nudge_hour, and only when
+        something is actually slipping — silence when the day is clean."""
+        cfg = self._config
+        if getattr(cfg, "nudge_hour", -1) < 0 or cfg.owner_id is None:
+            return
+        now = datetime.now(self._tz())
+        today = now.date().isoformat()
+        if now.hour != cfg.nudge_hour or self._last_nudge == today:
+            return
+        self._last_nudge = today
+        msg = self._commands.nudge_text(str(cfg.owner_id))
+        if not msg:
+            return
+        await self._bot_send(app.bot, cfg.owner_id, msg, self._quick_kb())
+        try:  # mirror into the web notification center + push to devices
+            from ..providers import push
+            await asyncio.to_thread(push.send_push, cfg, self._memory,
+                                    "👋 E.V. te cobrando", msg, "/", str(cfg.owner_id))
+        except Exception:
+            pass
+        log.info("Sent proactive open-loops nudge.")
 
     async def _maybe_monthly_report(self, app: Application) -> None:
         cfg = self._config
@@ -2381,6 +2414,7 @@ class TelegramInterface:
         app.add_handler(CommandHandler("menu", self.cmd_menu))
         app.add_handler(CommandHandler("ev", self.cmd_ev))
         app.add_handler(CommandHandler("plano", self.cmd_plano))
+        app.add_handler(CommandHandler("pendencias", self.cmd_pendencias))
         app.add_handler(CallbackQueryHandler(self.on_callback))
         # Deterministic commands (no LLM)
         app.add_handler(CommandHandler("ajuda", self.cmd_ajuda))

--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -1025,7 +1025,7 @@ f.onsubmit=e=>{e.preventDefault();if(slash.style.display==='block'&&slSel>=0){pi
   txt.value='';hideSlash();if(!m)return;
   if(m.startsWith('/'))runCmd(m.slice(1));else send(m);};
 
-const CAT={plano:['Plano do dia','sunrise'],tarefas:['Tarefas','list-checks'],lembretes:['Lembretes','alarm-clock'],gastos:['Gastos','wallet'],memorias:['Memórias','brain'],kb:['Base','book-open'],map:['Mapa','map'],graf:['Gráficos','bar-chart-3'],brain:['Cérebro','brain-circuit'],cam:['Câmera','camera'],buscar:['Buscar web','search'],noticias:['Notícias','newspaper'],clima:['Clima','cloud-sun'],relatorio:['Relatório','bar-chart-3'],status:['Status','activity'],semana:['Semana','calendar-days'],foco:['Pomodoro','timer'],procurar:['Procurar','file-search'],calendario:['Agenda','calendar'],habitos:['Hábitos','repeat'],diario:['Diário','notebook-pen'],orcamentos:['Orçamentos','piggy-bank'],assinaturas:['Assinaturas','credit-card'],dados:['Meus dados','database'],insights:['Insights','sparkles'],quiz:['Quiz','graduation-cap']};
+const CAT={plano:['Plano do dia','sunrise'],pendencias:['Pendências','bell-ring'],tarefas:['Tarefas','list-checks'],lembretes:['Lembretes','alarm-clock'],gastos:['Gastos','wallet'],memorias:['Memórias','brain'],kb:['Base','book-open'],map:['Mapa','map'],graf:['Gráficos','bar-chart-3'],brain:['Cérebro','brain-circuit'],cam:['Câmera','camera'],buscar:['Buscar web','search'],noticias:['Notícias','newspaper'],clima:['Clima','cloud-sun'],relatorio:['Relatório','bar-chart-3'],status:['Status','activity'],semana:['Semana','calendar-days'],foco:['Pomodoro','timer'],procurar:['Procurar','file-search'],calendario:['Agenda','calendar'],habitos:['Hábitos','repeat'],diario:['Diário','notebook-pen'],orcamentos:['Orçamentos','piggy-bank'],assinaturas:['Assinaturas','credit-card'],dados:['Meus dados','database'],insights:['Insights','sparkles'],quiz:['Quiz','graduation-cap']};
 const SM={tasks:['Tarefas','list-checks','tarefas'],reminders:['Lembretes','alarm-clock','lembretes'],expenses:['Gastos · mês','wallet','gastos'],memories:['Memórias','brain','memorias'],kb:['Base','book-open','kb'],kbfiles:['Arquivos','file-text','kb'],links:['Links','link','links'],habits:['Hábitos','repeat','habitos'],journal:['Diário','notebook-pen','diario'],subscriptions:['Assinaturas','credit-card','assinaturas'],budgets:['Orçamentos','piggy-bank','orcamentos'],watches:['Monitores','radar','monitores'],agenda:['Agenda · 7d','calendar','calendario'],activity:['Histórico · 24h','history','status'],provider:['Provedor','cpu','status'],model:['Modelo','box','modelo'],disk:['Disco','hard-drive','status'],ram:['RAM','memory-stick','status'],uptime:['Uptime','clock','status']};
 const RECUR=[{v:'',l:'Uma vez'},{v:'daily',l:'Diário'},{v:'weekly',l:'Semanal'},{v:'monthly',l:'Mensal'}];
 const RECUR_LBL={daily:'repete diário',weekly:'repete semanal',monthly:'repete mensal'};
@@ -2168,6 +2168,8 @@ def create_app(config: Config, brain: Brain | None = None):
             return "Conversa limpa nesta pasta."
         if name in ("plano", "manha", "manhã"):  # agentic day plan
             return await brain.plan_day(owner)
+        if name in ("pendencias", "pendências", "cobrar"):  # proactive open loops
+            return commands.nudge_text(owner) or "Tudo em dia, Ryan — nada atrasado. 👌"
         if name in commands.runnable():
             return commands.run(owner, name, rest)
         if name == "provedor":

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -21,6 +21,27 @@ def _commands(tmp_path):
     return Commands(config, Memory(tmp_path / "t.db"))
 
 
+def test_open_loops_and_nudge(tmp_path):
+    from datetime import datetime, timezone
+    c = _commands(tmp_path)
+    now = datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc)
+    m = c._memory
+    m.add_task("u", "entregar relatório", due="2026-08-01")   # overdue
+    m.add_task("u", "pagar boleto", due="2026-08-04")          # due today
+    m.add_task("u", "ler artigo")                              # no due — ignored
+    m.add_recurring("u", 39.9, "Netflix", "lazer", 5)          # charges tomorrow
+    m.add_recurring("u", 20.0, "Spotify", "lazer", 20)         # far off — ignored
+    loops = c.open_loops("u", now=now)
+    assert loops["overdue"] == ["entregar relatório"]
+    assert loops["due_today"] == ["pagar boleto"]
+    assert any("Netflix" in s for s in loops["subs"])
+    assert not any("Spotify" in s for s in loops["subs"])
+    msg = c.nudge_text("u", now=now)
+    assert "atrasada" in msg and "entregar relatório" in msg and "Netflix" in msg
+    # clean slate → empty nudge (E.V. stays silent when nothing is slipping)
+    assert c.nudge_text("v", now=now) == ""
+
+
 def test_task_flow(tmp_path):
     c = _commands(tmp_path)
     assert "adicionada" in c.tarefa("u", "comprar pão")


### PR DESCRIPTION
## 🤔 Context

A gente construiu a **agência** (o *"resolve minha manhã"*), mas a E.V. ainda não **fechava o ciclo**: montava o plano e não te cobrava depois. Esta PR dá o passo natural — E.V. **nota o que está escorregando e te avisa sozinha**, sem você pedir.

Uma vez por dia (em `EV_NUDGE_HOUR`, padrão 9h), ela varre e cobra:
- ⏰ **Tarefas atrasadas** (passaram do prazo)
- 📌 **Vence hoje**
- 💳 **Assinatura debitando em ≤2 dias** (aviso antes do débito)

Só fala quando há algo aberto — **silêncio em dia limpo**, pra não virar spam. Chega no **Telegram + central de notificações da web + push**.

```mermaid
flowchart LR
  L[briefing loop · 1x/dia] --> D[open_loops<br/>detector determinístico]
  D -->|atrasadas · vence hoje · assinaturas| N[nudge_text]
  N --> T[Telegram] & W[central de notificações] & P[push]
```

## Como usar
- **Automático:** todo dia no horário configurado.
- **Sob demanda:** `/pendencias` (web + Telegram) ou a ação rápida **Pendências**.

## Notas
- Detector é **determinístico** (sem LLM) → não gasta cota e é testável.
- 162 testes verdes, incluindo `test_open_loops_and_nudge` (atrasada/vence-hoje/assinatura + silêncio quando limpo).
- Novo `EV_NUDGE_HOUR` documentado no `.env.example`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)