### PR TITLE
feat: comando /modo (renomeia /serio) + na lista de comandos

### DIFF
--- a/ev/core/commands.py
+++ b/ev/core/commands.py
@@ -24,6 +24,7 @@ from .timeparse import add_months, parse_when
 
 # (command, description) — also used to populate Telegram's command menu.
 COMMAND_LIST = [
+    ("modo", "Liga/desliga o MODO SÉRIO (interface vermelha, tom tático)"),
     ("menu", "Abre o menu interativo com botões"),
     ("ev", "Falar com a IA (útil em grupos): /ev sua mensagem"),
     ("plano", "Resolve minha manhã: plano do dia (tarefas + agenda + clima)"),
@@ -189,6 +190,7 @@ class Commands:
         on the user's behalf (voice/text). Interface-only commands (documento,
         exportar, status, foco, silenciar, limpar*, dados) are handled elsewhere."""
         return {
+            "modo": lambda u, a: self.modo(u, a),
             "tarefa": lambda u, a: self.tarefa(u, a),
             "tarefas": lambda u, a: self.tarefas(u, a),
             "concluir": lambda u, a: self.concluir(u, a),
@@ -1093,6 +1095,20 @@ class Commands:
                 "automations": len(self._memory.list_automations(user_id)),
             },
         }
+
+    def modo(self, user_id: str, argstr: str = "") -> str:
+        """Liga/desliga o modo sério. argstr: on/off (vazio = alterna)."""
+        arg = (argstr or "").strip().lower()
+        cur = self._memory.get_setting("serious_mode") == "1"
+        if arg in ("on", "ligar", "ativar", "serio", "sério"):
+            on = True
+        elif arg in ("off", "desligar", "desativar", "normal"):
+            on = False
+        else:
+            on = not cur
+        self._memory.set_setting("serious_mode", "1" if on else "0")
+        return ("🔴 Modo sério ativado. Foco total."
+                if on else "Modo sério desativado. De volta ao normal.")
 
     def subscriptions_due(self, user_id: str, days_ahead: int = 2) -> list:
         """Recurring charges (assinaturas) whose due-day falls within the next

--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -1414,7 +1414,7 @@ f.onsubmit=e=>{e.preventDefault();if(slash.style.display==='block'&&slSel>=0){pi
   if(_pendingImg){const img=_pendingImg;setPendingImg(null);txt.value='';hideSlash();sendImage(img,m);return;}
   txt.value='';hideSlash();if(!m)return;sfx('send');
   if(m.startsWith('/')){const raw=m.slice(1).trim().toLowerCase();
-    if(raw==='serio'||raw==='sério'||raw.startsWith('serio ')||raw.startsWith('sério ')){
+    if(raw==='modo'||raw.startsWith('modo ')){
       const arg=raw.split(/\s+/)[1]||'';const on=arg==='off'?false:arg==='on'?true:!_serious;
       applySerious(on);fetch('/api/serious',{method:'POST',headers:H(),body:JSON.stringify({on})}).catch(()=>{});
       sys(on?'Modo sério ativado.':'Modo sério desativado.');return;}


### PR DESCRIPTION
## 🤔 Context

Dois pedidos:
1. **Renomear** o comando de `/serio` → **`/modo`**.
2. Fazer ele **aparecer na lista de comandos** (a barra "/").

Registrei `modo` no `COMMAND_LIST` e no `_dispatch` do `Commands` — então agora ele aparece no menu de comandos, funciona no **Telegram** e via **IA**, além do web. `/modo` alterna · `/modo on` liga · `/modo off` desliga. (A ativação por voz/linguagem natural — "modo sério", "fica séria" — segue funcionando.)

## Test
`modo` presente no COMMAND_LIST e no dispatch; alterna/on/off verificados. 185 testes verdes.

> [!NOTE]
> Deploy manual via `workflow_dispatch`.