### PR TITLE
feat: automations engine — quando X, faça Y

### DIFF
--- a/ev/core/automations.py
+++ b/ev/core/automations.py
@@ -1,0 +1,63 @@
+"""Deterministic automations engine — "quando X, faça Y".
+
+Pure trigger predicates (no I/O, no LLM) so they're cheap and unit-testable.
+The scheduler (telegram_bot) resolves data + performs the side effects; this
+module only decides *whether* a trigger fires and describes automations.
+"""
+from __future__ import annotations
+
+TRIGGERS = ("time", "expense_over", "task_overdue")
+ACTIONS = ("notify", "command", "reschedule")
+
+_WD_PT = ["segunda", "terça", "quarta", "quinta", "sexta", "sábado", "domingo"]
+
+
+def time_due(cfg: dict, now, last_fired: str | None) -> bool:
+    """True when a time trigger should fire: right weekday (or daily), at/after
+    the target HH:MM, and not already fired today. Robust to a coarse (per-minute)
+    scheduler — fires on the first tick at or after the target time."""
+    wd = cfg.get("weekday", -1)
+    if wd not in (-1, now.weekday()):
+        return False
+    tgt = (int(cfg.get("hour", 0)), int(cfg.get("minute", 0)))
+    if (now.hour, now.minute) < tgt:
+        return False
+    return last_fired != now.date().isoformat()
+
+
+def expense_matches(cfg: dict, expense: dict) -> bool:
+    """True when an expense meets/exceeds the threshold (and category, if set)."""
+    if float(expense.get("amount") or 0) < float(cfg.get("amount", 0)):
+        return False
+    cat = (cfg.get("category") or "").strip().lower()
+    if cat and (expense.get("category") or "").strip().lower() != cat:
+        return False
+    return True
+
+
+def describe(auto: dict) -> str:
+    """Human-readable one-liner for listings."""
+    t, c = auto.get("trig"), auto.get("trig_cfg") or {}
+    a, ac = auto.get("act"), auto.get("act_cfg") or {}
+    if t == "time":
+        wd = c.get("weekday", -1)
+        when = "todo dia" if wd == -1 else f"toda {_WD_PT[wd]}"
+        quando = f"{when} às {int(c.get('hour', 0)):02d}:{int(c.get('minute', 0)):02d}"
+    elif t == "expense_over":
+        cat = c.get("category")
+        quando = f"quando gastar mais de R$ {float(c.get('amount', 0)):.0f}" + (
+            f" em '{cat}'" if cat else "")
+    elif t == "task_overdue":
+        quando = "quando uma tarefa vencer"
+    else:
+        quando = t or "?"
+    if a == "notify":
+        faca = f"me avisar: \"{ac.get('message', '')}\""
+    elif a == "command":
+        faca = f"rodar /{ac.get('command', '')}"
+    elif a == "reschedule":
+        faca = "remarcar pro dia seguinte"
+    else:
+        faca = a or "?"
+    status = "" if auto.get("enabled", True) else " (pausada)"
+    return f"#{auto.get('id', '?')} — {quando} → {faca}{status}"

--- a/ev/core/brain.py
+++ b/ev/core/brain.py
@@ -737,6 +737,36 @@ class Brain:
             self._memory.add_place(user_id, nome, lat, lng)
             return f"ponto '{nome}' salvo no seu mapa."
 
