### PR TITLE
feat: daily off-VM encrypted backup + on-demand pull

### DIFF
--- a/ev/core/commands.py
+++ b/ev/core/commands.py
@@ -28,6 +28,7 @@ COMMAND_LIST = [
     ("ev", "Falar com a IA (útil em grupos): /ev sua mensagem"),
     ("plano", "Resolve minha manhã: plano do dia (tarefas + agenda + clima)"),
     ("pendencias", "O que está atrasado/vencendo — a E.V. te cobra"),
+    ("backup", "Envia agora um backup cifrado do banco (fora da VM)"),
     ("ajuda", "Lista os comandos disponíveis"),
     ("status", "Diagnóstico: VM, banco, chaves de API"),
     ("silenciar", "Não perturbe: /silenciar 2h (ou off)"),

--- a/ev/interfaces/telegram_bot.py
+++ b/ev/interfaces/telegram_bot.py
@@ -1990,28 +1990,51 @@ class TelegramInterface:
         return dest
 
     async def _maybe_send_backup_telegram(self, app: Application, path) -> None:
-        """Send the backup off the VM, into the owner's Telegram chat. Weekly
-        (Sundays), plus once right after startup so there's always a fresh copy."""
+        """Send the encrypted backup off the VM, into the owner's Telegram chat —
+        once per day. Off-site + encrypted means losing the VM never loses data."""
         cfg = self._config
         if not cfg.telegram_backup or cfg.owner_id is None or path is None:
             return
-        now = datetime.now(self._tz())
-        today = now.date().isoformat()
-        first_time = self._last_tg_backup is None
-        if not first_time and (now.weekday() != 6 or self._last_tg_backup == today):
+        today = datetime.now(self._tz()).date().isoformat()
+        if self._last_tg_backup == today:  # already sent today
             return
         self._last_tg_backup = today
+        await self._send_backup_doc(app, path)
+
+    async def _send_backup_doc(self, app: Application, path) -> bool:
+        cfg = self._config
+        if cfg.owner_id is None or path is None:
+            return False
         try:
             with open(path, "rb") as f:
                 await app.bot.send_document(
                     chat_id=cfg.owner_id,
                     document=f,
                     filename=path.name,
-                    caption="🗄️ Backup do banco da E.V. Guarde este arquivo — dá pra restaurar tudo com ele.",
+                    caption="🗄️ Backup cifrado da E.V. Guarde — restaura tudo com a EV_DB_KEY.",
                 )
             log.info("Backup sent to Telegram (%s).", path.name)
+            return True
         except Exception:
             log.exception("Failed to send backup to Telegram")
+            return False
+
+    async def cmd_backup(self, update: Update, _c: ContextTypes.DEFAULT_TYPE) -> None:
+        """On-demand off-VM backup: /backup sends a fresh encrypted copy now."""
+        if not self._authorized(update):
+            return
+        await update.message.reply_text("Gerando backup cifrado…")
+        try:
+            path = await asyncio.to_thread(self._do_backup)
+            with open(path, "rb") as f:
+                await update.message.reply_document(
+                    document=f, filename=path.name,
+                    caption="🗄️ Backup cifrado da E.V. Restaura com a EV_DB_KEY.")
+            self._last_tg_backup = datetime.now(self._tz()).date().isoformat()
+        except Exception:
+            log.exception("On-demand backup failed")
+            await update.message.reply_text(
+                "Falha ao gerar/enviar o backup. Vou tentar de novo no ciclo diário.")
 
     async def _briefing_loop(self, app: Application) -> None:
         while True:
@@ -2415,6 +2438,7 @@ class TelegramInterface:
         app.add_handler(CommandHandler("ev", self.cmd_ev))
         app.add_handler(CommandHandler("plano", self.cmd_plano))
         app.add_handler(CommandHandler("pendencias", self.cmd_pendencias))
+        app.add_handler(CommandHandler("backup", self.cmd_backup))
         app.add_handler(CallbackQueryHandler(self.on_callback))
         # Deterministic commands (no LLM)
         app.add_handler(CommandHandler("ajuda", self.cmd_ajuda))

--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -1025,7 +1025,7 @@ f.onsubmit=e=>{e.preventDefault();if(slash.style.display==='block'&&slSel>=0){pi
   txt.value='';hideSlash();if(!m)return;
   if(m.startsWith('/'))runCmd(m.slice(1));else send(m);};
 
-const CAT={plano:['Plano do dia','sunrise'],pendencias:['Pendências','bell-ring'],tarefas:['Tarefas','list-checks'],lembretes:['Lembretes','alarm-clock'],gastos:['Gastos','wallet'],memorias:['Memórias','brain'],kb:['Base','book-open'],map:['Mapa','map'],graf:['Gráficos','bar-chart-3'],brain:['Cérebro','brain-circuit'],cam:['Câmera','camera'],buscar:['Buscar web','search'],noticias:['Notícias','newspaper'],clima:['Clima','cloud-sun'],relatorio:['Relatório','bar-chart-3'],status:['Status','activity'],semana:['Semana','calendar-days'],foco:['Pomodoro','timer'],procurar:['Procurar','file-search'],calendario:['Agenda','calendar'],habitos:['Hábitos','repeat'],diario:['Diário','notebook-pen'],orcamentos:['Orçamentos','piggy-bank'],assinaturas:['Assinaturas','credit-card'],dados:['Meus dados','database'],insights:['Insights','sparkles'],quiz:['Quiz','graduation-cap']};
+const CAT={plano:['Plano do dia','sunrise'],pendencias:['Pendências','bell-ring'],bak:['Backup','database-backup'],tarefas:['Tarefas','list-checks'],lembretes:['Lembretes','alarm-clock'],gastos:['Gastos','wallet'],memorias:['Memórias','brain'],kb:['Base','book-open'],map:['Mapa','map'],graf:['Gráficos','bar-chart-3'],brain:['Cérebro','brain-circuit'],cam:['Câmera','camera'],buscar:['Buscar web','search'],noticias:['Notícias','newspaper'],clima:['Clima','cloud-sun'],relatorio:['Relatório','bar-chart-3'],status:['Status','activity'],semana:['Semana','calendar-days'],foco:['Pomodoro','timer'],procurar:['Procurar','file-search'],calendario:['Agenda','calendar'],habitos:['Hábitos','repeat'],diario:['Diário','notebook-pen'],orcamentos:['Orçamentos','piggy-bank'],assinaturas:['Assinaturas','credit-card'],dados:['Meus dados','database'],insights:['Insights','sparkles'],quiz:['Quiz','graduation-cap']};
 const SM={tasks:['Tarefas','list-checks','tarefas'],reminders:['Lembretes','alarm-clock','lembretes'],expenses:['Gastos · mês','wallet','gastos'],memories:['Memórias','brain','memorias'],kb:['Base','book-open','kb'],kbfiles:['Arquivos','file-text','kb'],links:['Links','link','links'],habits:['Hábitos','repeat','habitos'],journal:['Diário','notebook-pen','diario'],subscriptions:['Assinaturas','credit-card','assinaturas'],budgets:['Orçamentos','piggy-bank','orcamentos'],watches:['Monitores','radar','monitores'],agenda:['Agenda · 7d','calendar','calendario'],activity:['Histórico · 24h','history','status'],provider:['Provedor','cpu','status'],model:['Modelo','box','modelo'],disk:['Disco','hard-drive','status'],ram:['RAM','memory-stick','status'],uptime:['Uptime','clock','status']};
 const RECUR=[{v:'',l:'Uma vez'},{v:'daily',l:'Diário'},{v:'weekly',l:'Semanal'},{v:'monthly',l:'Mensal'}];
 const RECUR_LBL={daily:'repete diário',weekly:'repete semanal',monthly:'repete mensal'};
@@ -1037,7 +1037,7 @@ function renderStats(){const box=$('#stats');box.textContent='';config.stats.for
   num.appendChild(document.createTextNode(_counts[k]!=null?_counts[k]:'0'));s.appendChild(lbl);s.appendChild(num);box.appendChild(s);});window.lucide&&lucide.createIcons();}
 function renderActs(){const box=$('#acts');box.textContent='';config.actions.forEach(cmd=>{const m=CAT[cmd]||[cmd,'chevron-right'];
   const b=el('button','act');b.appendChild(ficon(m[1]));b.appendChild(document.createTextNode(m[0]));
-  b.onclick=e=>{if(cmd==='foco'){openPomo(25);return;}ripple(b,e);if(cmd==='cam'){$('#cambtn').click();return;}if(VIEWS[cmd]){switchView(cmd);return;}runCmd(cmd,b,e);};box.appendChild(b);});window.lucide&&lucide.createIcons();}
+  b.onclick=e=>{if(cmd==='foco'){openPomo(25);return;}ripple(b,e);if(cmd==='cam'){$('#cambtn').click();return;}if(cmd==='bak'){window.location='/api/backup?k='+encodeURIComponent(token);toast('Baixando backup cifrado…');return;}if(VIEWS[cmd]){switchView(cmd);return;}runCmd(cmd,b,e);};box.appendChild(b);});window.lucide&&lucide.createIcons();}
 async function loadPanel(){try{const r=await fetch('/api/panel',{headers:H()});if(!r.ok)return;_counts=await r.json();
   renderStats();$('#s-prov').textContent=_counts.provider;$('#s-model').textContent=_counts.model;$('#prov').value=_counts.provider;updateNBadge(_counts.notifs);}catch(e){}}
 async function loadConfig(){try{config=await (await fetch('/api/config',{headers:H()})).json();}catch(e){}renderActs();}
