### PR TITLE
feat: edit + delete ANY item straight from E.V.'s brain

### DIFF
--- a/ev/core/memory.py
+++ b/ev/core/memory.py
@@ -1016,6 +1016,21 @@ class Memory:
     def update_watch(self, u, i, url=None, keyword=None):
         return self._update("watches", u, i, {"url": url, "keyword": keyword})
 
+    def update_habit(self, u, i, name):
+        return self._update("habits", u, i, {"name": name})
+
+    def update_place(self, u, i, name):
+        return self._update("places", u, i, {"name": name})
+
+    def update_person(self, u, i, name):
+        return self._update("people", u, i, {"name": name})
+
+    def delete_person_by_id(self, user_id: str, person_id: int) -> bool:
+        cur = self._conn.execute(
+            "DELETE FROM people WHERE id = ? AND user_id = ?", (person_id, user_id))
+        self._conn.commit()
+        return cur.rowcount > 0
+
     def rename_habit(self, u, i, name):
         return self._update("habits", u, i, {"name": name})
 

--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -1805,18 +1805,17 @@ async function loadBrain(){
   brainAlpha=1;
   if(!brainRAF)brainRAF=requestAnimationFrame(brainTick);
 }
-const BRAIN_DEL={mem:'/api/facts/delete',tasks:'/api/tasks/delete',rem:'/api/reminders/delete',links:'/api/links/delete',places:'/api/places/delete',hab:'/api/habits/delete',jou:'/api/journal/delete',mon:'/api/watches/delete'};
 function reloadBrain(){brainLoaded=false;loadBrain();}
 function brainNodeMenu(node,mx,my){const m=$('#brain-menu');m.innerHTML='';
-  const parts=node.id.split(':'),grp=parts[0],rid=parts.slice(1).join(':');
+  const grp=node.group,hasRef=node.ref!==undefined&&node.ref!==null;
   m.appendChild(el('div','bm-t',node.label));
   const ob=el('button','');ob.appendChild(ficon('external-link'));ob.appendChild(document.createTextNode('Abrir'+(node.view?' ('+(VIEW_LABELS[node.view]||node.view)+')':'')));ob.onclick=()=>{m.classList.remove('on');if(node.view)switchView(node.view);};m.appendChild(ob);
-  if(grp==='mem'){const eb=el('button','');eb.appendChild(ficon('pencil'));eb.appendChild(document.createTextNode('Editar'));eb.onclick=async()=>{m.classList.remove('on');
-    const items=(await (await fetch('/api/facts',{headers:H()})).json()).items||[];const f=items.find(x=>String(x.id)===String(rid));if(!f)return;
-    const v=prompt('Editar memória:',f.fact);if(v==null)return;if(v.trim()&&v.trim()!==f.fact){await fetch('/api/facts/update',{method:'POST',headers:H(),body:JSON.stringify({id:f.id,text:v.trim()})});reloadBrain();}};m.appendChild(eb);}
-  if(BRAIN_DEL[grp]){const db=el('button','bm-del');db.appendChild(ficon('trash-2'));db.appendChild(document.createTextNode('Apagar do cérebro'));db.onclick=async()=>{m.classList.remove('on');
+  if(hasRef&&node.editable){const eb=el('button','');eb.appendChild(ficon('pencil'));eb.appendChild(document.createTextNode('Editar'));eb.onclick=async()=>{m.classList.remove('on');
+    const cur=node.full||node.label;const v=prompt('Editar:',cur);if(v==null)return;const t=v.trim();if(!t||t===cur)return;
+    try{await fetch('/api/brain/edit',{method:'POST',headers:H(),body:JSON.stringify({group:grp,ref:node.ref,text:t})});}catch(e){}reloadBrain();loadPanel();};m.appendChild(eb);}
+  if(hasRef){const db=el('button','bm-del');db.appendChild(ficon('trash-2'));db.appendChild(document.createTextNode('Apagar do cérebro'));db.onclick=async()=>{m.classList.remove('on');
     if(!(await confirmDialog('Apagar "'+node.label+'"? Isso remove o item de verdade da E.V.')))return;
-    try{await fetch(BRAIN_DEL[grp],{method:'POST',headers:H(),body:JSON.stringify({id:parseInt(rid)})});}catch(e){}reloadBrain();loadPanel();};m.appendChild(db);}
+    try{await fetch('/api/brain/delete',{method:'POST',headers:H(),body:JSON.stringify({group:grp,ref:node.ref})});}catch(e){}reloadBrain();loadPanel();};m.appendChild(db);}
   const wrap=$('#brain-wrap');m.style.left=Math.max(6,Math.min(mx,wrap.clientWidth-236))+'px';m.style.top=Math.min(my+8,wrap.clientHeight-140)+'px';m.classList.add('on');window.lucide&&lucide.createIcons();}
 function brainStep(){
   const n=brainNodes.length;if(!n)return;
@@ -3246,24 +3245,26 @@ def create_app(config: Config, brain: Brain | None = None):
     @app.get("/api/brain")
     async def brain_graph(request: Request):
         _check(request.headers.get("authorization"))
+        # idfn: the stable identifier used to edit/delete the item (id for most;
+        # name/source/category for the string-keyed tables). editable: shows "Editar".
         groups = [
-            ("mem", "Memórias", "mem", memory.list_facts(owner), lambda r: r["fact"]),
-            ("tasks", "Tarefas", "tasks", memory.open_tasks(owner), lambda r: r["text"]),
-            ("rem", "Lembretes", "rem", memory.open_reminders(owner), lambda r: r["text"]),
-            ("people", "Pessoas", "chat", memory.list_people(owner), lambda r: r["name"]),
-            ("links", "Links", "lnk", memory.list_links(owner), lambda r: r["name"]),
-            ("kb", "Base", "kb", memory.list_sources(owner), lambda r: r["source"]),
-            ("hab", "Hábitos", "hab", memory.list_habits(owner), lambda r: r["name"]),
-            ("jou", "Diário", "jou", memory.recent_journal(owner, 40), lambda r: r["text"]),
-            ("sub", "Assinaturas", "sub", memory.list_recurring(owner), lambda r: r["description"]),
-            ("orc", "Orçamentos", "orc", memory.list_budgets(owner), lambda r: r["category"]),
-            ("mon", "Monitores", "mon", memory.list_watches(owner), lambda r: r["url"]),
-            ("places", "Lugares", "map", memory.list_places(owner), lambda r: r["name"]),
+            ("mem", "Memórias", "mem", memory.list_facts(owner), lambda r: r["fact"], lambda r: r["id"], True),
+            ("tasks", "Tarefas", "tasks", memory.open_tasks(owner), lambda r: r["text"], lambda r: r["id"], True),
+            ("rem", "Lembretes", "rem", memory.open_reminders(owner), lambda r: r["text"], lambda r: r["id"], True),
+            ("people", "Pessoas", "chat", memory.list_people(owner), lambda r: r["name"], lambda r: r["id"], True),
+            ("links", "Links", "lnk", memory.list_links(owner), lambda r: r["name"], lambda r: r["id"], True),
+            ("kb", "Base", "kb", memory.list_sources(owner), lambda r: r["source"], lambda r: r["source"], False),
+            ("hab", "Hábitos", "hab", memory.list_habits(owner), lambda r: r["name"], lambda r: r["id"], True),
+            ("jou", "Diário", "jou", memory.recent_journal(owner, 40), lambda r: r["text"], lambda r: r["id"], True),
+            ("sub", "Assinaturas", "sub", memory.list_recurring(owner), lambda r: r["description"], lambda r: r["id"], True),
+            ("orc", "Orçamentos", "orc", memory.list_budgets(owner), lambda r: r["category"], lambda r: r["category"], False),
+            ("mon", "Monitores", "mon", memory.list_watches(owner), lambda r: r["url"], lambda r: r["id"], True),
+            ("places", "Lugares", "map", memory.list_places(owner), lambda r: r["name"], lambda r: r["id"], True),
         ]
         nodes = [{"id": "core", "label": "E.V.", "group": "core", "val": 22, "view": "chat"}]
         edges = []
         CAP = 40
-        for key, label, view, items, textfn in groups:
+        for key, label, view, items, textfn, idfn, editable in groups:
             if not items:
                 continue
             hub = f"g:{key}"
@@ -3273,7 +3274,8 @@ def create_app(config: Config, brain: Brain | None = None):
                 nid = f"{key}:{item.get('id', i)}"
                 txt = (textfn(item) or "").strip().replace("\n", " ")
                 nodes.append({
-                    "id": nid, "label": (txt[:60] or "—"), "group": key, "val": 4, "view": view,
+                    "id": nid, "label": (txt[:60] or "—"), "group": key, "val": 4,
+                    "view": view, "ref": idfn(item), "full": txt[:400], "editable": editable,
                 })
                 edges.append({"source": hub, "target": nid})
             extra = len(items) - CAP
@@ -3283,6 +3285,72 @@ def create_app(config: Config, brain: Brain | None = None):
                               "val": 5, "view": view})
                 edges.append({"source": hub, "target": more_id})
         return {"nodes": nodes, "links": edges}
