### PR TITLE
feat: proatividade financeira — alerta de assinatura vencendo + orçamento estourado

### DIFF
--- a/ev/core/commands.py
+++ b/ev/core/commands.py
@@ -1094,6 +1094,51 @@ class Commands:
             },
         }
 
+    def subscriptions_due(self, user_id: str, days_ahead: int = 2) -> list:
+        """Recurring charges (assinaturas) whose due-day falls within the next
+        `days_ahead` days — a heads-up BEFORE the charge lands. Empty if none."""
+        try:
+            tz = ZoneInfo(self._config.timezone) if ZoneInfo else None
+            now = datetime.now(tz)
+        except Exception:
+            now = datetime.now(timezone.utc)
+        today = now.day
+        import calendar as _cal
+        last_day = _cal.monthrange(now.year, now.month)[1]
+        out = []
+        for r in self._memory.list_recurring(user_id):
+            d = r.get("day") or 0
+            if not d:
+                continue
+            # days until the charge, clamping a day set past month-end to the last day
+            due = min(d, last_day)
+            delta = due - today
+            if 0 < delta <= days_ahead:
+                out.append({"id": r["id"], "description": r["description"],
+                            "amount": r["amount"], "day": due, "days_until": delta})
+        return out
+
+    def budget_alerts(self, user_id: str, warn_pct: int = 80) -> list:
+        """Budgets at/over threshold this month. level='over' (>=100%) or
+        'warn' (>=warn_pct). Empty if all healthy or no budgets."""
+        _, since, _ = self._month_bounds(0)
+        out = []
+        for b in self._memory.list_budgets(user_id):
+            amount = b.get("amount") or 0
+            if amount <= 0:
+                continue
+            spent = self._memory.category_total_since(user_id, b["category"], since)
+            pct = spent / amount * 100
+            if pct >= 100:
+                lvl = "over"
+            elif pct >= warn_pct:
+                lvl = "warn"
+            else:
+                continue
+            out.append({"category": b["category"], "spent": round(spent, 2),
+                        "amount": amount, "pct": round(pct), "level": lvl})
+        return out
+
     def spoken_status(self, user_id: str) -> str:
         """Short, TTS-friendly boot briefing (deterministic, no LLM): time-of-day
         greeting + today's open loops + birthdays. Written to be HEARD."""

--- a/ev/interfaces/telegram_bot.py
+++ b/ev/interfaces/telegram_bot.py
@@ -88,6 +88,8 @@ class TelegramInterface:
         self._last_monthly: str | None = None      # month of the last financial report
         self._last_nudge: str | None = None        # date of the last open-loops nudge
         self._last_insight: str | None = None       # date of the last learned-pattern share
+        self._last_subdue: str | None = None        # date of the last subscription-due heads-up
+        self._alerted_budgets: set[str] = set()      # month:category:level already alerted
         # Keep references to background tasks so they aren't garbage-collected
         # (a GC'd task would silently kill the scheduler).
         self._bg_tasks: list = []
@@ -2053,6 +2055,8 @@ class TelegramInterface:
                     await self._maybe_insight(app)
                     await self._maybe_run_automations(app)
                     await self._maybe_monthly_report(app)
+                    await self._maybe_subscription_due(app)
+                    await self._maybe_budget_alert(app)
             except Exception:
                 log.exception("Briefing loop error")
             await asyncio.sleep(60)
@@ -2130,6 +2134,52 @@ class TelegramInterface:
                 pass
         if len(self._alerted_events) > 500:  # keep the dedupe set bounded
             self._alerted_events.clear()
