### PR TITLE
feat: E.V. pronounces her name as Eevee (Ivi), not É-Vê

### DIFF
--- a/ev/providers/voice.py
+++ b/ev/providers/voice.py
@@ -24,6 +24,15 @@ def _apply_fixes(text: str, fixes) -> str:
     return text
 
 
+# Her name is written "E.V." but spoken "Eevee" (pt-BR "Ivi") — like the Pokémon,
+# never spelled out "É-Vê". Matches E.V. / E.V / E. V. / EV as a standalone token.
+_NAME_SAY = re.compile(r"\bE\.?\s*V\.?(?=\b|\W|$)", re.IGNORECASE)
+
+
+def say_name(text: str) -> str:
+    return _NAME_SAY.sub("Ivi", text or "")
+
+
 # Emoji / pictographic ranges the TTS would otherwise read out loud.
 _EMOJI = re.compile(
     "[\U0001F000-\U0001FAFF\U00002600-\U000027BF\U0001F1E6-\U0001F1FF"
@@ -82,7 +91,7 @@ async def synthesize(
     fixes=(),
 ) -> bytes:
     """Return MP3 bytes speaking `text` with the chosen voice/tuning."""
-    spoken = _apply_fixes(clean_for_speech(text), fixes) or "..."
+    spoken = _apply_fixes(say_name(clean_for_speech(text)), fixes) or "..."
     communicate = edge_tts.Communicate(spoken, voice, rate=rate, pitch=pitch)
     audio = bytearray()
     async for chunk in communicate.stream():

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -1,6 +1,15 @@
 """Tests for TTS-only pronunciation fixes."""
 
-from ev.providers.voice import _apply_fixes, clean_for_speech
+from ev.providers.voice import _apply_fixes, clean_for_speech, say_name
+
+
+def test_say_name_speaks_eevee_not_letters():
+    assert say_name("Sou a E.V., sua IA.") == "Sou a Ivi, sua IA."
+    assert say_name("a E.V está pronta") == "a Ivi está pronta"
+    assert say_name("e.v. ok") == "Ivi ok"
+    assert say_name("EV agora") == "Ivi agora"
+    # must NOT touch ordinary words containing e/v
+    assert say_name("level up eleven event") == "level up eleven event"
 
 
 def test_clean_for_speech_strips_markdown_and_emoji():


### PR DESCRIPTION
## 🤔 Context

Você pediu que a E.V. **pare de se chamar de "É-Vê"** e diga **"Eevee"** (como o Pokémon) ao se referir a si mesma.

O nome continua **escrito "E.V."** (logo/interface), mas na **voz** ela agora pronuncia **"Ivi"** (pt-BR) — o som de *Eevee*. Feito como passo padrão do TTS, então vale na **web e no Telegram**.

- `say_name()`: `E.V.` / `E.V` / `e.v.` / `EV` → `Ivi`, com fronteiras de palavra pra **nunca** mexer em palavras comuns (level, eleven, event…).
- Aplicado no `synthesize()` antes das correções do usuário.

## Verificação
`say_name("Sou a E.V., sua IA.")` → `"Sou a Ivi, sua IA."`; `"level up eleven event"` intacto. 172 testes verdes.

> [!NOTE]
> Isso muda só a **fala**. Se quiser que ela também **escreva** "Evee" ao se referir a si mesma no chat, me diz que eu ajusto a persona.

🤖 Generated with [Claude Code](https://claude.com/claude-code)