+        def criar_automacao(gatilho: str, acao: str, hora: int = -1, minuto: int = 0,
+                            dia_semana: int = -1, valor: float = 0.0, categoria: str = "",
+                            mensagem: str = "", comando: str = "") -> str:
+            """Cria uma automação 'quando X, faça Y' que roda sozinha depois.
+
+            Args:
+                gatilho: 'time' (horário recorrente), 'expense_over' (gasto acima de
+                    um valor) ou 'task_overdue' (quando uma tarefa vencer).
+                acao: 'notify' (avisar com uma mensagem), 'command' (rodar um comando
+                    da E.V.) ou 'reschedule' (remarcar tarefas vencidas; só com task_overdue).
+                hora: para 'time', hora 0-23.
+                minuto: para 'time', minuto 0-59.
+                dia_semana: para 'time', 0=segunda..6=domingo, ou -1 para todo dia.
+                valor: para 'expense_over', o limite em reais.
+                categoria: para 'expense_over', categoria opcional (ex 'comida').
+                mensagem: para 'notify', o texto do aviso.
+                comando: para 'command', o comando a rodar (ex 'semana', 'relatorio').
+
+            Ex: 'toda sexta 18h me manda o resumo' -> gatilho='time', hora=18,
+            dia_semana=4, acao='command', comando='semana'. 'quando eu gastar mais de
+            200 me avisa' -> gatilho='expense_over', valor=200, acao='notify',
+            mensagem='Gasto acima de 200!'.
+            """
+            aid, msg = self._commands.create_automation(
+                user_id, gatilho, acao,
+                hour=(None if hora < 0 else hora), minute=minuto, weekday=dia_semana,
+                amount=(None if valor <= 0 else valor), category=(categoria or None),
+                message=(mensagem or None), command=(comando or None))
+            return ("automação criada: " + msg) if aid else ("não consegui criar: " + msg)
+
         def planejar_dia() -> str:
             """Monta um plano acionável para o dia do usuário, juntando as tarefas
             abertas, os lembretes, a agenda, o clima e a localização atual, e
@@ -747,6 +777,7 @@ class Brain:
         callables: dict = {
             "executar_comando": executar_comando,
             "planejar_dia": planejar_dia,
+            "criar_automacao": criar_automacao,
             "anotar_pessoa": anotar_pessoa,
             "sobre_pessoa": sobre_pessoa,
             "minha_localizacao": minha_localizacao,
@@ -837,6 +868,25 @@ class Brain:
                 "Monta um plano acionável do dia do usuário juntando tarefas, "
                 "lembretes, agenda, clima e localização. Use para 'resolve minha "
                 "manhã', 'plano do dia', 'organiza meu dia', 'o que faço hoje'.",
+            ),
+            fn(
+                "criar_automacao",
+                "Cria uma automação 'quando X, faça Y' que roda sozinha. gatilho: "
+                "'time'|'expense_over'|'task_overdue'. acao: 'notify'|'command'|"
+                "'reschedule'. Use para 'toda sexta 18h me manda o resumo', 'quando "
+                "eu gastar mais de 200 me avisa', 'se uma tarefa vencer, remarca'.",
+                {
+                    "gatilho": {"type": s, "description": "time|expense_over|task_overdue"},
+                    "acao": {"type": s, "description": "notify|command|reschedule"},
+                    "hora": {"type": "integer", "description": "para time: 0-23"},
+                    "minuto": {"type": "integer", "description": "para time: 0-59"},
+                    "dia_semana": {"type": "integer", "description": "0=seg..6=dom, -1=todo dia"},
+                    "valor": {"type": "number", "description": "para expense_over: limite em R$"},
+                    "categoria": {"type": s, "description": "para expense_over: categoria opcional"},
+                    "mensagem": {"type": s, "description": "para notify: texto do aviso"},
+                    "comando": {"type": s, "description": "para command: ex 'semana'"},
+                },
+                ["gatilho", "acao"],
             ),
             fn(
                 "executar_comando",

--- a/ev/core/commands.py
+++ b/ev/core/commands.py
@@ -30,6 +30,8 @@ COMMAND_LIST = [
     ("pendencias", "O que está atrasado/vencendo — a E.V. te cobra"),
     ("backup", "Envia agora um backup cifrado do banco (fora da VM)"),
     ("padroes", "O que a E.V. aprendeu sobre seus padrões"),
+    ("automacoes", "Suas automações 'quando X, faça Y'"),
+    ("automacaorm", "Apaga uma automação: /automacaorm <id>"),
     ("ajuda", "Lista os comandos disponíveis"),
     ("status", "Diagnóstico: VM, banco, chaves de API"),
     ("silenciar", "Não perturbe: /silenciar 2h (ou off)"),
@@ -1157,6 +1159,67 @@ class Commands:
             return "🧠 Comecei a notar:\n" + "\n".join(
                 "- " + p["text"] for p in fresh[:8])
         return "Ainda estou te conhecendo — em alguns dias começo a notar seus padrões. 🌱"
+
+    # --- automations ("quando X, faça Y") ----------------------------------
+
+    def automacoes(self, user_id: str) -> str:
+        from .automations import describe
+        items = self._memory.list_automations(user_id)
+        if not items:
+            return ("Nenhuma automação ainda. Me diga algo como 'quando eu gastar "
+                    "mais de 200, me avisa' ou 'toda sexta 18h, me manda o resumo'.")
+        return ("🤖 Suas automações:\n" + "\n".join(describe(a) for a in items)
+                + "\n\nApagar: /automacaorm <id>")
+
+    def automacao_rm(self, user_id: str, arg: str) -> str:
+        try:
+            aid = int(str(arg).strip())
+        except (ValueError, TypeError):
+            return "Uso: /automacaorm <id> (veja os ids em /automacoes)."
+        if self._memory.delete_automation(user_id, aid):
+            return f"Automação #{aid} removida."
+        return "Não achei essa automação."
+
+    def create_automation(self, user_id: str, trigger: str, action: str, *,
+                          hour=None, minute=0, weekday=-1, amount=None,
+                          category=None, message=None, command=None):
+        """Deterministic constructor used by the AI tool + web form. Validates,
+        seeds trigger state (e.g. current max expense id, so it never fires on
+        past data). Returns (id_or_None, human_message)."""
+        from .automations import TRIGGERS, ACTIONS, describe
+        if trigger not in TRIGGERS:
+            return None, f"gatilho inválido ({trigger})"
+        if action not in ACTIONS:
+            return None, f"ação inválida ({action})"
+        trig_cfg, state = {}, {}
+        if trigger == "time":
+            if hour is None:
+                return None, "faltou a hora do gatilho"
+            trig_cfg = {"hour": int(hour), "minute": int(minute or 0),
+                        "weekday": int(weekday if weekday is not None else -1)}
+        elif trigger == "expense_over":
+            if amount is None:
+                return None, "faltou o valor do gatilho"
+            trig_cfg = {"amount": float(amount)}
+            if category:
+                trig_cfg["category"] = category
+            state = {"last_id": self._memory.max_expense_id(user_id)}
+        act_cfg = {}
+        if action == "notify":
+            act_cfg = {"message": message or "lembrete da automação"}
+        elif action == "command":
+            if not command:
+                return None, "faltou o comando a rodar"
+            act_cfg = {"command": command.lstrip("/")}
+        elif action == "reschedule":
+            if trigger != "task_overdue":
+                return None, "‘remarcar’ só funciona com o gatilho de tarefa vencida"
+        name = (message or (f"/{command}" if command else action))[:80]
+        aid = self._memory.add_automation(
+            user_id, name, trigger, trig_cfg, action, act_cfg, state)
+        a = {"id": aid, "trig": trigger, "trig_cfg": trig_cfg, "act": action,
+             "act_cfg": act_cfg, "enabled": True}
+        return aid, describe(a)
 
     # --- links (named, categorized) ----------------------------------------
 

--- a/ev/core/memory.py
+++ b/ev/core/memory.py
@@ -271,6 +271,19 @@ class Memory:
                 created  TEXT NOT NULL,
                 UNIQUE(user_id, key)
             );
+
+            CREATE TABLE IF NOT EXISTS automations (
+                id       INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id  TEXT NOT NULL,
+                name     TEXT NOT NULL,
+                trig     TEXT NOT NULL,
+                trig_cfg TEXT NOT NULL,
+                act      TEXT NOT NULL,
+                act_cfg  TEXT NOT NULL,
+                enabled  INTEGER NOT NULL DEFAULT 1,
+                state    TEXT NOT NULL DEFAULT '{}',
+                created  TEXT NOT NULL
+            );
             """
         )
         # Migrations for older DBs.
