### PR TITLE
feat(voz): Gemini TTS (mais natural) com fallback pro edge-tts

### DIFF
--- a/ev/config.py
+++ b/ev/config.py
@@ -42,6 +42,9 @@ class Config:
     voice_rate: str
     voice_pitch: str
     voice_fixes: tuple[tuple[str, str], ...]  # TTS-only pronunciation fixes
+    gemini_tts: bool          # use Gemini TTS (mais natural) c/ fallback pro edge-tts
+    gemini_tts_voice: str     # voz pré-definida do Gemini (Kore, Aoede, Leda, ...)
+    gemini_tts_model: str     # modelo de TTS do Gemini
     # Local model (Ollama) — never-runs-out safety net
     ollama_enabled: bool
     ollama_base_url: str
@@ -196,6 +199,10 @@ class Config:
             voice=os.getenv("EV_VOICE", "pt-BR-FranciscaNeural").strip(),
             voice_rate=os.getenv("EV_VOICE_RATE", "+0%").strip(),
             voice_pitch=os.getenv("EV_VOICE_PITCH", "+0Hz").strip(),
+            gemini_tts=_get_bool("EV_GEMINI_TTS", False),
+            gemini_tts_voice=os.getenv("EV_GEMINI_VOICE", "Kore").strip() or "Kore",
+            gemini_tts_model=os.getenv(
+                "EV_GEMINI_TTS_MODEL", "gemini-2.5-flash-preview-tts").strip(),
             voice_fixes=tuple(
                 tuple(p.split("=", 1))  # type: ignore[misc]
                 for p in os.getenv("EV_VOICE_FIXES", "").split(";")

--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -3413,12 +3413,10 @@ def create_app(config: Config, brain: Brain | None = None):
         except Exception:
             phrase = "Bem-vindo de volta, Ryan. Sistemas online, tudo pronto pra você."
         try:
-            mp3 = await voice_mod.synthesize(
-                phrase, config.voice, rate=config.voice_rate,
-                pitch=config.voice_pitch, fixes=config.voice_fixes)
+            audio, mime = await voice_mod.synth_web(config, phrase)
         except Exception:
-            mp3 = b""
-        return R(content=mp3, media_type="audio/mpeg")
+            audio, mime = b"", "audio/mpeg"
+        return R(content=audio, media_type=mime)
 
     @app.get("/api/health")
     async def health_ep():
@@ -5074,15 +5072,13 @@ def create_app(config: Config, brain: Brain | None = None):
         text = (d.get("text") or "").strip()
         if not text:
             raise HTTPException(status_code=400, detail="empty")
-        # optional per-request overrides (used by the voice picker for previews)
-        voice = d.get("voice") or config.voice
-        if not str(voice).startswith("pt-BR"):
-            voice = config.voice
-        rate = d.get("rate") or config.voice_rate
-        pitch = d.get("pitch") or config.voice_pitch
-        mp3 = await voice_mod.synthesize(
-            text[:1200], voice, rate=rate, pitch=pitch, fixes=config.voice_fixes)
-        return Response(content=mp3, media_type="audio/mpeg")
+        # optional per-request overrides (voice picker previews force edge-tts)
+        req_voice = d.get("voice")
+        voice = req_voice if str(req_voice or "").startswith("pt-BR") else None
+        audio, mime = await voice_mod.synth_web(
+            config, text[:1200], voice=voice,
+            rate=d.get("rate"), pitch=d.get("pitch"))
+        return Response(content=audio, media_type=mime)
 
     @app.get("/api/voice")
     async def voice_get(request: Request):

--- a/ev/providers/voice.py
+++ b/ev/providers/voice.py
@@ -13,9 +13,13 @@ the user reads. Configure via EV_VOICE_FIXES, e.g. "Ryan=Rian;Nome=Fonetico".
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import re
 
 import edge_tts
+
+log = logging.getLogger("ev.voice")
 
 
 def _apply_fixes(text: str, fixes) -> str:
@@ -98,3 +102,66 @@ async def synthesize(
         if chunk["type"] == "audio":
             audio.extend(chunk["data"])
     return bytes(audio)
+
+
+def _wav(pcm: bytes, rate: int = 24000) -> bytes:
+    """Wrap raw PCM (mono, 16-bit) in a WAV container — Gemini TTS returns PCM."""
+    import io
+    import wave
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(rate)
+        w.writeframes(pcm)
+    return buf.getvalue()
+
+
+def _gemini_tts_sync(text: str, api_key: str, voice: str, model: str) -> bytes:
+    """Synthesize with Gemini TTS -> WAV bytes. Raises on any failure so the
+    caller can fall back to edge-tts."""
+    from google import genai
+    from google.genai import types
+    client = genai.Client(api_key=api_key)
+    resp = client.models.generate_content(
+        model=model,
+        contents=text,
+        config=types.GenerateContentConfig(
+            response_modalities=["AUDIO"],
+            speech_config=types.SpeechConfig(
+                voice_config=types.VoiceConfig(
+                    prebuilt_voice_config=types.PrebuiltVoiceConfig(voice_name=voice)
+                )
+            ),
+        ),
+    )
+    raw = resp.candidates[0].content.parts[0].inline_data.data
+    if isinstance(raw, str):
+        import base64
+        raw = base64.b64decode(raw)
+    if not raw:
+        raise ValueError("Gemini TTS returned empty audio")
+    return _wav(raw)
+
+
+async def synth_web(config, text: str, voice: str | None = None,
+                    rate: str | None = None, pitch: str | None = None,
+                    fixes=None) -> tuple[bytes, str]:
+    """Return (audio_bytes, mime) for the web. Uses Gemini TTS when enabled
+    (mais natural); cai no edge-tts (Thalita/Francisca) em qualquer erro/quota.
+    Um `voice` pt-BR explícito (preview do seletor) força o edge-tts."""
+    fixes = config.voice_fixes if fixes is None else fixes
+    rate = rate or config.voice_rate
+    pitch = pitch or config.voice_pitch
+    explicit = bool(voice)
+    if getattr(config, "gemini_tts", False) and config.gemini_api_key and not explicit:
+        try:
+            spoken = _apply_fixes(say_name(clean_for_speech(text)), fixes) or "..."
+            data = await asyncio.to_thread(
+                _gemini_tts_sync, spoken, config.gemini_api_key,
+                config.gemini_tts_voice, config.gemini_tts_model)
+            return data, "audio/wav"
+        except Exception:
+            log.warning("Gemini TTS indisponível; usando edge-tts", exc_info=True)
+    mp3 = await synthesize(text, voice or config.voice, rate=rate, pitch=pitch, fixes=fixes)
+    return mp3, "audio/mpeg"


### PR DESCRIPTION
Adiciona **Gemini TTS** como voz principal (usa a chave Gemini que já existe, sem custo novo), com **fallback automático pro edge-tts** (Thalita) em qualquer erro/quota/modelo indisponível — então nada quebra.

- `voice.synth_web()` → tenta Gemini, cai no edge; PCM do Gemini vira WAV.
- `/api/tts` e `/api/greeting` devolvem o content-type certo. Preview do seletor força edge.
- Config: `EV_GEMINI_TTS`, `EV_GEMINI_VOICE`, `EV_GEMINI_TTS_MODEL`.

Vou habilitar e validar no VM (chave real). 185 testes verdes.

> [!NOTE]
> Deploy manual via workflow_dispatch.