### PR TITLE
feat: MODO SÉRIO — alerta vermelho + tom tático (chat/voz)

### DIFF
--- a/ev/core/brain.py
+++ b/ev/core/brain.py
@@ -444,6 +444,16 @@ class Brain:
     def _system_instruction(self, user_id: str, query: str | None) -> str:
         system = SYSTEM_PROMPT
 
+        # MODO SÉRIO — muda o tom das respostas enquanto ativo.
+        if self._memory.get_setting("serious_mode") == "1":
+            system += (
+                "\n\n## MODO SÉRIO ATIVO\n"
+                "O usuário ativou o modo sério. Responda de forma direta, "
+                "concisa e tática — sem piadas, sem floreio, sem emojis. Vá "
+                "direto ao ponto, tom de operação/missão, frases curtas. "
+                "Continue prestativa e precisa, só que séria e focada."
+            )
+
         # Current date/time so the model can resolve "tomorrow at 9am" to ISO.
         system += "\n\n## Data e hora atual\n" + self._now_str()
 
@@ -496,6 +506,21 @@ class Brain:
             """
             self._memory.add_fact(user_id, fato, embedding=self._embed(fato))
             return "ok, memorizado"
+
+        def modo_serio(ativar: bool = True) -> str:
+            """Ativa ou desativa o MODO SÉRIO da E.V.: a interface inteira entra
+            em alerta (azul -> vermelho) e o tom das respostas fica direto,
+            tático e sem piadas. Use quando o usuário pedir 'modo sério', 'fica
+            séria', 'modo de combate', 'modo foco total', ou para desligar:
+            'volta ao normal', 'desativa o modo sério', 'relaxa'.
+
+            Args:
+                ativar: true para ligar, false para voltar ao normal.
+            """
+            self._memory.set_setting("serious_mode", "1" if ativar else "0")
+            return ("Modo sério ativado. Interface em alerta, foco total."
+                    if ativar else
+                    "Modo sério desativado. De volta ao normal.")
 
         def criar_lembrete(texto: str, quando: str = "") -> str:
             """Cria um lembrete para o usuário.
