### PR TITLE
feat: nearby places with map photo + route links

### DIFF
--- a/ev/core/brain.py
+++ b/ev/core/brain.py
@@ -701,11 +701,19 @@ class Brain:
             if not (lat and lng):
                 return ("não sei sua localização ainda. Abra a aba Mapa e toque em "
                         "'Onde estou'.")
-            places = tools_mod.nearby_places(float(lat), float(lng), tipo, limit=6)
+            flat, flng = float(lat), float(lng)
+            places = tools_mod.nearby_places(flat, flng, tipo, limit=6)
             if not places:
                 return f"não achei '{tipo}' por perto agora."
-            lines = [f"- {p['name']} (~{p['dist']} m)" for p in places]
-            return f"{tipo.capitalize()} perto de você:\n" + "\n".join(lines)
+            # A map photo of the area with every result pinned, plus a route link
+            # per place so the user can navigate straight there.
+            img = tools_mod.static_map_url(
+                flat, flng, markers=[(p["lat"], p["lng"]) for p in places], zoom=15)
+            lines = [f"{tipo.capitalize()} perto de você:", f"![mapa]({img})"]
+            for i, p in enumerate(places, 1):
+                dl = tools_mod.directions_link(flat, flng, p["lat"], p["lng"])
+                lines.append(f"{i}. {p['name']} (~{int(p['dist'])} m) — 🧭 Ir: {dl}")
+            return "\n".join(lines)
 
         def meus_locais() -> str:
             """Lista os pontos de interesse que o usuário salvou no mapa da E.V."""

--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -417,6 +417,7 @@ body:not(.term) .msg.ev::after{content:"";position:absolute;top:7px;left:7px;wid
 .msg .mtable th,.msg .mtable td{border:1px solid var(--line);padding:6px 9px;text-align:left;white-space:nowrap}
 .msg .mtable th{background:var(--surface);color:var(--accent);font-family:var(--mono);font-size:10px;letter-spacing:.05em;text-transform:uppercase}
 .msg .mtable tr:nth-child(even) td{background:rgba(53,200,255,.045)}
+.msg .mimg{max-width:100%;border-radius:12px;margin:8px 0;border:1px solid var(--line-2);display:block;box-shadow:0 4px 18px rgba(0,0,0,.35)}
 .mchips{display:flex;flex-wrap:wrap;gap:7px;margin:3px 0 10px}
 .mchip{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:12px;color:var(--fg);background:var(--elev);border:1px solid var(--line);border-radius:999px;padding:6px 12px;cursor:pointer;position:relative;overflow:hidden;transition:background .15s,border-color .15s,color .15s}
 .mchip:hover,.mchip:active{background:var(--fg);color:var(--ink);border-color:var(--fg)}
@@ -910,6 +911,7 @@ function renderTable(box,rows){const t=document.createElement('table');t.classNa
   rows.slice(2).forEach(r=>{const tr=document.createElement('tr');splitRow(r).forEach(c=>{const td=document.createElement('td');appendRich(td,c);tr.appendChild(td);});tb.appendChild(tr);});
   t.appendChild(tb);box.appendChild(t);}
 function renderLine(box,s,st){let m;
+  if((m=s.match(/^!\[[^\]]*\]\((https?:\/\/[^)\s]+)\)$/))){const im=document.createElement('img');im.src=m[1];im.className='mimg';im.loading='lazy';im.alt='mapa';im.onerror=()=>im.remove();box.appendChild(im);st.first=false;return;}
   if(SEPRE.test(s)){box.appendChild(el('div','sep'));return;}
   if(EMOLEAD.test(s)){
     if(st.first){const h=el('span','h');h.appendChild(ficon(iconName(s)));h.appendChild(document.createTextNode(stripEmoji(s)));box.appendChild(h);st.first=false;return;}

--- a/ev/providers/tools.py
+++ b/ev/providers/tools.py
@@ -601,6 +601,26 @@ def maps_search_link(lat, lng, query: str) -> str:
             f"/@{lat},{lng},15z")
 
 
+def static_map_url(center_lat, center_lng, markers=None, zoom: int = 15,
+                   w: int = 600, h: int = 320) -> str:
+    """Free OpenStreetMap static-map image (no API key). `markers` = list of
+    (lat, lng), pinned in red. It's a community service — best-effort, may be
+    slow or occasionally unavailable; the route links work regardless."""
+    import urllib.parse
+    params = [("center", f"{center_lat},{center_lng}"), ("zoom", str(zoom)),
+              ("size", f"{w}x{h}")]
+    for mlat, mlng in (markers or []):
+        params.append(("markers", f"{mlat},{mlng},red-pushpin"))
+    return "https://staticmap.openstreetmap.de/staticmap.php?" + urllib.parse.urlencode(params)
+
+
+def directions_link(from_lat, from_lng, to_lat, to_lng, mode: str = "walking") -> str:
+    """Google Maps directions (route) link from the user's location to a place."""
+    tm = mode if mode in ("walking", "driving", "bicycling", "transit") else "walking"
+    return (f"https://www.google.com/maps/dir/?api=1&origin={from_lat},{from_lng}"
+            f"&destination={to_lat},{to_lng}&travelmode={tm}")
+
+
 def calendar_upcoming(config, account: str, max_results: int = 5) -> str:
     """List the user's upcoming Google Calendar events."""
     from datetime import datetime, timezone

--- a/tests/test_ai_commands.py
+++ b/tests/test_ai_commands.py
@@ -114,6 +114,8 @@ def test_location_tools(tmp_path, monkeypatch):
         {"name": "Drogaria X", "lat": -23.5, "lng": -46.6, "dist": 120, "kind": "pharmacy"}])
     out = fns["locais_proximos"]("farmácia")
     assert "Drogaria X" in out and "120" in out
+    assert "![mapa](" in out and "staticmap.openstreetmap.de" in out  # map photo
+    assert "maps/dir/" in out and "🧭" in out                          # route link
     assert "-23.5" in fns["minha_localizacao"]()
     # saved places surface via meus_locais
     b._memory.add_place("u", "Casa", -23.5, -46.6)


### PR DESCRIPTION
## 🤔 Context

Quando você pergunta "o que tem perto de mim", a E.V. só listava nomes + distância. Agora ela manda também:
- 🗺️ **uma foto do mapa** da região com **todos os resultados fixados** (pin vermelho);
- 🧭 **um link de trajeto por lugar** (rota do Google Maps a partir da sua localização) — pra você **ir direto** até lá.

## Como funciona
- `tools.static_map_url` — imagem estática do **OpenStreetMap** (grátis, sem API key), um pin por resultado.
- `tools.directions_link` — rota do Google Maps: sua posição → lugar.
- `locais_proximos` monta: foto do mapa + `1. Nome (~120 m) — 🧭 Ir: <link>`.
- O chat da web passou a renderizar **imagens inline** (`![]()`), então a foto do mapa aparece na conversa (imagem quebrada se remove sozinha).

> [!NOTE]
> A imagem do mapa usa um serviço **comunitário gratuito** (staticmap.openstreetmap.de) — best-effort, pode ficar lento/fora do ar às vezes; os **links de rota funcionam sempre**. Sem chave paga.

## Notas
- 170 testes verdes (estendi `test_location_tools` pra checar a foto do mapa + o link de rota).
- No Telegram os links de rota funcionam; a imagem aparece melhor na web (interface principal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)