### PR TITLE
feat: Spotify search — play any song by voice/search

### DIFF
--- a/ev/core/brain.py
+++ b/ev/core/brain.py
@@ -796,6 +796,26 @@ class Brain:
             return (f"tocando a playlist '{nome}'." if r.status_code in (200, 202, 204)
                     else "não consegui tocar agora.")
 
+        def tocar_musica(busca: str) -> str:
+            """Busca e toca QUALQUER música no Spotify (por nome de faixa/artista).
+            Use para 'toca Bohemian Rhapsody', 'bota um som do Djavan'.
+
+            Args:
+                busca: o que tocar (faixa e/ou artista).
+            """
+            from ..providers import spotify as _sp
+            tok = _sp.access_token(self._memory, self._config)
+            if not tok:
+                return "o Spotify não está conectado — conecte na aba Música."
+            uri = _sp.first_track_uri(tok, busca)
+            if not uri:
+                return f"não achei '{busca}' no Spotify."
+            r = _sp.api("PUT", "/me/player/play", tok, json={"uris": [uri]})
+            if r.status_code == 404:
+                return "não há dispositivo ativo. Abre o Spotify ou o player da E.V. e tenta de novo."
+            return (f"tocando '{busca}'." if r.status_code in (200, 202, 204)
+                    else "não consegui tocar agora.")
+
         def controlar_musica(acao: str) -> str:
             """Controla o playback do Spotify: pausar, continuar, próxima, anterior.
 
@@ -901,6 +921,7 @@ class Brain:
             "consultar_conector": consultar_conector,
             "criar_pagina": criar_pagina,
             "tocar_playlist": tocar_playlist,
+            "tocar_musica": tocar_musica,
             "controlar_musica": controlar_musica,
             "musica_atual": musica_atual,
             "anotar_pessoa": anotar_pessoa,
@@ -1000,6 +1021,14 @@ class Brain:
                 "conectado + Premium. Use para 'toca minha playlist X', 'bota um som'.",
                 {"nome": {"type": s, "description": "nome/parte da playlist"}},
                 ["nome"],
+            ),
+            fn(
+                "tocar_musica",
+                "Busca e toca QUALQUER música no Spotify por nome (faixa/artista). "
+                "Use para 'toca Bohemian Rhapsody', 'bota um som do X'. Requer "
+                "Spotify conectado + Premium.",
+                {"busca": {"type": s, "description": "faixa e/ou artista"}},
+                ["busca"],
             ),
             fn(
                 "controlar_musica",

--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -1669,6 +1669,17 @@ async function loadSpotify(){const box=$('#sp-section');if(!box)return;box.textC
   const now=el('span','eyebrow');now.id='sp-now';now.style.margin='0 0 0 6px';bar.appendChild(now);
   const dc=el('button','mchip');dc.style.marginLeft='auto';dc.textContent='desconectar';dc.onclick=async()=>{await fetch('/api/spotify/disconnect',{method:'POST',headers:H()});loadSpotify();};bar.appendChild(dc);
   box.appendChild(bar);
+  // search & play anything
+  const sf=el('div','');sf.style.cssText='display:flex;gap:8px;margin-bottom:10px';
+  const si=document.createElement('input');si.className='tv-search';si.placeholder='buscar e tocar (ex: Bohemian Rhapsody)';si.style.flex='1';
+  const sb=el('button','mchip');sb.appendChild(ficon('search'));
+  const doSearch=async()=>{const q=(si.value||'').trim();if(!q)return;const res=$('#sp-results');res.textContent='…';
+    try{const items=(await (await fetch('/api/spotify/search?q='+encodeURIComponent(q),{headers:H()})).json()).items||[];res.textContent='';
+      if(!items.length){res.appendChild(el('div','tv-empty','Nada encontrado.'));return;}
+      items.forEach(t=>{const row=el('div','mu-row');row.appendChild(el('span','n',t.name+' — '+t.artists));row.onclick=()=>{spPlay(t.uri);};res.appendChild(row);});}catch(e){res.textContent='';}};
+  sb.onclick=doSearch;si.addEventListener('keydown',e=>{if(e.key==='Enter')doSearch();});
+  sf.appendChild(si);sf.appendChild(sb);box.appendChild(sf);
+  const sres=el('div','vlist');sres.id='sp-results';sres.style.maxHeight='26vh';box.appendChild(sres);
   box.appendChild(el('div','tv-cat','Minhas playlists'));const pl=el('div','vlist');pl.style.maxHeight='34vh';box.appendChild(pl);
   try{const pls=(await (await fetch('/api/spotify/playlists',{headers:H()})).json()).items||[];
     if(!pls.length)pl.appendChild(el('div','tv-empty','Nenhuma playlist encontrada.'));
@@ -3720,8 +3731,18 @@ def create_app(config: Config, brain: Brain | None = None):
             raise HTTPException(status_code=400, detail="não conectado")
         d = await _body(request)
         body, dev = {}, d.get("device_id")
-        if d.get("uri"):
-            body["context_uri"] = d["uri"]
+        if d.get("uris"):
+            body["uris"] = d["uris"]
+        elif d.get("uri"):
+            u = d["uri"]
+            if u.startswith("spotify:track:"):
+                body["uris"] = [u]           # a single track
+            else:
+                body["context_uri"] = u      # playlist/album/artist
+        if d.get("query"):                   # search then play the top track
+            tk = await asyncio.to_thread(_sp.first_track_uri, tok, d["query"])
+            if tk:
+                body = {"uris": [tk]}
         def _work():
             path = "/me/player/play" + (f"?device_id={dev}" if dev else "")
             r = _sp_api("PUT", path, tok, json=body)
@@ -3730,6 +3751,17 @@ def create_app(config: Config, brain: Brain | None = None):
         if sc == 404:
             return {"ok": False, "error": "nenhum dispositivo ativo — abra o Spotify ou use o player da E.V."}
         return {"ok": sc in (200, 202, 204)}
+
+    @app.get("/api/spotify/search")
+    async def spotify_search(request: Request):
+        _check(request.headers.get("authorization"))
+        q = (request.query_params.get("q") or "").strip()
+        if not q:
+            return {"items": []}
+        tok = await asyncio.to_thread(_sp_access)
+        if not tok:
+            raise HTTPException(status_code=400, detail="não conectado")
+        return {"items": await asyncio.to_thread(_sp.search_tracks, tok, q)}
 
     @app.get("/api/spotify/current")
     async def spotify_current(request: Request):

--- a/ev/providers/spotify.py
+++ b/ev/providers/spotify.py
@@ -102,6 +102,32 @@ def find_playlist(token: str, name: str):
     return None
 
 
+def search_tracks(token: str, q: str, limit: int = 6) -> list[dict]:
+    """Search Spotify for tracks by free text."""
+    try:
+        r = api("GET", "/search", token,
+                params={"q": q, "type": "track", "limit": limit})
+        items = ((r.json().get("tracks") or {}).get("items")) or []
+    except Exception:
+        return []
+    out = []
+    for t in items:
+        if not t:
+            continue
+        imgs = (t.get("album") or {}).get("images") or []
+        out.append({
+            "name": t.get("name"), "uri": t.get("uri"),
+            "artists": ", ".join(a.get("name", "") for a in (t.get("artists") or [])),
+            "image": (imgs[-1].get("url") if imgs else ""),
+        })
+    return out
+
+
+def first_track_uri(token: str, q: str):
+    r = search_tracks(token, q, 1)
+    return r[0]["uri"] if r else None
+
+
 def current_track(token: str) -> str:
     try:
         r = api("GET", "/me/player/currently-playing", token)


### PR DESCRIPTION
## 🤔 Context

O maior buraco: só dava pra tocar **suas playlists**. Agora a E.V. **busca e toca qualquer música**.

- Campo **"buscar e tocar"** na aba Música (conectado) → resultados → clica pra tocar.
- **Voz:** `tocar_musica` — *"E.V., toca Bohemian Rhapsody"*, *"bota um som do Djavan"*.
- `/api/spotify/search`; o `/play` agora trata **faixa única** (`uris:[…]`) e busca-e-toca inline (`{query}`).

## Verificação
180 testes verdes; helpers de busca validados. Fim-a-fim depende do Spotify conectado (Premium).

🤖 Generated with [Claude Code](https://claude.com/claude-code)