### PR TITLE
feat: Spotify widget in pages + play automation

### DIFF
--- a/ev/core/automations.py
+++ b/ev/core/automations.py
@@ -7,7 +7,7 @@ module only decides *whether* a trigger fires and describes automations.
 from __future__ import annotations
 
 TRIGGERS = ("time", "expense_over", "task_overdue")
-ACTIONS = ("notify", "command", "reschedule")
+ACTIONS = ("notify", "command", "reschedule", "play")
 
 _WD_PT = ["segunda", "terça", "quarta", "quinta", "sexta", "sábado", "domingo"]
 
@@ -57,6 +57,8 @@ def describe(auto: dict) -> str:
         faca = f"rodar /{ac.get('command', '')}"
     elif a == "reschedule":
         faca = "remarcar pro dia seguinte"
+    elif a == "play":
+        faca = f"tocar '{ac.get('playlist') or ac.get('query') or '?'}' no Spotify"
     else:
         faca = a or "?"
     status = "" if auto.get("enabled", True) else " (pausada)"

--- a/ev/core/brain.py
+++ b/ev/core/brain.py
@@ -747,14 +747,16 @@ class Brain:
 
         def criar_automacao(gatilho: str, acao: str, hora: int = -1, minuto: int = 0,
                             dia_semana: int = -1, valor: float = 0.0, categoria: str = "",
-                            mensagem: str = "", comando: str = "") -> str:
+                            mensagem: str = "", comando: str = "", playlist: str = "",
+                            musica: str = "") -> str:
             """Cria uma automação 'quando X, faça Y' que roda sozinha depois.
 
             Args:
                 gatilho: 'time' (horário recorrente), 'expense_over' (gasto acima de
                     um valor) ou 'task_overdue' (quando uma tarefa vencer).
-                acao: 'notify' (avisar com uma mensagem), 'command' (rodar um comando
-                    da E.V.) ou 'reschedule' (remarcar tarefas vencidas; só com task_overdue).
+                acao: 'notify' (avisar), 'command' (rodar um comando), 'reschedule'
+                    (remarcar tarefas vencidas; só com task_overdue) ou 'play' (tocar
+                    música no Spotify).
                 hora: para 'time', hora 0-23.
                 minuto: para 'time', minuto 0-59.
                 dia_semana: para 'time', 0=segunda..6=domingo, ou -1 para todo dia.
@@ -762,17 +764,19 @@ class Brain:
                 categoria: para 'expense_over', categoria opcional (ex 'comida').
                 mensagem: para 'notify', o texto do aviso.
                 comando: para 'command', o comando a rodar (ex 'semana', 'relatorio').
+                playlist: para 'play', o nome da playlist a tocar.
+                musica: para 'play', uma faixa/artista a tocar (se não for playlist).
 
             Ex: 'toda sexta 18h me manda o resumo' -> gatilho='time', hora=18,
-            dia_semana=4, acao='command', comando='semana'. 'quando eu gastar mais de
-            200 me avisa' -> gatilho='expense_over', valor=200, acao='notify',
-            mensagem='Gasto acima de 200!'.
+            dia_semana=4, acao='command', comando='semana'. 'toda manhã 8h toca minha
+            playlist Foco' -> gatilho='time', hora=8, acao='play', playlist='Foco'.
             """
             aid, msg = self._commands.create_automation(
                 user_id, gatilho, acao,
                 hour=(None if hora < 0 else hora), minute=minuto, weekday=dia_semana,
                 amount=(None if valor <= 0 else valor), category=(categoria or None),
-                message=(mensagem or None), command=(comando or None))
+                message=(mensagem or None), command=(comando or None),
+                playlist=(playlist or None), musica=(musica or None))
             return ("automação criada: " + msg) if aid else ("não consegui criar: " + msg)
 
         def tocar_playlist(nome: str) -> str:
@@ -1076,6 +1080,8 @@ class Brain:
                     "categoria": {"type": s, "description": "para expense_over: categoria opcional"},
                     "mensagem": {"type": s, "description": "para notify: texto do aviso"},
                     "comando": {"type": s, "description": "para command: ex 'semana'"},
+                    "playlist": {"type": s, "description": "para play: nome da playlist"},
+                    "musica": {"type": s, "description": "para play: faixa/artista"},
                 },
                 ["gatilho", "acao"],
             ),

--- a/ev/core/commands.py
+++ b/ev/core/commands.py
@@ -1213,7 +1213,8 @@ class Commands:
 
     def create_automation(self, user_id: str, trigger: str, action: str, *,
                           hour=None, minute=0, weekday=-1, amount=None,
-                          category=None, message=None, command=None):
+                          category=None, message=None, command=None,
+                          playlist=None, musica=None):
         """Deterministic constructor used by the AI tool + web form. Validates,
         seeds trigger state (e.g. current max expense id, so it never fires on
         past data). Returns (id_or_None, human_message)."""