@@ -393,6 +406,68 @@ class Memory:
             (user_id, limit),
         ).fetchall()
         return [dict(r) for r in rows]
+
+    # --- automations ("quando X, faça Y") ----------------------------------
+
+    def add_automation(self, user_id: str, name: str, trig: str, trig_cfg: dict,
+                       act: str, act_cfg: dict, state: dict | None = None) -> int:
+        cur = self._conn.execute(
+            "INSERT INTO automations "
+            "(user_id, name, trig, trig_cfg, act, act_cfg, enabled, state, created) "
+            "VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?)",
+            (user_id, name, trig, json.dumps(trig_cfg), act, json.dumps(act_cfg),
+             json.dumps(state or {}), self._now()),
+        )
+        self._conn.commit()
+        return int(cur.lastrowid)
+
+    def _auto_row(self, r) -> dict:
+        d = dict(r)
+        for k in ("trig_cfg", "act_cfg", "state"):
+            try:
+                d[k] = json.loads(d.get(k) or "{}")
+            except (ValueError, TypeError):
+                d[k] = {}
+        d["enabled"] = bool(d.get("enabled"))
+        return d
+
+    def list_automations(self, user_id: str, only_enabled: bool = False) -> list[dict]:
+        q = ("SELECT id, name, trig, trig_cfg, act, act_cfg, enabled, state, created "
+             "FROM automations WHERE user_id = ?")
+        if only_enabled:
+            q += " AND enabled = 1"
+        rows = self._conn.execute(q + " ORDER BY id", (user_id,)).fetchall()
+        return [self._auto_row(r) for r in rows]
+
+    def delete_automation(self, user_id: str, auto_id: int) -> bool:
+        cur = self._conn.execute(
+            "DELETE FROM automations WHERE id = ? AND user_id = ?", (auto_id, user_id))
+        self._conn.commit()
+        return cur.rowcount > 0
+
+    def set_automation_enabled(self, user_id: str, auto_id: int, on: bool) -> bool:
+        cur = self._conn.execute(
+            "UPDATE automations SET enabled = ? WHERE id = ? AND user_id = ?",
+            (1 if on else 0, auto_id, user_id))
+        self._conn.commit()
+        return cur.rowcount > 0
+
+    def set_automation_state(self, auto_id: int, state: dict) -> None:
+        self._conn.execute("UPDATE automations SET state = ? WHERE id = ?",
+                           (json.dumps(state), auto_id))
+        self._conn.commit()
+
+    def expenses_after_id(self, user_id: str, after_id: int) -> list[dict]:
+        rows = self._conn.execute(
+            "SELECT id, amount, description, category, created FROM expenses "
+            "WHERE user_id = ? AND id > ? ORDER BY id", (user_id, after_id)).fetchall()
+        return [dict(r) for r in rows]
+
+    def max_expense_id(self, user_id: str) -> int:
+        row = self._conn.execute(
+            "SELECT COALESCE(MAX(id), 0) AS m FROM expenses WHERE user_id = ?",
+            (user_id,)).fetchone()
+        return int(row["m"]) if row else 0
 
     def list_notifications(self, user_id: str, limit: int = 100) -> list[dict]:
         rows = self._conn.execute(

--- a/ev/interfaces/telegram_bot.py
+++ b/ev/interfaces/telegram_bot.py
@@ -2051,6 +2051,7 @@ class TelegramInterface:
                     await self._maybe_habit_nudge(app)
                     await self._maybe_nudge(app)
                     await self._maybe_insight(app)
+                    await self._maybe_run_automations(app)
                     await self._maybe_monthly_report(app)
             except Exception:
                 log.exception("Briefing loop error")
@@ -2254,6 +2255,87 @@ class TelegramInterface:
             return
         await self._cmd_out(update, self._commands.learned_text(
             str(update.effective_user.id)))
+
+    async def _maybe_run_automations(self, app: Application) -> None:
+        """Evaluate the user's automations ('quando X, faça Y') and run those that
+        fire. Deterministic triggers (no LLM) → cheap and reliable."""
+        cfg = self._config
+        if cfg.owner_id is None:
+            return
+        from ..core import automations as au
+        now = datetime.now(self._tz())
+        owner = str(cfg.owner_id)
+        for a in self._memory.list_automations(owner, only_enabled=True):
+            try:
+                state = a["state"]
+                fired, extra = False, None
+                if a["trig"] == "time":
+                    if au.time_due(a["trig_cfg"], now, state.get("last")):
+                        fired = True
+                        state["last"] = now.date().isoformat()
+                elif a["trig"] == "expense_over":
+                    new = self._memory.expenses_after_id(owner, int(state.get("last_id", 0)))
+                    if new:
+                        state["last_id"] = new[-1]["id"]
+                        extra = next((e for e in new if au.expense_matches(a["trig_cfg"], e)), None)
+                        fired = extra is not None
+                elif a["trig"] == "task_overdue":
+                    loops = self._commands.open_loops(owner)
+                    if loops["overdue"] and state.get("last") != now.date().isoformat():
+                        fired, extra = True, loops["overdue"]
+                        state["last"] = now.date().isoformat()
+                if fired:
+                    await self._run_automation_action(app, a, extra)
+                self._memory.set_automation_state(a["id"], state)
+            except Exception:
+                log.exception("automation %s failed", a.get("id"))
+
+    async def _run_automation_action(self, app: Application, a: dict, extra) -> None:
+        cfg = self._config
+        owner = str(cfg.owner_id)
+        act, ac = a["act"], a["act_cfg"]
+        if act == "notify":
+            msg = "🤖 " + (ac.get("message") or a["name"])
+            if a["trig"] == "expense_over" and isinstance(extra, dict):
+                msg += f"\n(R$ {float(extra.get('amount', 0)):.2f} em {extra.get('description', '')})"
+        elif act == "command":
+            name = (ac.get("command") or "").lstrip("/").split()[0] if ac.get("command") else ""
+            out = self._commands.run(owner, name, "") if name in self._commands.runnable() else None
+            msg = "🤖 " + a["name"] + (("\n\n" + out) if out else "")
+        elif act == "reschedule":
+            from datetime import timedelta
+            today = datetime.now(self._tz()).date().isoformat()
+            tomorrow = (datetime.now(self._tz()).date() + timedelta(days=1)).isoformat()
+            n = 0
+            for t in self._memory.open_tasks(owner):
+                due = t.get("due")
+                if due and due[:10] < today:
+                    self._memory.update_task(owner, t["id"], due=tomorrow)
+                    n += 1
+            msg = f"🤖 {a['name']}: remarquei {n} tarefa(s) atrasada(s) pra amanhã."
+        else:
+            return
+        await self._bot_send(app.bot, cfg.owner_id, msg, self._quick_kb())
+        try:
+            from ..providers import push
+            await asyncio.to_thread(push.send_push, cfg, self._memory,
+                                    "🤖 Automação", msg[:200], "/", owner)
+        except Exception:
+            pass
+        log.info("Ran automation #%s (%s → %s).", a.get("id"), a["trig"], act)
+
+    async def cmd_automacoes(self, update: Update, _c: ContextTypes.DEFAULT_TYPE) -> None:
+        """List the user's automations."""
+        if not self._authorized(update):
+            return
+        await self._cmd_out(update, self._commands.automacoes(str(update.effective_user.id)))
+
+    async def cmd_automacaorm(self, update: Update, c: ContextTypes.DEFAULT_TYPE) -> None:
+        """Delete an automation by id: /automacaorm 3."""
+        if not self._authorized(update):
+            return
+        await self._cmd_out(update, self._commands.automacao_rm(
+            str(update.effective_user.id), self._args(c).strip()))
 
     async def _maybe_monthly_report(self, app: Application) -> None:
         cfg = self._config
@@ -2479,6 +2561,8 @@ class TelegramInterface:
         app.add_handler(CommandHandler("pendencias", self.cmd_pendencias))
         app.add_handler(CommandHandler("backup", self.cmd_backup))
         app.add_handler(CommandHandler("padroes", self.cmd_padroes))
+        app.add_handler(CommandHandler("automacoes", self.cmd_automacoes))
+        app.add_handler(CommandHandler("automacaorm", self.cmd_automacaorm))
         app.add_handler(CallbackQueryHandler(self.on_callback))
         # Deterministic commands (no LLM)
         app.add_handler(CommandHandler("ajuda", self.cmd_ajuda))

--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -1026,7 +1026,7 @@ f.onsubmit=e=>{e.preventDefault();if(slash.style.display==='block'&&slSel>=0){pi
   txt.value='';hideSlash();if(!m)return;
   if(m.startsWith('/'))runCmd(m.slice(1));else send(m);};
 
-const CAT={plano:['Plano do dia','sunrise'],pendencias:['Pendências','bell-ring'],padroes:['Padrões','sparkles'],bak:['Backup','database-backup'],tarefas:['Tarefas','list-checks'],lembretes:['Lembretes','alarm-clock'],gastos:['Gastos','wallet'],memorias:['Memórias','brain'],kb:['Base','book-open'],map:['Mapa','map'],graf:['Gráficos','bar-chart-3'],brain:['Cérebro','brain-circuit'],cam:['Câmera','camera'],buscar:['Buscar web','search'],noticias:['Notícias','newspaper'],clima:['Clima','cloud-sun'],relatorio:['Relatório','bar-chart-3'],status:['Status','activity'],semana:['Semana','calendar-days'],foco:['Pomodoro','timer'],procurar:['Procurar','file-search'],calendario:['Agenda','calendar'],habitos:['Hábitos','repeat'],diario:['Diário','notebook-pen'],orcamentos:['Orçamentos','piggy-bank'],assinaturas:['Assinaturas','credit-card'],dados:['Meus dados','database'],insights:['Insights','sparkles'],quiz:['Quiz','graduation-cap']};
+const CAT={plano:['Plano do dia','sunrise'],pendencias:['Pendências','bell-ring'],padroes:['Padrões','sparkles'],automacoes:['Automações','zap'],bak:['Backup','database-backup'],tarefas:['Tarefas','list-checks'],lembretes:['Lembretes','alarm-clock'],gastos:['Gastos','wallet'],memorias:['Memórias','brain'],kb:['Base','book-open'],map:['Mapa','map'],graf:['Gráficos','bar-chart-3'],brain:['Cérebro','brain-circuit'],cam:['Câmera','camera'],buscar:['Buscar web','search'],noticias:['Notícias','newspaper'],clima:['Clima','cloud-sun'],relatorio:['Relatório','bar-chart-3'],status:['Status','activity'],semana:['Semana','calendar-days'],foco:['Pomodoro','timer'],procurar:['Procurar','file-search'],calendario:['Agenda','calendar'],habitos:['Hábitos','repeat'],diario:['Diário','notebook-pen'],orcamentos:['Orçamentos','piggy-bank'],assinaturas:['Assinaturas','credit-card'],dados:['Meus dados','database'],insights:['Insights','sparkles'],quiz:['Quiz','graduation-cap']};
 const SM={tasks:['Tarefas','list-checks','tarefas'],reminders:['Lembretes','alarm-clock','lembretes'],expenses:['Gastos · mês','wallet','gastos'],memories:['Memórias','brain','memorias'],kb:['Base','book-open','kb'],kbfiles:['Arquivos','file-text','kb'],links:['Links','link','links'],habits:['Hábitos','repeat','habitos'],journal:['Diário','notebook-pen','diario'],subscriptions:['Assinaturas','credit-card','assinaturas'],budgets:['Orçamentos','piggy-bank','orcamentos'],watches:['Monitores','radar','monitores'],agenda:['Agenda · 7d','calendar','calendario'],activity:['Histórico · 24h','history','status'],provider:['Provedor','cpu','status'],model:['Modelo','box','modelo'],disk:['Disco','hard-drive','status'],ram:['RAM','memory-stick','status'],uptime:['Uptime','clock','status']};
 const RECUR=[{v:'',l:'Uma vez'},{v:'daily',l:'Diário'},{v:'weekly',l:'Semanal'},{v:'monthly',l:'Mensal'}];
 const RECUR_LBL={daily:'repete diário',weekly:'repete semanal',monthly:'repete mensal'};
@@ -2206,6 +2206,10 @@ def create_app(config: Config, brain: Brain | None = None):
             return commands.nudge_text(owner) or "Tudo em dia, Ryan — nada atrasado. 👌"
         if name in ("padroes", "padrões", "aprendi"):  # continuous learning view
             return commands.learned_text(owner)
+        if name in ("automacoes", "automações", "automacao", "automação"):
+            return commands.automacoes(owner)
+        if name == "automacaorm":
+            return commands.automacao_rm(owner, rest)
         if name in commands.runnable():
             return commands.run(owner, name, rest)
         if name == "provedor":

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -1,0 +1,37 @@
+"""Tests for the deterministic automations engine (pure predicates)."""
+
+from datetime import datetime, timezone
+
+from ev.core import automations as au
+
+
+def test_time_due():
+    now = datetime(2026, 8, 7, 18, 5, tzinfo=timezone.utc)  # a Friday
+    daily = {"hour": 18, "minute": 0, "weekday": -1}
+    assert au.time_due(daily, now, None) is True            # daily, at/after 18:00
+    assert au.time_due(daily, now, "2026-08-07") is False   # already fired today
+    assert au.time_due({"hour": 19, "minute": 0, "weekday": -1}, now, None) is False  # too early
+    wd = now.weekday()
+    assert au.time_due({"hour": 0, "minute": 0, "weekday": wd}, now, None) is True
+    assert au.time_due({"hour": 0, "minute": 0, "weekday": (wd + 1) % 7}, now, None) is False
+
+
+def test_expense_matches():
+    assert au.expense_matches({"amount": 200}, {"amount": 250}) is True
+    assert au.expense_matches({"amount": 200}, {"amount": 150}) is False
+    assert au.expense_matches({"amount": 100, "category": "comida"},
+                              {"amount": 150, "category": "lazer"}) is False
+    # category match is case-insensitive
+    assert au.expense_matches({"amount": 100, "category": "comida"},
+                              {"amount": 150, "category": "Comida"}) is True
+
+
+def test_describe():
+    a = {"id": 1, "trig": "expense_over", "trig_cfg": {"amount": 200},
+         "act": "notify", "act_cfg": {"message": "alto"}, "enabled": True}
+    d = au.describe(a)
+    assert "200" in d and "avisar" in d
+    t = {"id": 2, "trig": "time", "trig_cfg": {"hour": 18, "minute": 0, "weekday": 4},
+         "act": "command", "act_cfg": {"command": "semana"}, "enabled": False}
+    dt = au.describe(t)
+    assert "sexta" in dt and "18:00" in dt and "semana" in dt and "pausada" in dt

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -42,6 +42,25 @@ def test_open_loops_and_nudge(tmp_path):
     assert c.nudge_text("v", now=now) == ""
 
 
+def test_automations_crud(tmp_path):
+    c = _commands(tmp_path)
+    aid, msg = c.create_automation("u", "expense_over", "notify", amount=200,
+                                   message="Gasto alto")
+    assert aid and "200" in msg
+    listing = c.automacoes("u")
+    assert "200" in listing and "avisar" in listing
+    # a time+command automation
+    aid2, _ = c.create_automation("u", "time", "command", hour=18, weekday=4,
+                                  command="semana")
+    assert aid2 and "sexta" in c.automacoes("u")
+    # validation: bad trigger / missing field
+    assert c.create_automation("u", "bogus", "notify")[0] is None
+    assert c.create_automation("u", "expense_over", "notify")[0] is None  # no amount
+    # remove
+    assert "removida" in c.automacao_rm("u", str(aid))
+    assert c.automacao_rm("u", "999") == "Não achei essa automação."
+
+
 def test_learned_patterns_and_persistence(tmp_path):
     from datetime import datetime, timezone, timedelta
     c = _commands(tmp_path)


### PR DESCRIPTION
## 🤔 Context

Até aqui a E.V. **observava, cobrava e aprendia** — mas não **agia sozinha**. Esta PR é o salto de autonomia: um **motor de automações**. Você descreve regras em linguagem natural e ela **executa por conta própria, pra sempre**.

- *"toda sexta 18h, me manda o resumo da semana"*
- *"quando eu gastar mais de 200, me avisa"*
- *"se uma tarefa vencer, remarca pro dia seguinte"*

## Gatilhos × Ações
| Gatilho | Dispara quando | Ações |
|--------|-----------------|-------|
| `time` | HH:MM, diário ou num dia da semana | notify · command |
| `expense_over` | novo gasto acima do limite (categoria opcional) | notify · command |
| `task_overdue` | uma tarefa passa do prazo | notify · reschedule |

> [!NOTE]
> Avaliação **determinística (sem LLM)** → não gasta cota. O Gemini só entra **uma vez, na criação** (parseia a frase → parâmetros). O estado é semeado (id do último gasto) pra **nunca disparar em dados antigos**.

## Como usar
- **Criar:** falar no chat/voz — *"quando eu gastar mais de 200 me avisa"*.
- **Ver/apagar:** `/automacoes`, `/automacaorm <id>`, ou a ação rápida **Automações**.

## Notas
- 170 testes verdes (novo `test_automations.py` + `test_automations_crud`).
- Roda no loop do agendador (respeita `/silenciar`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)