+
+    async def _proactive_send(self, app: Application, title: str, msg: str) -> None:
+        """Deliver a proactive alert to Telegram + web push + notification center."""
+        cfg = self._config
+        if cfg.owner_id is None:
+            return
+        await self._bot_send(app.bot, cfg.owner_id, msg, self._quick_kb())
+        try:  # send_push also persists to the web notification center
+            from ..providers import push
+            await asyncio.to_thread(push.send_push, cfg, self._memory,
+                                    title, msg, "/", str(cfg.owner_id))
+        except Exception:
+            pass
+
+    async def _maybe_subscription_due(self, app: Application) -> None:
+        cfg = self._config
+        if cfg.owner_id is None:
+            return
+        today = datetime.now(self._tz()).date().isoformat()
+        if self._last_subdue == today:  # one heads-up sweep per day
+            return
+        self._last_subdue = today
+        for s in self._commands.subscriptions_due(str(cfg.owner_id)):
+            when = "amanhã" if s["days_until"] == 1 else f"em {s['days_until']} dias"
+            msg = f"💳 Sua assinatura {s['description']} (R$ {s['amount']:.2f}) vence {when}."
+            await self._proactive_send(app, "💳 Assinatura chegando", msg)
+
+    async def _maybe_budget_alert(self, app: Application) -> None:
+        cfg = self._config
+        if cfg.owner_id is None:
+            return
+        month = datetime.now(self._tz()).strftime("%Y-%m")
+        for a in self._commands.budget_alerts(str(cfg.owner_id)):
+            key = f"{month}:{a['category']}:{a['level']}"
+            if key in self._alerted_budgets:  # once per category/level per month
+                continue
+            self._alerted_budgets.add(key)
+            if a["level"] == "over":
+                msg = (f"🔴 Orçamento estourado — {a['category']}: "
+                       f"R$ {a['spent']:.2f} de R$ {a['amount']:.2f} ({a['pct']:.0f}%).")
+            else:
+                msg = (f"🟡 Atenção ao orçamento — {a['category']} já em {a['pct']:.0f}% "
+                       f"(R$ {a['spent']:.2f} / R$ {a['amount']:.2f}).")
+            await self._proactive_send(app, "💰 Orçamento", msg)
+        if len(self._alerted_budgets) > 500:
+            self._alerted_budgets.clear()
 
     def _log_notif(self, title: str, body: str = "") -> None:
         """Record a proactive alert in the web notification center too."""

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -113,6 +113,31 @@ def test_learned_patterns_and_persistence(tmp_path):
     assert "conhecendo" in c.learned_text("v").lower()
 
 
+def test_budget_alerts(tmp_path):
+    c = _commands(tmp_path)
+    c.orcamento("u", "comida 100")
+    assert c.budget_alerts("u") == []          # nothing spent yet
+    c.gasto("u", "95 mercado #comida")
+    warn = c.budget_alerts("u")
+    assert warn and warn[0]["level"] == "warn" and warn[0]["pct"] == 95
+    c.gasto("u", "20 doce #comida")
+    over = c.budget_alerts("u")
+    assert over and over[0]["level"] == "over" and over[0]["pct"] >= 100
+
+
+def test_subscriptions_due(tmp_path):
+    from datetime import datetime
+    c = _commands(tmp_path)
+    tomorrow = datetime.now().day + 1
+    c._memory.add_recurring("u", 50, "Netflix", "lazer", tomorrow)
+    due = c.subscriptions_due("u")
+    # a charge set for "day 32+" won't happen this month; guard on that
+    if tomorrow <= 28:
+        assert due and due[0]["description"] == "Netflix" and due[0]["days_until"] == 1
+    far = c.subscriptions_due("u", days_ahead=0)
+    assert far == []
+
+
 def test_task_flow(tmp_path):
     c = _commands(tmp_path)
     assert "adicionada" in c.tarefa("u", "comprar pão")


### PR DESCRIPTION
## 🤔 Context

Você escolheu **proatividade**. Auditando o que já existia, a E.V. **já é bem proativa** — briefing matinal, check-in, alerta de evento (Google), revisão semanal, alerta de chuva, nudge de hábito e de pendências, insight, automações, relatório mensal, reminders e monitores web — tudo via **Telegram + web push + central de notificações**, respeitando `/silenciar`.

Faltavam **dois avisos financeiros** de alto valor (você usa gastos/orçamentos bastante):

- **💳 Assinatura vencendo** (`_maybe_subscription_due`): heads-up **antes** da cobrança — "sua assinatura X (R$Y) vence amanhã / em N dias". Antes a E.V. só avisava **no dia**, ao lançar o gasto.
- **💰 Orçamento** (`_maybe_budget_alert`): avisa quando um orçamento passa de **80% (🟡)** e de **100% (🔴)**, uma vez por categoria/nível por mês (sem spam).

A lógica ficou em helpers **puros e testáveis** no `Commands` (`subscriptions_due`, `budget_alerts`); a entrega reusa o caminho dos demais alertas (`_proactive_send` → Telegram + push + notificações).

## Test

`test_budget_alerts` (80%→🟡, 100%→🔴) e `test_subscriptions_due` (vence amanhã). 184 testes verdes.

> [!NOTE]
> Deploy manual via `workflow_dispatch` (o merge não dispara o CI sozinho).