+
+    def _brain_delete(group: str, ref) -> bool:
+        """Delete an item of any brain group by its ref (id, or name/source/category)."""
+        if group == "rem":
+            return memory.cancel_reminder(owner, int(ref)) or True
+        if group == "kb":
+            return memory.delete_source(owner, str(ref)) > 0
+        if group == "orc":
+            return memory.delete_budget(owner, str(ref))
+        if group == "hab":
+            return memory.delete_habit(owner, int(ref))          # cascades habit_logs
+        if group == "people":
+            return memory.delete_person_by_id(owner, int(ref))
+        byid = {"mem": memory.delete_fact, "tasks": memory.delete_task,
+                "links": memory.delete_link, "jou": memory.delete_journal,
+                "sub": memory.delete_recurring, "mon": memory.delete_watch,
+                "places": memory.delete_place}.get(group)
+        if byid:
+            return byid(owner, int(ref))
+        raise HTTPException(status_code=400, detail="unknown group")
+
+    def _brain_edit(group: str, ref, text: str) -> bool:
+        text = (text or "").strip()
+        if not text:
+            return False
+        editors = {
+            "mem": lambda: memory.update_fact(owner, int(ref), text),
+            "tasks": lambda: memory.update_task(owner, int(ref), text=text),
+            "rem": lambda: memory.update_reminder(owner, int(ref), text=text),
+            "links": lambda: memory.update_link(owner, int(ref), name=text),
+            "jou": lambda: memory.update_journal(owner, int(ref), text),
+            "sub": lambda: memory.update_recurring(owner, int(ref), description=text),
+            "mon": lambda: memory.update_watch(owner, int(ref), url=text),
+            "hab": lambda: memory.update_habit(owner, int(ref), text),
+            "people": lambda: memory.update_person(owner, int(ref), text),
+            "places": lambda: memory.update_place(owner, int(ref), text),
+        }.get(group)
+        if not editors:
+            raise HTTPException(status_code=400, detail="group not editable")
+        return editors()
+
+    @app.post("/api/brain/delete")
+    async def brain_delete(request: Request):
+        _check(request.headers.get("authorization"))
+        d = await _body(request)
+        ref = d.get("ref")
+        if ref is None:
+            raise HTTPException(status_code=400, detail="no ref")
+        try:
+            _brain_delete(d.get("group", ""), ref)
+        except (ValueError, TypeError):
+            raise HTTPException(status_code=400, detail="bad ref")
+        return {"ok": True}
+
+    @app.post("/api/brain/edit")
+    async def brain_edit(request: Request):
+        _check(request.headers.get("authorization"))
+        d = await _body(request)
+        ref = d.get("ref")
+        if ref is None:
+            raise HTTPException(status_code=400, detail="no ref")
+        try:
+            ok = _brain_edit(d.get("group", ""), ref, d.get("text", ""))
+        except (ValueError, TypeError):
+            raise HTTPException(status_code=400, detail="bad ref")
+        return {"ok": bool(ok)}
 
     @app.post("/api/tts")
     async def tts(request: Request):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -53,6 +53,30 @@ def _auth():
     return {"Authorization": "Bearer secret"}
 
 