@@ -2517,6 +2517,22 @@ def create_app(config: Config, brain: Brain | None = None):
         return StreamingResponse(gen(), media_type="text/event-stream",
                                  headers={"Cache-Control": "no-cache",
                                           "X-Accel-Buffering": "no"})
+
+    @app.get("/api/backup")
+    async def api_backup(request: Request):
+        # On-demand off-VM pull: a browser download can't set headers, so the
+        # token comes as ?k=. Returns a fresh, SQLCipher-encrypted copy of the DB.
+        tok = request.query_params.get("k", "")
+        if not config.web_token or not hmac.compare_digest(tok, config.web_token):
+            raise HTTPException(status_code=401, detail="unauthorized")
+        from fastapi.responses import FileResponse
+        from datetime import datetime
+        bdir = config.db_path.parent / "backups"
+        bdir.mkdir(exist_ok=True)
+        dest = bdir / f"ev_memory.{datetime.now().strftime('%Y%m%d-%H%M%S')}.db"
+        await asyncio.to_thread(memory.backup, dest)
+        return FileResponse(str(dest), media_type="application/octet-stream",
+                            filename=dest.name)
 
     @app.get("/api/push/key")
     async def push_key(request: Request):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -53,6 +53,16 @@ def _auth():
     return {"Authorization": "Bearer secret"}
 
 