@@ -919,6 +944,7 @@ class Brain:
             return self._plan_day_sync(user_id)
 
         callables: dict = {
+            "modo_serio": modo_serio,
             "executar_comando": executar_comando,
             "planejar_dia": planejar_dia,
             "criar_automacao": criar_automacao,
@@ -1013,6 +1039,15 @@ class Brain:
 
         s = "string"
         schemas = [
+            fn(
+                "modo_serio",
+                "Ativa/desativa o modo sério da E.V. (interface azul->vermelha "
+                "em alerta + tom direto e tático). Use para 'modo sério', 'fica "
+                "séria', 'modo de combate', ou desligar: 'volta ao normal'.",
+                {"ativar": {"type": "boolean",
+                            "description": "true para ligar, false para desligar"}},
+                [],
+            ),
             fn(
                 "planejar_dia",
                 "Monta um plano acionável do dia do usuário juntando tarefas, "

--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -405,6 +405,14 @@ body.speaking .bigcore .r2{animation-delay:.15s}body.speaking .bigcore .r3{anima
    it for the compact picker and shrink the labelled buttons to icons. */
 /* base: attach "+" and bottom-nav are phone-only (media rules below turn them on) */
 #attach{display:none}#bnav{display:none}
+/* --- MODO SÉRIO (alerta vermelho) — recolore tudo que usa --accent/--glow --- */
+body.serious{--accent:#ff3b46;--accent-dim:#b3202a;--glow:rgba(255,59,70,.55)}
+#serfx{position:fixed;inset:0;pointer-events:none;z-index:38;opacity:0;transition:opacity .5s;border:1px solid transparent}
+body.serious #serfx{opacity:1;box-shadow:inset 0 0 150px -50px rgba(255,45,55,.6);border-color:rgba(255,60,70,.12)}
+#serfx.sweep{animation:seriousSweep 1.15s ease-out}
+@keyframes seriousSweep{0%{background:radial-gradient(circle at 50% 46%,rgba(255,55,66,.75),transparent 6%)}
+  45%{background:radial-gradient(circle at 50% 46%,rgba(255,55,66,.45),rgba(255,40,50,.18) 55%,transparent 100%)}
+  100%{background:radial-gradient(circle,transparent,transparent)}}
 @media(max-width:760px){
   .tabs{display:none}
   .mnav{display:block;flex:1 1 auto;min-width:60px}
@@ -1076,6 +1084,7 @@ textarea.minput{resize:vertical;min-height:74px;font-family:var(--body);line-hei
   <button id="vc-cont" class="tbtn" style="margin-top:14px"><i data-lucide="infinity"></i> Modo contínuo: off</button>
   <button id="vc-convo" class="tbtn" style="margin-top:8px"><i data-lucide="messages-square"></i> Conversa: off</button>
 </div>
+<div id="serfx"></div>
 <nav id="bnav">
   <button data-view="inicio"><i data-lucide="layout-dashboard"></i><span>Início</span></button>
   <button data-view="chat"><i data-lucide="message-square"></i><span>Conversa</span></button>
@@ -1408,7 +1417,15 @@ function renderStats(){const box=$('#stats');box.textContent='';config.stats.for
 function renderActs(){const box=$('#acts');box.textContent='';config.actions.forEach(cmd=>{const m=CAT[cmd]||[cmd,'chevron-right'];
   const b=el('button','act');b.appendChild(ficon(m[1]));b.appendChild(document.createTextNode(m[0]));
   b.onclick=e=>{if(cmd==='foco'){openPomo(25);return;}ripple(b,e);if(cmd==='cam'){$('#cambtn').click();return;}if(cmd==='bak'){window.location='/api/backup?k='+encodeURIComponent(token);toast('Baixando backup cifrado…');return;}if(VIEWS[cmd]){switchView(cmd);return;}runCmd(cmd,b,e);};box.appendChild(b);});window.lucide&&lucide.createIcons();}
+let _serious=false;
+function applySerious(on){on=!!on;document.body.classList.toggle('serious',on);
+  if(on===_serious)return;_serious=on;
+  const fx=$('#serfx');if(fx){fx.classList.remove('sweep');void fx.offsetWidth;fx.classList.add('sweep');}
+  try{if(on&&window.speak)speak('Modo sério ativado.');}catch(e){}}
+function toggleSerious(){const on=!_serious;applySerious(on);
+  fetch('/api/serious',{method:'POST',headers:H(),body:JSON.stringify({on})}).catch(()=>{});}
 async function loadPanel(){const _t0=(window.performance||Date).now();try{const r=await fetch('/api/panel',{headers:H()});if(!r.ok)return;_counts=await r.json();
+  applySerious(_counts.serious);
   renderStats();$('#s-prov').textContent=_counts.provider;$('#s-model').textContent=_counts.model;$('#prov').value=_counts.provider;updateNBadge(_counts.notifs);
   const lat=Math.round((window.performance||Date).now()-_t0),sl=$('#s-lat');if(sl)sl.textContent='~'+lat+'ms';
   const st=$('#s-status');if(st){st.textContent='ONLINE';st.classList.add('on-dot');}
@@ -2721,7 +2738,7 @@ function filterRows(box,q){if(!box)return;q=(q||'').trim().toLowerCase();let cur
 [['tasks-search','tasklist'],['exp-search','explist'],['rem-search','remlist'],['mem-search','memlist'],['kb-search','kblist'],['lnk-search','lnklist'],['hab-search','hablist'],['jou-search','joulist'],['sub-search','sublist'],['orc-search','orclist'],['mon-search','monlist'],['act-search','actlist']].forEach(p=>{const inp=document.getElementById(p[0]);if(inp)inp.oninput=()=>filterRows(document.getElementById(p[1]),inp.value);});
 // command palette (Ctrl/Cmd+K)
 const CK=$('#cmdk'),CKI=$('#ck-input'),CKL=$('#ck-list');let ckItems=[],ckSel=0;
-function ckBuild(){const nav=[['Conversa',()=>switchView('chat')],['Tarefas',()=>switchView('tasks')],['Gastos',()=>switchView('exp')],['Lembretes',()=>switchView('rem')],['Agenda',()=>switchView('cal')],['Memórias',()=>switchView('mem')],['Links',()=>switchView('lnk')],['Hábitos',()=>switchView('hab')],['Diário',()=>switchView('jou')],['Assinaturas',()=>switchView('sub')],['Orçamentos',()=>switchView('orc')],['Monitores',()=>switchView('mon')],['Base',()=>switchView('kb')],['Cérebro',()=>switchView('brain')],['Pomodoro',()=>openPomo(25)],['Voz ao vivo',()=>$('#vcopen').click()],['Chaves de API',()=>openKeys()]];
+function ckBuild(){const nav=[['Conversa',()=>switchView('chat')],['Tarefas',()=>switchView('tasks')],['Gastos',()=>switchView('exp')],['Lembretes',()=>switchView('rem')],['Agenda',()=>switchView('cal')],['Memórias',()=>switchView('mem')],['Links',()=>switchView('lnk')],['Hábitos',()=>switchView('hab')],['Diário',()=>switchView('jou')],['Assinaturas',()=>switchView('sub')],['Orçamentos',()=>switchView('orc')],['Monitores',()=>switchView('mon')],['Base',()=>switchView('kb')],['Cérebro',()=>switchView('brain')],['Pomodoro',()=>openPomo(25)],['Voz ao vivo',()=>$('#vcopen').click()],['Modo sério (liga/desliga)',()=>toggleSerious()],['Chaves de API',()=>openKeys()]];
   return nav.map(n=>({k:'ir',label:n[0],desc:'abrir',run:n[1]})).concat((COMMANDS||[]).map(c=>({k:'/'+c.name,label:c.name,desc:c.desc,run:()=>runCmd(c.name)})));}
 function ckRender(q){ckItems=ckBuild().filter(i=>(i.label+' '+i.k+' '+i.desc).toLowerCase().includes((q||'').toLowerCase())).slice(0,40);ckSel=0;CKL.textContent='';
   ckItems.forEach((i,ix)=>{const r=el('div','ck-item'+(ix===0?' sel':''));r.appendChild(el('span','ck-k',i.k));r.appendChild(el('span','',i.label));r.appendChild(el('span','ck-d',i.desc||''));r.onclick=()=>{ckClose();i.run();};CKL.appendChild(r);});}
@@ -4245,6 +4262,14 @@ def create_app(config: Config, brain: Brain | None = None):
         except Exception:
             return datetime.now(_tz.utc).date().isoformat()
 
+    # --- modo sério (alerta vermelho) --------------------------------------
+    @app.post("/api/serious")
+    async def serious_set(request: Request):
+        _check(request.headers.get("authorization"))
+        body = await request.json()
+        memory.set_setting("serious_mode", "1" if body.get("on") else "0")
+        return {"ok": True, "serious": bool(body.get("on"))}
+
     # --- home dashboard overview -------------------------------------------
     @app.get("/api/overview")
     async def overview_ep(request: Request):
@@ -4889,6 +4914,7 @@ def create_app(config: Config, brain: Brain | None = None):
             "notifs": memory.unread_notifications(owner),
             "provider": prov,
             "model": model,
+            "serious": memory.get_setting("serious_mode") == "1",
         }
 
     # groups shown in the "brain" graph: (key, hub label, view to jump to on

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -53,6 +53,17 @@ def _auth():
     return {"Authorization": "Bearer secret"}
 
 
+def test_serious_mode(tmp_path):
+    client, _ = _client(tmp_path)
+    assert client.get("/api/panel", headers=_auth()).json()["serious"] is False
+    assert client.post("/api/serious", json={"on": True}).status_code == 401  # needs auth
+    r = client.post("/api/serious", json={"on": True}, headers=_auth()).json()
+    assert r["serious"] is True
+    assert client.get("/api/panel", headers=_auth()).json()["serious"] is True
+    client.post("/api/serious", json={"on": False}, headers=_auth())
+    assert client.get("/api/panel", headers=_auth()).json()["serious"] is False
+
+
 def test_overview_dashboard(tmp_path):
     client, _ = _client(tmp_path)
     client.post("/api/cmd", json={"command": "tarefa comprar pão"}, headers=_auth())


### PR DESCRIPTION
## 🤔 Context

Novo **modo sério** da E.V., acionável por **chat e voz**:

- **Interface azul → vermelha**: a classe `body.serious` troca `--accent`/`--glow`, recolorindo **toda a UI de uma vez** (orb, emblema, marca, botões, anéis, chips…), com um **sweep de alerta** e uma **vinheta vermelha** persistente enquanto ativo.
- **Muda o jeito de responder**: com o modo ligado, o `_system_instruction` injeta uma diretriz de tom **direto, tático, sem piadas/emojis**.
- **Gatilho universal**: ferramenta de IA `modo_serio(ativar)` (Gemini AFC + schema Groq) entende *"modo sério"*, *"fica séria"*, *"modo de combate"*, *"volta ao normal"* — no **chat, na voz e no Telegram**.
- **Cross-canal**: estado em `settings` (`serious_mode`); a web aplica via `loadPanel` (SSE) → recolore quase instantâneo mesmo se ativado pelo Telegram. Toggle local instantâneo + entrada na paleta de comandos (`Cmd/Ctrl+K`) + `POST /api/serious`.

## Visual

Verificado ao vivo: `toggleSerious()` → `body.serious`, `--accent` vira `#ff3b46`, `panel.serious=true`, sweep tocando, zero erros de console. Toda a tela ficou vermelha.

## Test
`test_serious_mode` (endpoint + flag no panel). 185 verdes.

> [!NOTE]
> Deploy manual via `workflow_dispatch`.