+def test_brain_edit_and_delete(tmp_path):
+    client, _ = _client(tmp_path)
+    # create a task, then edit + delete it straight from the brain
+    client.post("/api/cmd", json={"command": "tarefa comprar pão"}, headers=_auth())
+    nodes = client.get("/api/brain", headers=_auth()).json()["nodes"]
+    task = next(n for n in nodes if n.get("group") == "tasks" and "ref" in n)
+    assert task["editable"] is True
+    r = client.post("/api/brain/edit",
+                    json={"group": "tasks", "ref": task["ref"], "text": "comprar leite"},
+                    headers=_auth())
+    assert r.json()["ok"] is True
+    labels = [n["label"] for n in client.get("/api/brain", headers=_auth()).json()["nodes"]]
+    assert any("comprar leite" in l for l in labels)
+    assert client.post("/api/brain/delete",
+                       json={"group": "tasks", "ref": task["ref"]}, headers=_auth()).json()["ok"]
+    groups = {n.get("group") for n in client.get("/api/brain", headers=_auth()).json()["nodes"]}
+    assert "tasks" not in groups  # the only task is gone
+    # guards
+    assert client.post("/api/brain/delete", json={"group": "tasks"}, headers=_auth()).status_code == 400
+    assert client.post("/api/brain/delete", json={"group": "nope", "ref": 1},
+                       headers=_auth()).status_code == 400
+    assert client.post("/api/brain/edit").status_code == 401
+
+
 def test_face_enroll_and_clear(tmp_path):
     client, _ = _client(tmp_path)
     assert client.get("/api/face").status_code == 401  # needs auth