@@ -1245,7 +1246,15 @@ class Commands:
         elif action == "reschedule":
             if trigger != "task_overdue":
                 return None, "‘remarcar’ só funciona com o gatilho de tarefa vencida"
-        name = (message or (f"/{command}" if command else action))[:80]
+        elif action == "play":
+            if playlist:
+                act_cfg = {"playlist": playlist}
+            elif musica:
+                act_cfg = {"query": musica}
+            else:
+                return None, "diga a playlist ou a música pra tocar"
+        name = (message or ("tocar " + (playlist or musica) if action == "play" and (playlist or musica)
+                            else (f"/{command}" if command else action)))[:80]
         aid = self._memory.add_automation(
             user_id, name, trigger, trig_cfg, action, act_cfg, state)
         a = {"id": aid, "trig": trigger, "trig_cfg": trig_cfg, "act": action,

--- a/ev/interfaces/telegram_bot.py
+++ b/ev/interfaces/telegram_bot.py
@@ -2313,6 +2313,8 @@ class TelegramInterface:
                     self._memory.update_task(owner, t["id"], due=tomorrow)
                     n += 1
             msg = f"🤖 {a['name']}: remarquei {n} tarefa(s) atrasada(s) pra amanhã."
+        elif act == "play":
+            msg = await asyncio.to_thread(self._auto_play, a, ac)
         else:
             return
         await self._bot_send(app.bot, cfg.owner_id, msg, self._quick_kb())
@@ -2323,6 +2325,28 @@ class TelegramInterface:
         except Exception:
             pass
         log.info("Ran automation #%s (%s → %s).", a.get("id"), a["trig"], act)
+
+    def _auto_play(self, a: dict, ac: dict) -> str:
+        """Play a playlist/track on Spotify for a 'play' automation (sync)."""
+        from ..providers import spotify as sp
+        tok = sp.access_token(self._memory, self._config)
+        if not tok:
+            return f"🤖 {a['name']} — mas o Spotify não está conectado."
+        if ac.get("playlist"):
+            uri = sp.find_playlist(tok, ac["playlist"])
+            body = {"context_uri": uri} if uri else None
+        else:
+            uri = sp.first_track_uri(tok, ac.get("query", ""))
+            body = {"uris": [uri]} if uri else None
+        if not body:
+            return f"🤖 {a['name']} — não achei o que tocar."
+        try:
+            r = sp.api("PUT", "/me/player/play", tok, json=body)
+        except Exception:
+            return f"🤖 {a['name']} — falha ao tocar."
+        if r.status_code == 404:
+            return f"🤖 {a['name']} — sem dispositivo ativo (abre o Spotify)."
+        return f"🤖 {a['name']}"
 
     async def cmd_automacoes(self, update: Update, _c: ContextTypes.DEFAULT_TYPE) -> None:
         """List the user's automations."""

--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -1368,6 +1368,9 @@ async function renderWidget(card,w){
   else if(w.type==='connector'){card.appendChild(el('div','pg-wt',w.name||'Conector'));const v=el('div','pg-big','…');card.appendChild(v);
     try{const r=await (await fetch('/api/connectors/run',{method:'POST',headers:H(),body:JSON.stringify({name:w.name})})).json();v.textContent=r.ok?r.value:('erro: '+r.error);}catch(e){v.textContent='erro';}}
   else if(w.type==='command'){const b=el('button','act');b.appendChild(ficon(w.icon||'zap'));b.appendChild(document.createTextNode(' '+(w.label||w.cmd)));b.onclick=e=>{ripple(b,e);runCmd(w.cmd);};card.appendChild(b);}
+  else if(w.type==='spotify'){card.appendChild(el('div','pg-wt','Spotify'));const f=document.createElement('iframe');
+    f.src='https://open.spotify.com/embed/'+w.kind+'/'+w.ref;f.loading='lazy';f.allow='encrypted-media';
+    f.style.cssText='width:100%;height:'+((w.kind==='track'||w.kind==='episode')?'152':'352')+'px;border:0;border-radius:12px';card.appendChild(f);}
   else if(w.type==='chart'){card.appendChild(el('div','pg-wt','Gastos por categoria'));
     try{const d=await (await fetch('/api/charts',{headers:H()})).json();const cs=(d.exp_cat||[]).slice(0,8);const mx=Math.max(1,...cs.map(c=>c.value));
       if(!cs.length)card.appendChild(el('div','tv-empty','Sem gastos no período.'));
@@ -1382,10 +1385,10 @@ function openPageBuilder(page){const m=$('#modal');m.textContent='';const card=e
     widgets.forEach((w,i)=>{const row=el('div','vrow');row.appendChild(el('span','vname',w.type+(w.category?(' · '+w.category):w.name?(' · '+w.name):w.cmd?(' · '+w.cmd):w.text?' · nota':'')));
       const del=el('button','vplay');del.appendChild(ficon('trash-2'));del.onclick=()=>{widgets.splice(i,1);draw();};row.appendChild(del);list.appendChild(row);});};
   draw();card.appendChild(el('div','tv-cat','Widgets'));card.appendChild(list);
-  const sel=document.createElement('select');sel.className='minput';['note','tasks','connector','command','chart'].forEach(t=>{const o=document.createElement('option');o.value=t;o.textContent={note:'Nota',tasks:'Tarefas',connector:'Conector',command:'Botão de comando',chart:'Gráfico de gastos'}[t];sel.appendChild(o);});sel.style.margin='8px 0 6px';card.appendChild(sel);
+  const sel=document.createElement('select');sel.className='minput';['note','tasks','connector','command','chart','spotify'].forEach(t=>{const o=document.createElement('option');o.value=t;o.textContent={note:'Nota',tasks:'Tarefas',connector:'Conector',command:'Botão de comando',chart:'Gráfico de gastos',spotify:'Spotify (link)'}[t];sel.appendChild(o);});sel.style.margin='8px 0 6px';card.appendChild(sel);
   const arg=document.createElement('input');arg.className='minput';arg.placeholder='detalhe (categoria / nome do conector / comando / texto)';card.appendChild(arg);
   const add=el('button','mbtn2','+ adicionar widget');add.style.marginTop='6px';add.onclick=()=>{const t=sel.value,a=(arg.value||'').trim();const w={type:t};
-    if(t==='tasks')w.category=a;else if(t==='connector')w.name=a;else if(t==='command'){w.cmd=a;w.label=a;}else if(t==='note')w.text=a;
+    if(t==='tasks')w.category=a;else if(t==='connector')w.name=a;else if(t==='command'){w.cmd=a;w.label=a;}else if(t==='note')w.text=a;else if(t==='spotify')w.url=a;
     widgets.push(w);arg.value='';draw();};card.appendChild(add);
   const bar=el('div','mbar');const cl=el('button','mbtn2','Cancelar');cl.onclick=()=>m.classList.remove('on');
   if(page){const dl=el('button','mbtn2','Apagar');dl.onclick=async()=>{await fetch('/api/pages/delete',{method:'POST',headers:H(),body:JSON.stringify({id:page.id})});m.classList.remove('on');await loadPages();if(curView==='page:'+page.id)switchView('chat');};bar.appendChild(dl);}
@@ -3579,15 +3582,25 @@ def create_app(config: Config, brain: Brain | None = None):
         return {"ok": True, "value": str(val)[:800]}
 
     # --- custom pages (declarative dashboards, no code) --------------------
-    _WIDGET_TYPES = {"note", "tasks", "connector", "command", "chart"}
+    _WIDGET_TYPES = {"note", "tasks", "connector", "command", "chart", "spotify"}
 
     def _clean_widgets(raw):
+        from ..providers import spotify as _sp2
         out = []
         for w in (raw or [])[:20]:
             if not isinstance(w, dict) or w.get("type") not in _WIDGET_TYPES:
                 continue
-            out.append({k: v for k, v in w.items()
-                        if k in ("type", "text", "category", "name", "cmd", "label", "icon")})
+            ww = {k: v for k, v in w.items()
+                  if k in ("type", "text", "category", "name", "cmd", "label", "icon", "kind", "ref")}
+            if ww.get("type") == "spotify":
+                if w.get("url"):
+                    p = _sp2.parse(w["url"])
+                    if not p:
+                        continue
+                    ww["kind"], ww["ref"] = p
+                if not ww.get("kind") or not ww.get("ref"):
+                    continue
+            out.append(ww)
         return out
 
     @app.get("/api/pages")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -65,6 +65,10 @@ def test_automations_crud(tmp_path):
     # validation: bad trigger / missing field
     assert c.create_automation("u", "bogus", "notify")[0] is None
     assert c.create_automation("u", "expense_over", "notify")[0] is None  # no amount
+    # a Spotify 'play' automation
+    aid3, m3 = c.create_automation("u", "time", "play", hour=8, playlist="Foco")
+    assert aid3 and "Foco" in m3
+    assert c.create_automation("u", "time", "play", hour=8)[0] is None  # no target
     # remove
     assert "removida" in c.automacao_rm("u", str(aid))
     assert c.automacao_rm("u", "999") == "Não achei essa automação."


### PR DESCRIPTION
## 🤔 Context

Fecha a rodada de Música compondo com o resto da E.V.:

- 🧩 **Widget Spotify nas páginas:** adicione uma **playlist/faixa/álbum** embutida numa página personalizada (o link é parseado no servidor pra um embed seguro).
- ⏰ **Ação "play" nas automações:** *"toda manhã 8h toca minha playlist Foco"* → toca uma playlist (ou faixa buscada) no Spotify no gatilho.
- 🗣️ `criar_automacao` aceita `acao='play'` (playlist/musica); o Telegram executa via Web API.

## Verificação
180+ testes verdes; `describe()` mostra "todo dia às 08:00 → tocar 'Foco' no Spotify"; `create_automation('play')` valida alvo; widget parseia kind+ref.

Com esta, os **4** que você escolheu (busca, player rico, dispositivo/volume/fila, páginas+automação) estão prontos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)