### PR TITLE
docs: atualiza documentação (terminal, modo serious, Spotify, Gemini TTS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,11 @@ EV_VOICE_PITCH=+0Hz
 # separated "from=to". Ex so the PT-BR voice says names right: Ryan=Rian
 EV_VOICE_FIXES=
 
+# Gemini TTS (optional, more natural than edge-tts). Uses GEMINI_API_KEY —
+# no separate key needed. Falls back to edge-tts on any error/quota limit.
+EV_GEMINI_TTS=false
+EV_GEMINI_VOICE=Kore
+
 # --- Fallback providers (optional) ---
 # If set, E.V. falls back to these when Gemini is rate-limited.
 # Leave empty to disable a provider.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ hands — loyal, warm, playful, and always on your side.
 ![Telegram](https://img.shields.io/badge/Bot-Telegram-1a1a1a?logo=telegram&logoColor=white)
 ![LLMs](https://img.shields.io/badge/LLMs-Gemini·Groq·OpenRouter-1a1a1a)
 ![SQLite](https://img.shields.io/badge/Memory-SQLite%20+%20vectors-1a1a1a?logo=sqlite&logoColor=white)
-![Tests](https://img.shields.io/badge/tests-133%20passing-2e7d32)
+![Tests](https://img.shields.io/badge/tests-185%20passing-2e7d32)
 [![Deploy](https://github.com/Ryanditko/E.V/actions/workflows/deploy.yml/badge.svg)](https://github.com/Ryanditko/E.V/actions/workflows/deploy.yml)
 
 **[Features](#what-she-does) · [Architecture](#architecture) · [Web console](#the-web-console) · [Quick start](#quick-start) · [Deploy 24/7](#run-her-24-7) · [Docs](#documentation)**
@@ -67,9 +67,18 @@ is recalled on the phone.
 
 **Real tools & reach**
 - Web search (**Tavily → Brave → DuckDuckGo**), web-page indexing, document generation
- (PDF/Word), and — with setup — **Google Calendar & Gmail**.
+ (PDF/Word), **Spotify** playback control (web console), and — with setup — **Google
+ Calendar & Gmail**.
 - **Hands-free**: she can *run* any command herself (create/edit/delete) from chat or voice.
 - **Owner-locked** to you (`EV_OWNER_ID`) and works in Telegram topic groups on mention.
+
+**Web console extras**
+- A **terminal de ação** shows her thinking → acting → result per step for a command.
+- **Modo Morte Súbita** — a focus-mode visual toggle (red/high-contrast) with a
+  persistent header badge.
+- Proactive alerts (subscriptions due, budgets over) surface in the notification center;
+  a **Cmd/Ctrl+K** searches your actual data, not just views; dashboard cards are
+  draggable to reorder.
 
 **Runs like a product**
 - **CI/CD** (test-gated auto-deploy), **systemd** services, a **watchdog** that restarts
@@ -297,7 +306,7 @@ E.V/
 │       └── terminal.py      # terminal REPL
 ├── deploy/                  # setup_vm.sh · watchdog.sh · HTTPS runbooks
 ├── docs/                    # full documentation (index below)
-└── tests/                   # 133 tests across 14 files
+└── tests/                   # 185 tests
 ```
 
 ---
@@ -305,7 +314,7 @@ E.V/
 ## Testing
 
 ```bash
-./.venv/bin/python -m pytest -q      # 133 passing
+./.venv/bin/python -m pytest -q      # 185 passing
 ```
 
 CI runs the suite as a **gate before every deploy** — a red test never ships.
@@ -342,9 +351,9 @@ CI runs the suite as a **gate before every deploy** — a red test never ships.
 ## Built with
 
 `Python 3` · `FastAPI` + `uvicorn` · `python-telegram-bot` · `SQLite` · `edge-tts` ·
-`Groq Whisper` · `Google Gemini` · `Groq` · `OpenRouter` · `Ollama` · `pypdf` ·
-`python-docx` · `reportlab` · `Tavily/Brave/DuckDuckGo` · `Tailscale` · `systemd` ·
-`GitHub Actions` · `Lucide` · `pytest`
+`Gemini TTS` · `Groq Whisper` · `Google Gemini` · `Groq` · `OpenRouter` · `Ollama` ·
+`pypdf` · `python-docx` · `reportlab` · `Tavily/Brave/DuckDuckGo` · `Spotify Web API` +
+`Web Playback SDK` · `Tailscale` · `systemd` · `GitHub Actions` · `Lucide` · `pytest`
 
 ---
 
@@ -359,6 +368,10 @@ CI runs the suite as a **gate before every deploy** — a red test never ships.
 - [x] **Web console** (JARVIS-style) with browser voice via Whisper
 - [x] **Private HTTPS** via Tailscale (mic, PiP, notifications unlocked)
 - [x] CI/CD + watchdog + backups
+- [x] **Terminal de ação** (V1) — see the action per step, not just the final reply
+- [x] **Modo Morte Súbita** focus toggle + **Spotify** playback control
+- [x] Dashboard drag-reorder, today summary, content search (Cmd/Ctrl+K), proactive
+      notification alerts
 - [ ] Google Calendar & Gmail live (needs OAuth authorization)
 - [ ] Login via Google/GitHub on the web
 

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -28,7 +28,12 @@ She is **locked to you** (owner-only) and replies with a natural female voice.
 > for every data type with edit and recurrence. It's served privately over HTTPS via
 > **Tailscale Serve** (`https://ev.<tailnet>.ts.net`, reachable only from your Tailscale
 > devices, no open ports) — which is what unlocks the browser microphone, Picture-in-Picture
-> and notifications. See [WEB.md](WEB.md) and [../deploy/HTTPS_TAILSCALE.md](../deploy/HTTPS_TAILSCALE.md).
+> and notifications. The web console adds a few things Telegram doesn't have: a
+> **terminal de ação** that shows her thinking/acting/result per step, a **Modo Morte
+> Súbita** focus toggle, **Spotify** playback (including acting as the playback device
+> herself), draggable dashboard cards with a today-at-a-glance summary, and a
+> **Cmd/Ctrl+K** that searches your actual data, not just views. See [WEB.md](WEB.md) and
+> [../deploy/HTTPS_TAILSCALE.md](../deploy/HTTPS_TAILSCALE.md).
 
 ## 2. What she does in conversation (AI)
 
@@ -177,7 +182,7 @@ on it. (When you ask via the AI, she can also save it in the same step.)
 | Command | Does |
 |---------|------|
 | `/buscar <termo>` | Web search (with sources) |
-| `/procurar <termo>` | Search across YOUR data (memory, tasks, links, journal, KB...) |
+| `/procurar <termo>` | Search across YOUR data (memory, tasks, links, journal, KB, expenses, messages...) — same engine the web console's Cmd/Ctrl+K uses |
 | `/noticias [assunto]` | Latest news with sources + TabNews (tech) |
 | `/clima [cidade]` | Real weather forecast (today + next days) |
 
@@ -210,7 +215,9 @@ on it. (When you ask via the AI, she can also save it in the same step.)
 | Every ~30 min | Checks web monitors (`/vigiar`) and alerts on real changes |
 | Weekly + on restart | Sends a **DB backup** to your Telegram (off-VM copy) |
 
-All hours/days are configurable in `.env`.
+All hours/days are configurable in `.env`. On the **web console**, subscriptions due
+soon and over-budget categories also show up proactively in the notification center as
+soon as you open it — computed fresh each time, not a scheduled push.
 
 ## 5. What she stores (your data, local SQLite)
 
@@ -227,6 +234,10 @@ Everything is add / list / delete — you can undo anything.
 - **Fallbacks (auto):** Groq (`openai/gpt-oss-120b`, reliable tools) → OpenRouter
  (Nemotron) → **Ollama** (local, never rate-limited — if enabled on a capable host).
 - **Audio transcription:** Groq Whisper. **Embeddings:** Gemini `gemini-embedding-001`.
+- **Voice output:** **edge-tts** (Microsoft neural pt-BR voice, free, no key) by default;
+ optionally **Gemini TTS** (more natural) when `EV_GEMINI_TTS=true` or a specific Gemini
+ voice is picked in the voice selector — falls back to edge-tts automatically on any
+ error or quota limit.
 - If a provider hits its limit, she falls through automatically — she rarely goes
  silent. `/modelo` shows what's active and today's usage.
 

--- a/docs/KEYS.md
+++ b/docs/KEYS.md
@@ -49,6 +49,27 @@ Full guide: [GOOGLE.md](GOOGLE.md). Free, but Google Cloud may ask for billing (
 |---------|----------|------|
 | **open-meteo** | Weather forecast + rain alerts | https://open-meteo.com |
 
+## Spotify (optional — web console playback)
+
+| Step | Link |
+|------|------|
+| Create an app (Client ID + Secret) | https://developer.spotify.com/dashboard |
+| Add a redirect URI matching your web console URL + `/spotify/callback` | Dashboard → app → Settings |
+
+`.env`: `EV_SPOTIFY_CLIENT_ID`, `EV_SPOTIFY_CLIENT_SECRET`. Then connect from the web
+console (Música tab → "Conectar Spotify") — one-time OAuth per user. Free; requires a
+Spotify account (Premium needed for playback control, per Spotify's own API rules).
+
+## Gemini TTS (optional — more natural voice than edge-tts)
+
+| `.env` variable | What for | Default |
+|-----------------|----------|---------|
+| `EV_GEMINI_TTS` | Set `true` to prefer Gemini's native voice over edge-tts | `false` |
+| `EV_GEMINI_VOICE` | Which Gemini voice (`Kore`, `Aoede`, `Leda`, ...) | `Kore` |
+
+Uses the same `GEMINI_API_KEY` — no separate key needed. Falls back to edge-tts
+automatically on any error or quota limit.
+
 ## Hosting (run E.V. 24/7)
 
 | Option | Link | Cost / card? |

--- a/docs/STACK.md
+++ b/docs/STACK.md
@@ -16,7 +16,7 @@ throughout; nothing here requires a paid plan for personal use.
 | Fallback 3 (local) | **Ollama** | `llama3.1` (disabled on the 1 GB VM) |
 | Speech-to-text | **Groq Whisper** | `whisper-large-v3-turbo` (pt-BR) |
 | Embeddings | **Google Gemini** | `gemini-embedding-001` (semantic memory / RAG) |
-| Text-to-speech | **edge-tts** | Microsoft neural pt-BR voice (free, no key) |
+| Text-to-speech | **edge-tts** (default) / **Gemini TTS** (optional, `EV_GEMINI_TTS=true`) | Microsoft neural pt-BR voice (free, no key) / Gemini native voices (Kore, Aoede, Leda...), falls back to edge-tts on error/quota |
 
 ## Python libraries (`requirements.txt`)
 - **Interfaces:** `python-telegram-bot` (bot), `FastAPI` + `uvicorn` + `python-multipart` (web).
@@ -45,6 +45,8 @@ throughout; nothing here requires a paid plan for personal use.
 - **Tavily → Brave → DuckDuckGo** search chain.
 - **open-meteo** (weather), news via DuckDuckGo/TabNews.
 - **Google Calendar & Gmail** (optional, OAuth).
+- **Spotify** (optional, OAuth + Web Playback SDK) — now-playing, playback control,
+  search/queue/playlists, and E.V. can act as a playback device herself.
 
 ## Networking & access
 - **Tailscale** (`cloudflared` alternative documented) — private HTTPS to the web

--- a/docs/WEB.md
+++ b/docs/WEB.md
@@ -27,6 +27,29 @@ Telegram bot.
 - Customizable quick-actions + "Sistema" stat panels, Pomodoro (focus + break),
   clickable links everywhere, PDF/Word open & download from the KB, API-key manager
   (`/api/keys`), in-app confirm/edit modals, favicon, full responsiveness.
+- **Terminal de ação** — a draggable/resizable floating window (desktop only) that shows
+  E.V. "thinking → acting → result" as she runs a command, instead of just the final
+  chat reply. Opened from the chat input; geometry (width/height) persists across
+  sessions via `localStorage['ev_term_geo']`. V1 renders each step after it completes
+  (not truly live token-by-token) — see the "Terminal V1 vs. future streaming" note below.
+- **Modo Morte Súbita ("serious mode")** — a visual tone toggle (`/serious`, the header
+  skull button, or `#mm-badge`) that hue-rotates the whole UI to red/high-contrast for
+  focus sessions. State persists server-side (`/api/serious`) and a pulsing badge stays
+  visible in the header for as long as it's active, so it's obvious at a glance which
+  mode you're in.
+- **Spotify** — connect your account (`/spotify/connect`, OAuth) to see now-playing,
+  control playback, search and queue tracks, browse playlists, and embed a Spotify
+  widget on the dashboard. With the **Web Playback SDK**, E.V. can become a playback
+  device herself (`/api/spotify/transfer`) so you can control Spotify from the lock
+  screen through her.
+- **Dashboard (início)**: cards are draggable to reorder (pointer events, order persists
+  in `localStorage['ev_ov_order']`), and the hero area shows a **today summary** (next
+  reminder + first open task) at a glance.
+- **Cmd/Ctrl+K** searches both views (navigation) **and** your content — tasks, expenses,
+  reminders, memories, journal, links, and recent messages — via `/api/search`.
+- **Notification center** surfaces proactive alerts (subscription due soon, budget over
+  threshold) alongside regular notifications — computed fresh on every load, not stored,
+  so there's no stale/duplicate state to manage.
 
 ## Run it locally
 
@@ -69,6 +92,21 @@ travels in cleartext).
 
 `/` (UI) · `/api/chat` · `/api/cmd` · `/api/stt` (voice→text) · `/api/tts` (text→voice) ·
 `/api/greeting` · `/api/panel` · `/api/config` · `/api/keys` · `/api/threads` (folders) ·
-`/api/history` · plus per-type CRUD under `/api/{tasks,expenses,reminders,facts,links,
-habits,journal,recurring,budgets,watches,kb}` (list/create/update/delete). All require
-the bearer token except the static page and favicon.
+`/api/history` · `/api/search` (Cmd/Ctrl+K content search) · `/api/notifications`
+(regular + ephemeral proactive alerts) · `/api/serious` (serious-mode on/off) ·
+`/spotify/connect` + `/api/spotify/*` (status, nowplaying, control, play, queue, search,
+playlists, devices, transfer, token, disconnect) · plus per-type CRUD under
+`/api/{tasks,expenses,reminders,facts,links,habits,journal,recurring,budgets,watches,kb}`
+(list/create/update/delete). All require the bearer token except the static page and
+favicon.
+
+## Terminal V1 vs. future streaming
+
+The action terminal (V1, shipped) renders each step of a command run — thinking, the
+action taken, the result — as it *completes*, reusing the same `respond()` path every
+other channel uses. It is **not** true token-by-token or live sub-step streaming: for a
+single fast command there's little visible difference from the normal chat reply. A
+"Phase 2" rewrite (true real-time AFC streaming, live narration between actions, a real
+pre-action interrupt) would matter most for long multi-step tasks, but touches the core
+`respond()` path used by Telegram, web and terminal alike — real risk for a benefit that's
+mostly about long-running work. Not planned for now.


### PR DESCRIPTION
## 🤔 Context

Várias features shippadas em sessões anteriores nunca chegaram a ser documentadas: o terminal de ação, o Modo Morte Súbita, a integração com Spotify (incluindo Web Playback SDK) e o Gemini TTS como alternativa ao edge-tts. Essa PR fecha essa lacuna antes de uma pausa longa no desenvolvimento da E.V., cobrindo:

- `docs/WEB.md` — terminal de ação, modo serious, Spotify, e os 6 refinamentos de interface mais recentes (persistência, drag-reorder, resumo do dia, busca de conteúdo, notificações proativas).
- `docs/CAPABILITIES.md` — menção ao Gemini TTS como voz alternativa e aos extras do console web.
- `docs/KEYS.md` + `.env.example` — variáveis do Spotify (`EV_SPOTIFY_CLIENT_ID/SECRET`, já existiam no `.env.example` mas sem doc) e do Gemini TTS (`EV_GEMINI_TTS`, `EV_GEMINI_VOICE`, que não existiam em nenhum dos dois lugares).
- `docs/STACK.md` + `README.md` — contagem de testes atualizada (133→185) e inventário de stack/roadmap refletindo o que já está em produção.

> [!NOTE]
> Só documentação — nenhuma mudança de código nesta PR.