### PR DESCRIPTION
## 🤔 Context

Você quis usar o **cérebro** como o painel central pra gerenciar tudo — e faz todo sentido. Antes, no grafo do cérebro o **apagar** cobria só 8 de 12 grupos e o **editar** funcionava **só pra memórias**. Agora **cada nó** pode ser **editado e apagado no lugar** — o cérebro vira o **controle único** de todos os dados da E.V.

## O que mudou
- `/api/brain` passou a mandar por nó: um **`ref` estável** (id — ou nome/fonte/categoria nas tabelas por texto), o **texto completo** e um flag **`editable`**.
- Dois endpoints **genéricos** — `POST /api/brain/delete` e `/api/brain/edit` — despacham por grupo pros métodos que já existiam (sem endpoint novo por tipo).

| Ação | Cobertura |
|------|-----------|
| 🗑️ **Apagar** | **todos os 12 grupos** (novos: pessoas, base, assinaturas, orçamentos) |
| ✏️ **Editar** | **10 grupos** (novos: tarefas, lembretes, links, pessoas, hábitos, diário, assinaturas, monitores, lugares) |
| delete-only | base (docs ingeridos) e orçamentos (por design — chave é categoria+valor) |

Clicar num nó → **Abrir · Editar · Apagar**. O Editar já vem **pré-preenchido com o texto completo**.

## Notas
- 166 testes verdes, incluindo `test_brain_edit_and_delete` (cria → edita → apaga uma tarefa pelo cérebro + guardas 400/401).
- Reaproveita os métodos de `memory` já existentes; só somei `update_habit/place/person` + `delete_person_by_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)