### PR TITLE
feat: abrir no Início (painel de uso) por padrão

### DIFF
--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -2874,7 +2874,8 @@ async function delU(delUrl,delBody,recUrl,recBody,reload,label){await fetch(delU
   toastUndo((label||'Item')+' apagado',async()=>{await fetch(recUrl,{method:'POST',headers:H(),body:JSON.stringify(recBody)});reload();loadPanel();});}
 async function startApp(){try{COMMANDS=(await (await fetch('/api/commands',{headers:H()})).json()).commands;}catch(e){}
   scopeEl.textContent='Conversa · '+thread;await loadFolders();await loadHistory();await loadConfig();loadPanel();loadPages();
-  initPWA();startPoll();startEvents();window.lucide&&lucide.createIcons();}
+  initPWA();startPoll();startEvents();window.lucide&&lucide.createIcons();
+  switchView('inicio');}   // abre no painel de uso (Início)
 function enter(){$('#login').classList.remove('on');startApp();welcome();}
 async function doLogin(){const inp=$('#login-token');const tok=((inp&&inp.value.trim())||token);if(!tok){$('#login-err').textContent='Informe o token.';if(inp)inp.style.display='block';return;}
   $('#login-err').textContent='verificando...';if(!(await validate(tok))){$('#login-err').textContent='Token inválido.';token='';localStorage.removeItem('ev_token');if(inp)inp.style.display='block';return;}


### PR DESCRIPTION
## 🤔 Context

Complemento do #97: agora a E.V. **abre direto no painel de uso (Início)** em vez da Conversa. O dashboard é a primeira coisa que você vê ao entrar — resumo de tarefas, gastos, hábitos, clima etc.

`startApp()` chama `switchView('inicio')` ao final. A conversa continua carregando em background (histórico, pastas) e fica a um clique de distância (aba **Conversa**, atalho, ou `mnav`).