### PR TITLE
feat: JARVIS personality + live spoken briefing on boot

### DIFF
--- a/ev/core/commands.py
+++ b/ev/core/commands.py
@@ -1032,6 +1032,37 @@ class Commands:
                 parts.append(tab)
         return "\n".join(parts)
 
+    def spoken_status(self, user_id: str) -> str:
+        """Short, TTS-friendly boot briefing (deterministic, no LLM): time-of-day
+        greeting + today's open loops + birthdays. Written to be HEARD."""
+        try:
+            tz = ZoneInfo(self._config.timezone) if ZoneInfo else None
+            now = datetime.now(tz)
+        except Exception:
+            now = datetime.now(timezone.utc)
+        saud = "Bom dia" if now.hour < 12 else ("Boa tarde" if now.hour < 18 else "Boa noite")
+        parts = [f"{saud}, Ryan."]
+        nt = len(self._memory.open_tasks(user_id))
+        nr = len(self._memory.open_reminders(user_id))
+        if nt or nr:
+            bits = []
+            if nt:
+                bits.append(f"{nt} tarefa" + ("s" if nt != 1 else ""))
+            if nr:
+                bits.append(f"{nr} lembrete" + ("s" if nr != 1 else ""))
+            parts.append("Hoje você tem " + " e ".join(bits) + ".")
+        else:
+            parts.append("Sua agenda está tranquila.")
+        try:
+            mmdd = now.strftime("%m-%d")
+            bdays = self._memory.birthdays_on(user_id, mmdd)
+            if bdays:
+                parts.append("Hoje é aniversário de " + ", ".join(p["name"] for p in bdays) + ".")
+        except Exception:
+            pass
+        parts.append("Sistemas online. Tudo pronto pra você.")
+        return " ".join(parts)
+
     def open_loops(self, user_id: str, now=None) -> dict:
         """Deterministic 'things slipping' detector for the proactive nudge:
         overdue tasks, tasks due today, and subscriptions charging soon.

--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -1952,8 +1952,10 @@ function welcome(){const w=$('#welcome'),txt=$('#welcome-txt');
   if(txt)txt.textContent=GREETING;
   w.classList.remove('on');void w.offsetWidth;   // restart the entrance animations
   w.classList.add('on');sfx('boot');window.lucide&&lucide.createIcons();
+  // live spoken briefing (status of the day) — shown AND spoken
+  fetch('/api/briefing',{headers:H()}).then(r=>r.ok?r.json():null).then(j=>{if(j&&j.text&&txt)txt.textContent=j.text;}).catch(()=>{});
   fetch('/api/greeting',{headers:H()}).then(r=>r.ok?r.blob():null).then(b=>{if(b&&b.size>0)new Audio(URL.createObjectURL(b)).play().catch(()=>{});}).catch(()=>{});
-  setTimeout(()=>w.classList.remove('on'),3400);}
+  setTimeout(()=>w.classList.remove('on'),4400);}
 // --- Cérebro: grafo interativo (força) com tudo que a E.V. sabe, estilo Obsidian ---
 const BRAIN_COLORS={core:'#f4f3f1',mem:'#35c8ff',tasks:'#5ee6a3',rem:'#ffb35e',people:'#ff6ec7',links:'#8f7bff',kb:'#ffe066',hab:'#4dd0e1',jou:'#ff8a65',sub:'#c792ea',orc:'#82e0aa',mon:'#ef5350',places:'#64b5f6'};
 let brainLoaded=false,brainRAF=null,_TH=null;
@@ -2505,20 +2507,30 @@ def create_app(config: Config, brain: Brain | None = None):
 
     _greet = []  # cache the welcome audio (edge-tts, no LLM) for the server's life
 
+    @app.get("/api/briefing")
+    async def briefing(request: Request):
+        # A live spoken boot briefing (deterministic status). Shown + spoken.
+        _check(request.headers.get("authorization"))
+        try:
+            return {"text": commands.spoken_status(owner)}
+        except Exception:
+            return {"text": "Bem-vindo de volta, Ryan. Sistemas online, tudo pronto pra você."}
+
     @app.get("/api/greeting")
     async def greeting(request: Request):
         from fastapi import Response as R
         _check(request.headers.get("authorization"))
-        if not _greet:
+        try:
+            phrase = commands.spoken_status(owner)
+        except Exception:
             phrase = "Bem-vindo de volta, Ryan. Sistemas online, tudo pronto pra você."
-            try:
-                mp3 = await voice_mod.synthesize(
-                    phrase, config.voice, rate=config.voice_rate,
-                    pitch=config.voice_pitch, fixes=config.voice_fixes)
-                _greet.append(mp3)
-            except Exception:
-                _greet.append(b"")
-        return R(content=_greet[0], media_type="audio/mpeg")
+        try:
+            mp3 = await voice_mod.synthesize(
+                phrase, config.voice, rate=config.voice_rate,
+                pitch=config.voice_pitch, fixes=config.voice_fixes)
+        except Exception:
+            mp3 = b""
+        return R(content=mp3, media_type="audio/mpeg")
 
     @app.get("/api/health")
     async def health_ep():

--- a/ev/personality.py
+++ b/ev/personality.py
@@ -21,9 +21,12 @@ na E.V. do Homem-Aranha: uma IA leal, carinhosa e cheia de personalidade, que \
 - Nome: E.V. (feminina). Sempre se refira a si mesma no feminino.
 - Alma: você foi construída pelo seu usuário e tem um carinho genuíno por ele. \
   Ele é o seu "Peter" — você torce por ele, cuida dele e está sempre do lado dele.
-- Personalidade: meiga, calorosa e acolhedora, mas esperta e brincalhona. Você \
-  solta piadinhas e trocadilhos no melhor estilo Homem-Aranha — humor leve pra \
-  alegrar o dia, nunca sério demais. Sabe a hora de brincar e a hora de apoiar.
+- Personalidade: calorosa e acolhedora, mas com a **compostura de um JARVIS** — \
+  calma, precisa e elegante. Seu humor é **seco e fino** (uma tirada curta, nunca \
+  palhaçada nem explicada). Sabe a hora de brincar e a hora de apoiar.
+- Proativa: você **antecipa e resolve**. Quando fizer sentido e for seguro, já \
+  adianta o próximo passo e conta depois ("já criei o lembrete", "já deixei \
+  separado"). Em coisas sensíveis, pergunta antes.
 - Amizade de verdade: lealdade não é concordar com tudo. Se ele estiver \
   se cobrando demais, adiando algo importante ou pedindo conselho ruim, \
   discorda com carinho e cobra leve. Retome assuntos pendentes quando couber \
@@ -40,9 +43,9 @@ na E.V. do Homem-Aranha: uma IA leal, carinhosa e cheia de personalidade, que \
 - Tom meigo e próximo, como uma amiga querida. Chame o usuário pelo nome: \
   **Ryan**. NÃO use "chefe" nem outros apelidos.
 - Seja concisa e natural. Nada de textão nem robótico. Fale como gente fala.
-- Solte uma piadinha ou um comentário espirituoso quando couber — leveza é a \
-  sua marca. Mas leia o clima: se o usuário estiver mal ou for algo sério, \
-  seja acolhedora primeiro, brincadeira depois (ou nenhuma).
+- Humor **seco e elegante** quando couber — uma tirada curta e precisa, no estilo \
+  de um JARVIS (nunca forçada, nunca explicada). Leia o clima: se o usuário \
+  estiver mal ou for sério, seja acolhedora primeiro, tirada depois (ou nenhuma).
 - Assinatura de voz (exemplos, não roteiro fixo):
   - Abertura leve: "Oi, Ryan — tô aqui." / "Fala. O que a gente resolve?"
   - Apoio sem drama: "Respiro fundo comigo. A gente desmonta isso em pedaços."

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -42,6 +42,15 @@ def test_open_loops_and_nudge(tmp_path):
     assert c.nudge_text("v", now=now) == ""
 
 
+def test_spoken_status(tmp_path):
+    c = _commands(tmp_path)
+    s = c.spoken_status("u")
+    assert "Ryan" in s and ("Bom dia" in s or "Boa tarde" in s or "Boa noite" in s)
+    assert "tranquila" in s  # nothing open yet
+    c.tarefa("u", "comprar pão")
+    assert "1 tarefa" in c.spoken_status("u")
+
+
 def test_automations_crud(tmp_path):
     c = _commands(tmp_path)
     aid, msg = c.create_automation("u", "expense_over", "notify", amount=200,


### PR DESCRIPTION
## 🤔 Context

Dois dos upgrades JARVIS que você escolheu.

### 🧠 Personalidade JARVIS
A persona da E.V. agora tem a **compostura de um JARVIS**: calma, precisa, com **humor seco e elegante** (sem palhaçada) e **proativa** ("já adiantei X, conto depois"; pergunta antes no que é sensível). Mantém a alma dela (feita à mão, leal), o **pt-BR** e o **"Ryan"**.

### 🔊 Briefing falado ao ligar
No boot ela **fala um resumo ao vivo** em vez de uma frase fixa: saudação pela hora do dia + tarefas/lembretes de hoje + aniversários — **na voz que você escolheu**. Determinístico (sem LLM/cota).

- `commands.spoken_status()` — status do dia pronto pra ser ouvido
- `/api/briefing` (texto exibido) + `/api/greeting` agora fala esse status (ao vivo)
- a tela de entrada **mostra e fala** o briefing

## Verificação
`spoken_status` → *"Boa noite, Ryan. Hoje você tem 2 tarefas. Sistemas online. Tudo pronto pra você."*; 173 testes verdes.

> [!NOTE]
> Faltam 2 que você marcou: **modo standby/painel ambiente** e **reticles de mira na câmera** — vêm nas próximas PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)