+def test_backup_download(tmp_path):
+    client, _ = _client(tmp_path)
+    # browser downloads can't set headers → token via ?k=
+    r = client.get("/api/backup?k=secret")
+    assert r.status_code == 200
+    assert len(r.content) > 0  # a real DB copy came back
+    assert client.get("/api/backup?k=wrong").status_code == 401
+    assert client.get("/api/backup").status_code == 401
+
+
 def test_index_served(tmp_path):
     client, _ = _client(tmp_path)
     r = client.get("/")


### PR DESCRIPTION
## 🤔 Context

A E.V. virou um **segundo cérebro** — memórias, gastos, hábitos, agência, nudges. Tudo num único banco, numa única VM. Se a VM (ou o disco) morre, era **perder tudo de uma vez**.

O backup **diário local** já existia, mas só saía da VM **1x/semana** (domingos) via Telegram — então até **~6 dias** ficavam em risco. Esta PR fecha esse buraco.

> [!NOTE]
> O arquivo é **cifrado com SQLCipher** (mesma `EV_DB_KEY`), então mandar pro Telegram / baixar pro Mac é seguro: sem a chave, ninguém abre.

## O que mudou
- 📆 **Backup off-VM agora é DIÁRIO** (1x/dia), não semanal.
- 💬 **`/backup`** (Telegram) — envia uma cópia cifrada fresca na hora.
- ⬇️ **`GET /api/backup?k=<token>`** — baixa uma cópia fresca pelo navegador. Funciona **pelo túnel `localhost`** → um clique do Mac.
- ⚡ Ação rápida **Backup** na web dispara o download.

## Restaurar (para referência)
Com a `EV_DB_KEY`, o `.db` baixado abre normalmente — é o banco inteiro. Basta colocá-lo no lugar do `ev_memory.db`.

## Notas
- 163 testes verdes, incluindo `test_backup_download` (200 com token / 401 sem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)