### PR TITLE
feat: self-service API connectors + dynamic keys (no code)

### DIFF
--- a/ev/core/brain.py
+++ b/ev/core/brain.py
@@ -775,6 +775,36 @@ class Brain:
                 message=(mensagem or None), command=(comando or None))
             return ("automação criada: " + msg) if aid else ("não consegui criar: " + msg)
 
+        def consultar_conector(nome: str) -> str:
+            """Consulta um conector de API que o usuário criou (pelo nome) e retorna
+            o valor atual. Use quando ele perguntar algo que um conector dele cobre
+            (ex 'qual a cotação do dólar?' se ele tiver um conector de cotação).
+
+            Args:
+                nome: o nome do conector configurado.
+            """
+            import os as _os
+            import re as _re
+            import json as _json
+            from ..providers import connectors as _cn
+            c = self._memory.get_connector(user_id, nome)
+            if not c:
+                av = [x["name"] for x in self._memory.list_connectors(user_id)]
+                return (f"não achei o conector '{nome}'."
+                        + (f" Você tem: {', '.join(av)}." if av else
+                           " Você ainda não criou conectores (aba Conectores)."))
+            def sub(s):
+                return _re.sub(r"\{\{\s*([A-Z][A-Z0-9_]{1,39})\s*\}\}",
+                               lambda m: _os.environ.get(m.group(1), ""), s or "")
+            val, err = _cn.fetch(sub(c["url"]),
+                                 {k: sub(v) for k, v in (c["headers"] or {}).items()},
+                                 c["path"])
+            if err:
+                return f"não consegui consultar '{c['name']}': {err}"
+            if isinstance(val, (dict, list)):
+                val = _json.dumps(val, ensure_ascii=False)[:600]
+            return f"{c['name']}: {str(val)[:600]}"
+
         def planejar_dia() -> str:
             """Monta um plano acionável para o dia do usuário, juntando as tarefas
             abertas, os lembretes, a agenda, o clima e a localização atual, e
@@ -786,6 +816,7 @@ class Brain:
             "executar_comando": executar_comando,
             "planejar_dia": planejar_dia,
             "criar_automacao": criar_automacao,
+            "consultar_conector": consultar_conector,
             "anotar_pessoa": anotar_pessoa,
             "sobre_pessoa": sobre_pessoa,
             "minha_localizacao": minha_localizacao,
@@ -876,6 +907,14 @@ class Brain:
                 "Monta um plano acionável do dia do usuário juntando tarefas, "
                 "lembretes, agenda, clima e localização. Use para 'resolve minha "
                 "manhã', 'plano do dia', 'organiza meu dia', 'o que faço hoje'.",
+            ),
+            fn(
+                "consultar_conector",
+                "Consulta um conector de API que o usuário criou (pelo nome) e "
+                "retorna o valor atual. Use quando a pergunta dele bate com um "
+                "conector configurado.",
+                {"nome": {"type": s, "description": "nome do conector"}},
+                ["nome"],
             ),
             fn(
                 "criar_automacao",

--- a/ev/core/memory.py
+++ b/ev/core/memory.py
@@ -284,6 +284,16 @@ class Memory:
                 state    TEXT NOT NULL DEFAULT '{}',
                 created  TEXT NOT NULL
             );
+
+            CREATE TABLE IF NOT EXISTS connectors (
+                id       INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id  TEXT NOT NULL,
+                name     TEXT NOT NULL,
+                url      TEXT NOT NULL,
+                headers  TEXT NOT NULL DEFAULT '{}',
+                path     TEXT NOT NULL DEFAULT '',
+                created  TEXT NOT NULL
+            );
             """
         )
         # Migrations for older DBs.
@@ -456,6 +466,43 @@ class Memory:
         self._conn.execute("UPDATE automations SET state = ? WHERE id = ?",
                            (json.dumps(state), auto_id))
         self._conn.commit()
+
+    # --- connectors (user-defined API integrations) ------------------------
+
+    def add_connector(self, user_id: str, name: str, url: str,
+                      headers: dict, path: str) -> int:
+        cur = self._conn.execute(
+            "INSERT INTO connectors (user_id, name, url, headers, path, created) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (user_id, name, url, json.dumps(headers or {}), path or "", self._now()))
+        self._conn.commit()
+        return int(cur.lastrowid)
+
+    def list_connectors(self, user_id: str) -> list[dict]:
+        rows = self._conn.execute(
+            "SELECT id, name, url, headers, path, created FROM connectors "
+            "WHERE user_id = ? ORDER BY name", (user_id,)).fetchall()
+        out = []
+        for r in rows:
+            d = dict(r)
+            try:
+                d["headers"] = json.loads(d.get("headers") or "{}")
+            except (ValueError, TypeError):
+                d["headers"] = {}
+            out.append(d)
+        return out
+
+    def get_connector(self, user_id: str, name: str) -> dict | None:
+        for c in self.list_connectors(user_id):
+            if c["name"].lower() == (name or "").lower():
+                return c
+        return None
+
+    def delete_connector(self, user_id: str, conn_id: int) -> bool:
+        cur = self._conn.execute(
+            "DELETE FROM connectors WHERE id = ? AND user_id = ?", (conn_id, user_id))
+        self._conn.commit()
+        return cur.rowcount > 0
 
     def expenses_after_id(self, user_id: str, after_id: int) -> list[dict]:
         rows = self._conn.execute(

--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -822,6 +822,7 @@ textarea.minput{resize:vertical;min-height:74px;font-family:var(--body);line-hei
     <div class="eyebrow">Provedor de IA</div>
     <select id="prov"><option>auto</option><option>gemini</option><option>groq</option><option>openrouter</option><option>ollama</option></select>
     <button class="act" id="btn-voice" style="margin-top:12px;width:100%"><i data-lucide="mic-vocal"></i>Voz da E.V.</button>
+    <button class="act" id="btn-conn" style="margin-top:8px;width:100%"><i data-lucide="plug-zap"></i>Conectores de API</button>
     <button class="act" id="btn-keys" style="margin-top:8px;width:100%"><i data-lucide="key-round"></i>Chaves de API</button>
     <button class="act" id="btn-notifs" style="margin-top:8px;width:100%"><i data-lucide="bell"></i>Notificações<span id="notif-badge" class="nbadge"></span></button>
   </aside>
@@ -1176,6 +1177,50 @@ async function openKeys(){let d;try{d=await (await fetch('/api/keys',{headers:H(
     if(Object.keys(body).length){const r=await (await fetch('/api/keys',{method:'POST',headers:H(),body:JSON.stringify(body)})).json();sys('Chaves atualizadas: '+(r.changed||[]).join(', '));loadPanel();}});}
 $('#btn-keys').onclick=openKeys;
 $('#btn-voice').onclick=openVoicePicker;
+$('#btn-conn').onclick=openConnectors;
+async function openConnectors(){
+  let conns=[],keys=[];
+  try{conns=(await (await fetch('/api/connectors',{headers:H()})).json()).items||[];}catch(e){}
+  try{keys=(await (await fetch('/api/keys/custom',{headers:H()})).json()).keys||[];}catch(e){}
+  const m=$('#modal');m.textContent='';const card=el('div','mcard');
+  card.appendChild(el('div','mtitle','Conectores de API'));
+  card.appendChild(el('div','mconf','Conecte qualquer API HTTPS pela interface — sem código. Guarde a chave aqui e use {{NOME_DA_CHAVE}} na URL ou nos headers.'));
+  // --- secret keys ---
+  card.appendChild(el('div','tv-cat','Chaves guardadas'));
+  const klist=el('div','vlist');
+  const drawKeys=()=>{klist.textContent='';if(!keys.length)klist.appendChild(el('div','tv-empty','Nenhuma chave ainda.'));
+    keys.forEach(k=>{const row=el('div','vrow');row.appendChild(el('span','vname',k.name+(k.set?' ✓':'')));
+      const del=el('button','vplay');del.appendChild(ficon('trash-2'));del.onclick=async()=>{await fetch('/api/keys/custom',{method:'POST',headers:H(),body:JSON.stringify({name:k.name,clear:true})});keys=keys.filter(x=>x.name!==k.name);drawKeys();};
+      row.appendChild(del);klist.appendChild(row);});};
+  drawKeys();card.appendChild(klist);
+  const kf=el('div','vrange');const kn=document.createElement('input');kn.className='minput';kn.placeholder='NOME_DA_CHAVE (ex: OPENWEATHER_KEY)';kn.style.marginBottom='6px';
+  const kv=document.createElement('input');kv.className='minput';kv.placeholder='valor da chave';kv.type='password';
+  const kb=el('button','mbtn2','Guardar chave');kb.style.marginTop='6px';
+  kb.onclick=async()=>{const nm=(kn.value||'').trim().toUpperCase();if(!nm||!kv.value)return;
+    const r=await fetch('/api/keys/custom',{method:'POST',headers:H(),body:JSON.stringify({name:nm,value:kv.value})});
+    if(r.ok){if(!keys.find(x=>x.name===nm))keys.push({name:nm,set:true});kn.value='';kv.value='';drawKeys();sfx('confirm');}else{const e=await r.json().catch(()=>({}));toast(e.detail||'nome inválido');}};
+  kf.appendChild(kn);kf.appendChild(kv);kf.appendChild(kb);card.appendChild(kf);
+  // --- connectors ---
+  card.appendChild(el('div','tv-cat','Conectores'));
+  const clist=el('div','vlist');
+  const drawConns=()=>{clist.textContent='';if(!conns.length)clist.appendChild(el('div','tv-empty','Nenhum conector ainda.'));
+    conns.forEach(c=>{const row=el('div','vrow');row.appendChild(el('span','vname',c.name));
+      const test=el('button','vplay');test.appendChild(ficon('play'));test.onclick=async()=>{test.classList.add('busy');const r=await (await fetch('/api/connectors/run',{method:'POST',headers:H(),body:JSON.stringify({name:c.name})})).json();test.classList.remove('busy');toast(r.ok?('→ '+r.value):('erro: '+r.error));};
+      const del=el('button','vplay');del.appendChild(ficon('trash-2'));del.onclick=async()=>{await fetch('/api/connectors/delete',{method:'POST',headers:H(),body:JSON.stringify({id:c.id})});conns=conns.filter(x=>x.id!==c.id);drawConns();};
+      row.appendChild(test);row.appendChild(del);clist.appendChild(row);});};
+  drawConns();card.appendChild(clist);
+  const mk=(ph,val)=>{const i=document.createElement('input');i.className='minput';i.placeholder=ph;i.style.marginBottom='6px';if(val)i.value=val;return i;};
+  const cn=mk('nome (ex: Cotação dólar)'),cu=mk('https://api.exemplo.com/... (pode usar {{CHAVE}})'),ch=mk('header opcional  ex: Authorization: Bearer {{CHAVE}}'),cp=mk('caminho no JSON (ex: rates.BRL ou data[0].price)');
+  [cn,cu,ch,cp].forEach(i=>card.appendChild(i));
+  const parseH=()=>{const t=(ch.value||'').trim();if(!t)return{};const i=t.indexOf(':');return i>0?{[t.slice(0,i).trim()]:t.slice(i+1).trim()}:{};};
+  const bar=el('div','mbar');
+  const tb=el('button','mbtn2','Testar');tb.onclick=async()=>{const r=await (await fetch('/api/connectors/run',{method:'POST',headers:H(),body:JSON.stringify({url:cu.value.trim(),headers:parseH(),path:cp.value.trim()})})).json();toast(r.ok?('→ '+r.value):('erro: '+r.error));};
+  const sv=el('button','mbtn','Salvar conector');sv.onclick=async()=>{if(!cn.value.trim()||!cu.value.trim().startsWith('https://')){toast('nome e URL https são obrigatórios');return;}
+    const r=await fetch('/api/connectors',{method:'POST',headers:H(),body:JSON.stringify({name:cn.value.trim(),url:cu.value.trim(),headers:parseH(),path:cp.value.trim()})});
+    if(r.ok){const j=await r.json();conns.push({id:j.id,name:cn.value.trim(),url:cu.value.trim(),headers:parseH(),path:cp.value.trim()});cn.value=cu.value=ch.value=cp.value='';drawConns();sfx('confirm');}};
+  const cl=el('button','mbtn2','Fechar');cl.onclick=()=>m.classList.remove('on');
+  bar.appendChild(cl);bar.appendChild(tb);bar.appendChild(sv);card.appendChild(bar);
+  m.appendChild(card);m.classList.add('on');window.lucide&&lucide.createIcons();}
 async function openVoicePicker(){
   let d;try{d=await (await fetch('/api/voice',{headers:H()})).json();}catch(e){return;}
   const m=$('#modal');m.textContent='';const card=el('div','mcard');
@@ -3247,6 +3292,104 @@ def create_app(config: Config, brain: Brain | None = None):
                 except Exception:
                     pass
         return {"ok": bool(changed), "changed": changed, "keys": _keys_state()}
+
+    # --- dynamic keys + connectors (self-service integrations, no code) -----
+    import os as _os
+    import re as _re
+    from ..providers import connectors as conn_mod
+
+    def _custom_keys():
+        try:
+            return json.loads(memory.get_setting("custom_keys") or "[]")
+        except (ValueError, TypeError):
+            return []
+
+    @app.get("/api/keys/custom")
+    async def custom_keys_get(request: Request):
+        _check(request.headers.get("authorization"))
+        names = _custom_keys()
+        return {"keys": [{"name": n, "set": bool(_os.environ.get(n))} for n in names]}
+
+    @app.post("/api/keys/custom")
+    async def custom_keys_set(request: Request):
+        _check(request.headers.get("authorization"))
+        d = await _body(request)
+        name = (d.get("name") or "").strip().upper()
+        if not _re.match(r"^[A-Z][A-Z0-9_]{1,39}$", name):
+            raise HTTPException(status_code=400, detail="nome inválido (use MAIÚSCULAS_E_UNDERSCORE)")
+        names = _custom_keys()
+        if d.get("clear"):
+            _os.environ.pop(name, None)
+            try:
+                _env_write(name, "")
+            except Exception:
+                pass
+            names = [n for n in names if n != name]
+            memory.set_setting("custom_keys", json.dumps(names))
+            return {"ok": True, "removed": name}
+        val = (d.get("value") or "").strip()
+        if not val:
+            raise HTTPException(status_code=400, detail="valor vazio")
+        _os.environ[name] = val                      # live for connectors, no restart
+        try:
+            _env_write(name, val)                    # persist to .env
+        except Exception:
+            pass
+        if name not in names:
+            names.append(name)
+            memory.set_setting("custom_keys", json.dumps(names))
+        return {"ok": True, "name": name}
+
+    def _subst(s: str) -> str:
+        # replace {{SECRET_NAME}} with the value from the environment (never logged)
+        return _re.sub(r"\{\{\s*([A-Z][A-Z0-9_]{1,39})\s*\}\}",
+                       lambda m: _os.environ.get(m.group(1), ""), s or "")
+
+    @app.get("/api/connectors")
+    async def connectors_list(request: Request):
+        _check(request.headers.get("authorization"))
+        return {"items": memory.list_connectors(owner)}
+
+    @app.post("/api/connectors")
+    async def connectors_add(request: Request):
+        _check(request.headers.get("authorization"))
+        d = await _body(request)
+        name = (d.get("name") or "").strip()
+        url = (d.get("url") or "").strip()
+        if not name or not url.startswith("https://"):
+            raise HTTPException(status_code=400, detail="nome e URL https são obrigatórios")
+        headers = d.get("headers") if isinstance(d.get("headers"), dict) else {}
+        cid = memory.add_connector(owner, name[:60], url, headers, (d.get("path") or "").strip())
+        return {"ok": True, "id": cid}
+
+    @app.post("/api/connectors/delete")
+    async def connectors_del(request: Request):
+        _check(request.headers.get("authorization"))
+        memory.delete_connector(owner, int((await _body(request)).get("id") or 0))
+        return {"ok": True}
+
+    @app.post("/api/connectors/run")
+    async def connectors_run(request: Request):
+        _check(request.headers.get("authorization"))
+        d = await _body(request)
+        # run either a saved connector (by name) or an ad-hoc test payload
+        if d.get("name"):
+            c = memory.get_connector(owner, d["name"])
+            if not c:
+                raise HTTPException(status_code=404, detail="conector não encontrado")
+            url, headers, path = c["url"], c["headers"], c["path"]
+        else:
+            url = (d.get("url") or "").strip()
+            headers = d.get("headers") if isinstance(d.get("headers"), dict) else {}
+            path = (d.get("path") or "").strip()
+        url = _subst(url)
+        headers = {k: _subst(v) for k, v in (headers or {}).items()}
+        val, err = await asyncio.to_thread(conn_mod.fetch, url, headers, path)
+        if err:
+            return {"ok": False, "error": err}
+        if isinstance(val, (dict, list)):
+            val = json.dumps(val, ensure_ascii=False)[:800]
+        return {"ok": True, "value": str(val)[:800]}
 
     # --- Links / Habits / Journal CRUD -------------------------------------
     @app.get("/api/links")

--- a/ev/providers/connectors.py
+++ b/ev/providers/connectors.py
@@ -1,0 +1,100 @@
+"""User-defined API connectors — fetch an allowed external HTTPS endpoint and
+pull out a value. Config-driven (NO code execution).
+
+Security: SSRF-guarded — https only, public hosts only (private/loopback/
+link-local/reserved IPs are blocked), redirects disabled (a 3xx could hop to
+an internal host), and response size/time capped. Secrets are substituted by
+the caller (never logged here).
+"""
+from __future__ import annotations
+
+import ipaddress
+import json
+import re
+import socket
+import urllib.request
+from urllib.parse import urlparse
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    # Block redirects entirely — otherwise a public URL could 3xx to an internal one.
+    def redirect_request(self, *a, **k):
+        return None
+
+
+_OPENER = urllib.request.build_opener(_NoRedirect)
+
+
+def _host_is_public(host: str) -> bool:
+    """True only if every resolved IP for `host` is a public address."""
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except Exception:
+        return False
+    if not infos:
+        return False
+    for info in infos:
+        try:
+            ip = ipaddress.ip_address(info[4][0])
+        except ValueError:
+            return False
+        if (ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved
+                or ip.is_multicast or ip.is_unspecified):
+            return False
+    return True
+
+
+def _tokens(path: str):
+    """Parse a simple JSON path like '$.a.b[0].c' -> ['a','b',0,'c']."""
+    out: list = []
+    for seg in (path or "").lstrip("$").split("."):
+        seg = seg.strip()
+        if not seg:
+            continue
+        key = re.match(r"^[^\[\]]*", seg).group(0)
+        if key:
+            out.append(key)
+        for idx in re.findall(r"\[(\d+)\]", seg):
+            out.append(int(idx))
+    return out
+
+
+def json_path(data, path: str):
+    """Extract a value from parsed JSON via a simple dotted/indexed path."""
+    cur = data
+    for part in _tokens(path):
+        if isinstance(part, int):
+            if not isinstance(cur, list) or part >= len(cur):
+                return None
+            cur = cur[part]
+        else:
+            if not isinstance(cur, dict) or part not in cur:
+                return None
+            cur = cur[part]
+    return cur
+
+
+def fetch(url: str, headers: dict | None = None, path: str = "",
+          timeout: int = 8, max_bytes: int = 200_000):
+    """Fetch a connector endpoint safely. Returns (value, error_message)."""
+    u = urlparse(url or "")
+    if u.scheme != "https":
+        return None, "Só https é permitido."
+    if not u.hostname or not _host_is_public(u.hostname):
+        return None, "Host não permitido (endereço interno/privado bloqueado)."
+    req = urllib.request.Request(
+        url, headers=headers or {"User-Agent": "E.V.-connector/1.0"})
+    try:
+        with _OPENER.open(req, timeout=timeout) as r:
+            raw = r.read(max_bytes + 1)
+    except Exception as exc:
+        return None, f"Falha ao buscar: {exc}"
+    if len(raw) > max_bytes:
+        return None, "Resposta grande demais."
+    text = raw.decode("utf-8", "replace")
+    try:
+        data = json.loads(text)
+    except ValueError:
+        return text[:800], None  # not JSON — return raw text snippet
+    val = json_path(data, path) if path else data
+    return val, None

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -1,0 +1,38 @@
+"""Tests for user-defined API connectors — SSRF guard + JSON path (offline)."""
+
+from ev.providers import connectors as cn
+from ev.core.memory import Memory
+
+
+def test_https_only():
+    val, err = cn.fetch("http://example.com/x")
+    assert val is None and "https" in err
+
+
+def test_blocks_private_and_loopback():
+    # IP literals + localhost resolve without network; all must be refused
+    for url in ("https://127.0.0.1/x", "https://10.0.0.1/x",
+                "https://192.168.1.1/x", "https://169.254.169.254/latest",
+                "https://localhost/x"):
+        val, err = cn.fetch(url)
+        assert val is None and "interno" in err.lower(), url
+
+
+def test_json_path():
+    data = {"rates": {"BRL": 5.42}, "list": [{"price": 10}, {"price": 20}]}
+    assert cn.json_path(data, "rates.BRL") == 5.42
+    assert cn.json_path(data, "$.list[1].price") == 20
+    assert cn.json_path(data, "list[0].price") == 10
+    assert cn.json_path(data, "nope.x") is None
+
+
+def test_connector_crud(tmp_path):
+    m = Memory(tmp_path / "t.db")
+    cid = m.add_connector("u", "Dólar", "https://api.x/usd",
+                          {"Authorization": "Bearer {{FX_KEY}}"}, "rates.BRL")
+    items = m.list_connectors("u")
+    assert len(items) == 1 and items[0]["name"] == "Dólar"
+    assert items[0]["headers"]["Authorization"].startswith("Bearer ")
+    assert m.get_connector("u", "dólar")["path"] == "rates.BRL"
+    assert m.delete_connector("u", cid) is True
+    assert m.list_connectors("u") == []


### PR DESCRIPTION
## 🤔 Context

O coração da "auto-extensão" que você pediu: a E.V. ganha **novas integrações pela própria interface — sem eu escrever código**. Você registra uma **API HTTPS** + (opcional) uma **chave guardada**, e ela busca/responde a partir disso.

### Como funciona
- **Chaves dinâmicas:** adicione **qualquer chave nomeada** pela UI → vai pro `.env` **e** fica viva no processo (sem restart). Use como `{{NOME}}` na URL ou nos headers do conector.
- **Conectores:** nome + URL + header opcional + caminho no JSON (ex: `rates.BRL`). Testar e salvar direto no modal.
- **Na conversa:** a E.V. lê um conector via a tool `consultar_conector` ("qual a cotação do dólar?").

> [!WARNING]
> **Segurança (SSRF):** só **https**, só **hosts públicos** (bloqueia 127.0.0.1, 10/8, 192.168, 169.254 etc.), **redirects desativados** (evita hop pra rede interna), tamanho/tempo limitados. É **config, não execução de código**.

## Verificação
Ao vivo: URL interna **bloqueada**; API pública real (GitHub) buscada e extraída por JSON path (`full_name` → `python/cpython`). 177 testes verdes (SSRF, https-only, JSON path, CRUD).

> [!NOTE]
> Próximo: **páginas/painéis personalizados** (widgets declarativos) — a outra metade da auto-extensão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)