### PR TITLE
Add local-PC task execution with mandatory human approval

### DIFF
--- a/ev/core/brain.py
+++ b/ev/core/brain.py
@@ -952,10 +952,38 @@ class Brain:
             dia', 'organiza meu dia', 'o que eu faço hoje'."""
             return self._plan_day_sync(user_id)
 
+        def solicitar_tarefa_local(tipo: str, descricao: str, comando: str = "") -> str:
+            """Pede para EXECUTAR algo no computador pessoal do usuário (não no
+            servidor da E.V.): rodar um script já cadastrado por ele, abrir um
+            app/arquivo, automatizar o navegador, ou rodar um comando de shell.
+            NUNCA executa nada sozinha — isso só cria um pedido pendente que o
+            usuário precisa aprovar manualmente (no console web, com fallback
+            pelo Telegram). Use quando ele pedir explicitamente para 'rodar no
+            meu pc', 'abrir X no computador', 'executa esse script pra mim'.
+
+            Args:
+                tipo: 'script' (um script já cadastrado por nome), 'open' (abrir
+                    app/arquivo/pasta), 'browser' (automação de navegador) ou
+                    'shell' (comando livre — maior risco, sempre aprovado à mão).
+                descricao: frase curta explicando o que a tarefa faz, mostrada ao
+                    usuário na hora de aprovar (ex: "abrir o VS Code no projeto X").
+                comando: o script/comando/URL/instrução em si.
+            """
+            kind = (tipo or "").strip().lower()
+            if kind not in ("script", "open", "browser", "shell"):
+                return "tipo inválido — use script, open, browser ou shell"
+            tid = self._memory.add_local_task(
+                user_id, kind, (descricao or comando or "tarefa local")[:200],
+                {"command": comando or ""},
+            )
+            return (f"pedido #{tid} criado — preciso que você aprove pelo console "
+                    f"da E.V. (ou pelo Telegram) antes de rodar isso no seu computador")
+
         callables: dict = {
             "modo_serio": modo_serio,
             "executar_comando": executar_comando,
             "planejar_dia": planejar_dia,
+            "solicitar_tarefa_local": solicitar_tarefa_local,
             "criar_automacao": criar_automacao,
             "consultar_conector": consultar_conector,
             "criar_pagina": criar_pagina,
@@ -1062,6 +1090,23 @@ class Brain:
                 "Monta um plano acionável do dia do usuário juntando tarefas, "
                 "lembretes, agenda, clima e localização. Use para 'resolve minha "
                 "manhã', 'plano do dia', 'organiza meu dia', 'o que faço hoje'.",
+            ),
+            fn(
+                "solicitar_tarefa_local",
+                "Pede para executar algo no computador pessoal do usuário (script "
+                "cadastrado, abrir app/arquivo, automação de navegador ou shell "
+                "livre). NUNCA executa sozinha — cria um pedido pendente que o "
+                "usuário precisa aprovar manualmente (console web, fallback "
+                "Telegram). Use para 'roda isso no meu pc', 'abre X no computador'.",
+                {
+                    "tipo": {"type": s, "description":
+                             "script, open, browser ou shell"},
+                    "descricao": {"type": s, "description":
+                                  "frase curta do que a tarefa faz"},
+                    "comando": {"type": s, "description":
+                                "o script/comando/URL/instrução em si"},
+                },
+                ["tipo", "descricao"],
             ),
             fn(
                 "tocar_playlist",

--- a/ev/core/memory.py
+++ b/ev/core/memory.py
@@ -340,6 +340,29 @@ class Memory:
                 data     BLOB NOT NULL,
                 created  TEXT NOT NULL
             );
+
+            CREATE TABLE IF NOT EXISTS local_scripts (
+                id       INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id  TEXT NOT NULL,
+                name     TEXT NOT NULL,
+                command  TEXT NOT NULL,
+                created  TEXT NOT NULL,
+                UNIQUE(user_id, name)
+            );
+
+            CREATE TABLE IF NOT EXISTS local_tasks (
+                id       INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id  TEXT NOT NULL,
+                kind     TEXT NOT NULL,
+                label    TEXT NOT NULL,
+                payload  TEXT NOT NULL DEFAULT '{}',
+                status   TEXT NOT NULL DEFAULT 'pending',
+                result   TEXT,
+                notified INTEGER NOT NULL DEFAULT 0,
+                created  TEXT NOT NULL,
+                decided  TEXT,
+                finished TEXT
+            );
             """
         )
         # Migrations for older DBs.
@@ -512,6 +535,117 @@ class Memory:
         self._conn.execute("UPDATE automations SET state = ? WHERE id = ?",
                            (json.dumps(state), auto_id))
         self._conn.commit()
+
+    # --- local scripts (allowlist for the local execution agent) -----------
+
+    def add_local_script(self, user_id: str, name: str, command: str) -> int:
+        cur = self._conn.execute(
+            "INSERT INTO local_scripts (user_id, name, command, created) "
+            "VALUES (?, ?, ?, ?)",
+            (user_id, name, command, self._now()),
+        )
+        self._conn.commit()
+        return int(cur.lastrowid)
+
+    def list_local_scripts(self, user_id: str) -> list[dict]:
+        rows = self._conn.execute(
+            "SELECT id, name, command, created FROM local_scripts "
+            "WHERE user_id = ? ORDER BY name", (user_id,)).fetchall()
+        return [dict(r) for r in rows]
+
+    def delete_local_script(self, user_id: str, script_id: int) -> bool:
+        cur = self._conn.execute(
+            "DELETE FROM local_scripts WHERE id = ? AND user_id = ?",
+            (script_id, user_id))
+        self._conn.commit()
+        return cur.rowcount > 0
+
+    # --- local tasks (PC execution queue — always requires approval) -------
+
+    def _local_task_row(self, r) -> dict:
+        d = dict(r)
+        try:
+            d["payload"] = json.loads(d.get("payload") or "{}")
+        except (ValueError, TypeError):
+            d["payload"] = {}
+        try:
+            d["result"] = json.loads(d["result"]) if d.get("result") else None
+        except (ValueError, TypeError):
+            d["result"] = None
+        return d
+
+    def add_local_task(self, user_id: str, kind: str, label: str, payload: dict) -> int:
+        cur = self._conn.execute(
+            "INSERT INTO local_tasks (user_id, kind, label, payload, status, created) "
+            "VALUES (?, ?, ?, ?, 'pending', ?)",
+            (user_id, kind, label, json.dumps(payload or {}), self._now()),
+        )
+        self._conn.commit()
+        return int(cur.lastrowid)
+
+    def list_local_tasks(self, user_id: str, status: str | None = None,
+                          limit: int = 50) -> list[dict]:
+        q = ("SELECT id, kind, label, payload, status, result, created, decided, finished "
+             "FROM local_tasks WHERE user_id = ?")
+        args: list = [user_id]
+        if status:
+            q += " AND status = ?"
+            args.append(status)
+        q += " ORDER BY id DESC LIMIT ?"
+        args.append(limit)
+        rows = self._conn.execute(q, tuple(args)).fetchall()
+        return [self._local_task_row(r) for r in rows]
+
+    def get_local_task(self, user_id: str, task_id: int) -> dict | None:
+        row = self._conn.execute(
+            "SELECT id, kind, label, payload, status, result, created, decided, finished "
+            "FROM local_tasks WHERE id = ? AND user_id = ?", (task_id, user_id)).fetchone()
+        return self._local_task_row(row) if row else None
+
+    def unnotified_local_tasks(self) -> list[dict]:
+        """Pending local tasks (any user) that still need a Telegram nudge."""
+        rows = self._conn.execute(
+            "SELECT id, user_id, kind, label, payload, status, created "
+            "FROM local_tasks WHERE status = 'pending' AND notified = 0"
+        ).fetchall()
+        return [self._local_task_row(r) for r in rows]
+
+    def mark_local_task_notified(self, task_id: int) -> None:
+        self._conn.execute(
+            "UPDATE local_tasks SET notified = 1 WHERE id = ?", (task_id,))
+        self._conn.commit()
+
+    def set_local_task_status(self, user_id: str, task_id: int, status: str) -> bool:
+        cur = self._conn.execute(
+            "UPDATE local_tasks SET status = ?, decided = ? "
+            "WHERE id = ? AND user_id = ? AND status = 'pending'",
+            (status, self._now(), task_id, user_id))
+        self._conn.commit()
+        return cur.rowcount > 0
+
+    def claim_local_task(self, user_id: str) -> dict | None:
+        """Atomically hands the oldest approved task to the local agent."""
+        row = self._conn.execute(
+            "SELECT id FROM local_tasks WHERE user_id = ? AND status = 'approved' "
+            "ORDER BY id LIMIT 1", (user_id,)).fetchone()
+        if not row:
+            return None
+        cur = self._conn.execute(
+            "UPDATE local_tasks SET status = 'running' "
+            "WHERE id = ? AND status = 'approved'", (row["id"],))
+        self._conn.commit()
+        if cur.rowcount == 0:
+            return None
+        return self.get_local_task(user_id, row["id"])
+
+    def finish_local_task(self, user_id: str, task_id: int, ok: bool, output: dict) -> bool:
+        cur = self._conn.execute(
+            "UPDATE local_tasks SET status = ?, result = ?, finished = ? "
+            "WHERE id = ? AND user_id = ? AND status = 'running'",
+            ("done" if ok else "failed", json.dumps(output or {}), self._now(),
+             task_id, user_id))
+        self._conn.commit()
+        return cur.rowcount > 0
 
     # --- connectors (user-defined API integrations) ------------------------
 

--- a/ev/interfaces/telegram_bot.py
+++ b/ev/interfaces/telegram_bot.py
@@ -1479,6 +1479,9 @@ class TelegramInterface:
         uid = str(q.from_user.id)
         section, _, action = q.data.partition(":")
 
+        if section == "loctask":
+            await self._handle_loctask(q, uid, action)
+            return
         if section == "docsave":
             await self._save_doc_to_kb(q, uid, action)
             return
@@ -1860,6 +1863,27 @@ class TelegramInterface:
             reply_markup=kb,
         )
 
+    async def _handle_loctask(self, q, uid: str, action: str) -> None:
+        decision, _, tid_s = action.partition(":")
+        try:
+            tid = int(tid_s)
+        except ValueError:
+            return
+        status = "approved" if decision == "aprovar" else "rejected"
+        ok = self._memory.set_local_task_status(uid, tid, status)
+        try:
+            await q.edit_message_reply_markup(reply_markup=None)
+        except Exception:
+            pass
+        if not ok:
+            await q.answer("Esse pedido já foi decidido.", show_alert=True)
+            return
+        await q.answer("Aprovado ✅" if status == "approved" else "Recusado")
+        await q.message.reply_text(
+            "Aprovado — vai rodar no seu computador assim que o executor local sincronizar."
+            if status == "approved" else "Recusado.",
+        )
+
     async def _confirm_expense(self, q, uid: str, eid: str) -> None:
         exp = self._pending_expense.pop(eid, None)
         if exp is None:
@@ -1962,6 +1986,7 @@ class TelegramInterface:
             asyncio.create_task(self._briefing_loop(app)),
             asyncio.create_task(self._backup_loop(app)),
             asyncio.create_task(self._watch_loop(app)),
+            asyncio.create_task(self._loctask_loop(app)),
         ]
         log.info(
             "Schedulers started (reminders every %ss; daily briefing at %sh; daily backup).",
@@ -2502,6 +2527,31 @@ class TelegramInterface:
             text = self._commands.daily_briefing(str(cfg.owner_id))
             await self._bot_send(app.bot, cfg.owner_id, text, self._kb_main())
             log.info("Sent daily briefing to owner.")
+
+    async def _loctask_loop(self, app: Application) -> None:
+        """Telegram fallback for local-PC task approvals: the web console is
+        the primary place to approve, this just makes sure a pending request
+        never gets missed if the user isn't looking at the console."""
+        while True:
+            try:
+                if self._config.owner_id is not None:
+                    for t in self._memory.unnotified_local_tasks():
+                        b = InlineKeyboardButton
+                        kb = InlineKeyboardMarkup([[
+                            b("✅ Aprovar", callback_data=f"loctask:aprovar:{t['id']}"),
+                            b("✖️ Recusar", callback_data=f"loctask:recusar:{t['id']}"),
+                        ]])
+                        await self._bot_send(
+                            app.bot, self._config.owner_id,
+                            f"🖥️ A E.V. quer executar no seu computador:\n"
+                            f"[{t['kind']}] {t['label']}\n\n"
+                            "Isso só roda depois que você aprovar.",
+                            kb,
+                        )
+                        self._memory.mark_local_task_notified(t["id"])
+            except Exception:
+                log.exception("Local task loop error")
+            await asyncio.sleep(20)
 
     async def _reminder_loop(self, app: Application) -> None:
         while True:

--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -1154,6 +1154,17 @@ textarea.minput{resize:vertical;min-height:74px;font-family:var(--body);line-hei
         <div id="brain-menu"></div>
       </div>
     </div>
+    <div id="locview">
+      <div class="tv-h">Executor local · roda no seu computador</div>
+      <div class="tv-empty" style="margin-bottom:10px">Toda tarefa abaixo só executa depois que você aprovar aqui ou no Telegram — a E.V. nunca roda nada sozinha no seu PC.</div>
+      <div class="tv-cat">Pendentes de aprovação</div>
+      <div id="loc-pending"></div>
+      <div class="tv-cat">Histórico</div>
+      <div id="loc-hist"></div>
+      <div class="tv-cat" style="margin-top:18px">Scripts cadastrados (allowlist)</div>
+      <form id="locscriptform" class="tv-form"><input id="locs-name" placeholder="Nome (ex: rodar backup)"><input id="locs-cmd" placeholder="Comando/caminho a executar"><button class="mbtn" type="submit">Cadastrar</button></form>
+      <div id="loc-scripts"></div>
+    </div>
     <div id="chartsview">
       <div class="tv-h">Gráficos · seus dados</div>
       <div class="tv-form" style="gap:8px;flex-wrap:wrap;align-items:center;margin-bottom:14px">
@@ -2165,10 +2176,10 @@ function toggleAmb(){if(!SR){toast('Presença ambiente precisa do Chrome, Edge o
 $('#amb').onclick=toggleAmb;
 renderAmbBtn();
 // view tabs — customizable: pick which appear in the header (minimalist)
-const VIEW_LABELS={chat:'Conversa',inicio:'Início',tasks:'Tarefas',exp:'Gastos',rem:'Lembretes',cal:'Agenda',mem:'Memórias',lnk:'Links',hab:'Hábitos',jou:'Diário',sub:'Assinaturas',orc:'Orçamentos',mon:'Monitores',act:'Histórico',kb:'Base',map:'Mapa',brain:'Cérebro',graf:'Gráficos',musica:'Música',clima:'Clima',metas:'Metas',saude:'Saúde',cofre:'Cofre',painel:'Painel'};
+const VIEW_LABELS={chat:'Conversa',inicio:'Início',tasks:'Tarefas',exp:'Gastos',rem:'Lembretes',cal:'Agenda',mem:'Memórias',lnk:'Links',hab:'Hábitos',jou:'Diário',sub:'Assinaturas',orc:'Orçamentos',mon:'Monitores',act:'Histórico',kb:'Base',map:'Mapa',brain:'Cérebro',graf:'Gráficos',musica:'Música',clima:'Clima',metas:'Metas',saude:'Saúde',cofre:'Cofre',painel:'Painel',loc:'Executor local'};
 // groups only drive tab ORDER + subtle separators in the topbar strip — tabsShown still controls visibility
-const VIEW_GROUPS=[['Principal',['chat','inicio']],['Produtividade',['tasks','rem','cal','hab','jou','metas','saude']],['Financeiro',['exp','sub','orc','cofre']],['Conhecimento',['mem','lnk','kb','brain','act']],['Explorar',['map','graf','musica','clima','mon','painel']]];
-const VIEW_ICONS={chat:'message-square',inicio:'layout-dashboard',tasks:'list-checks',exp:'wallet',rem:'alarm-clock',cal:'calendar',mem:'database',lnk:'link',hab:'repeat',jou:'book-open',sub:'credit-card',orc:'pie-chart',mon:'radar',act:'activity',kb:'library',map:'map',brain:'brain',graf:'bar-chart-3',musica:'music',clima:'cloud-sun',metas:'target',saude:'heart-pulse',cofre:'lock',painel:'layout-panel-top'};
+const VIEW_GROUPS=[['Principal',['chat','inicio']],['Produtividade',['tasks','rem','cal','hab','jou','metas','saude']],['Financeiro',['exp','sub','orc','cofre']],['Conhecimento',['mem','lnk','kb','brain','act']],['Explorar',['map','graf','musica','clima','mon','painel']],['Automação',['loc']]];
+const VIEW_ICONS={chat:'message-square',inicio:'layout-dashboard',tasks:'list-checks',exp:'wallet',rem:'alarm-clock',cal:'calendar',mem:'database',lnk:'link',hab:'repeat',jou:'book-open',sub:'credit-card',orc:'pie-chart',mon:'radar',act:'activity',kb:'library',map:'map',brain:'brain',graf:'bar-chart-3',musica:'music',clima:'cloud-sun',metas:'target',saude:'heart-pulse',cofre:'lock',painel:'layout-panel-top',loc:'terminal'};
 let curView='chat',tabsShown;try{tabsShown=JSON.parse(localStorage.getItem('ev_tabs'));}catch(e){}
 // default to every section — the tab strip scrolls horizontally, so nothing
 // needs to be hidden just to make room; "+" still lets you trim it down.
@@ -2199,7 +2210,7 @@ function openSectionsSheet(){const m=$('#modal');m.textContent='';const card=el(
   const bar=el('div','mbar');const c=el('button','mbtn2','Fechar');c.onclick=()=>m.classList.remove('on');bar.appendChild(c);card.appendChild(bar);
   m.appendChild(card);m.classList.add('on');window.lucide&&lucide.createIcons();}
 $('#mnav').onclick=()=>openSectionsSheet();
-const VIEWS={chat:'#chatview',inicio:'#inicioview',tasks:'#taskview',exp:'#expview',rem:'#remview',cal:'#calview',mem:'#memview',lnk:'#lnkview',hab:'#habview',jou:'#jouview',sub:'#subview',orc:'#orcview',mon:'#monview',kb:'#kbview',act:'#actview',map:'#mapview',brain:'#brainview',graf:'#chartsview',musica:'#musicview',clima:'#climaview',metas:'#metasview',saude:'#saudeview',cofre:'#cofreview',painel:'#painelview'};
+const VIEWS={chat:'#chatview',inicio:'#inicioview',tasks:'#taskview',exp:'#expview',rem:'#remview',cal:'#calview',mem:'#memview',lnk:'#lnkview',hab:'#habview',jou:'#jouview',sub:'#subview',orc:'#orcview',mon:'#monview',kb:'#kbview',act:'#actview',map:'#mapview',brain:'#brainview',graf:'#chartsview',musica:'#musicview',clima:'#climaview',metas:'#metasview',saude:'#saudeview',cofre:'#cofreview',painel:'#painelview',loc:'#locview'};
 function switchView(v){const isPage=(''+v).indexOf('page:')===0;
   if(!isPage&&!VIEWS[v])v='chat';curView=v;document.querySelectorAll('#tabs .tab').forEach(t=>t.classList.toggle('on',t.dataset.view===v));
   document.body.classList.toggle('v-chat',v==='chat');
@@ -2209,7 +2220,7 @@ function switchView(v){const isPage=(''+v).indexOf('page:')===0;
   Object.entries(VIEWS).forEach(([k,sel])=>{const el2=$(sel);if(el2)el2.style.display=(k===v)?((k==='chat'||k==='brain')?'flex':'block'):'none';});
   const pv=$('#pageview');if(pv)pv.style.display=isPage?'block':'none';
   if(isPage){renderPage(v.slice(5));return;}
-  ({inicio:loadInicio,tasks:loadTasks,exp:loadExp,rem:loadRem,mem:loadMem,kb:loadKB,cal:loadCal,lnk:loadLinks,hab:loadHabits,jou:loadJournal,sub:loadSub,orc:loadOrc,mon:loadMon,act:loadAct,map:loadMap,brain:loadBrain,graf:loadCharts,musica:loadMusic,clima:loadClima,metas:loadGoals,saude:loadSaude,cofre:loadCofre,painel:loadPainel}[v]||function(){})();}
+  ({inicio:loadInicio,tasks:loadTasks,exp:loadExp,rem:loadRem,mem:loadMem,kb:loadKB,cal:loadCal,lnk:loadLinks,hab:loadHabits,jou:loadJournal,sub:loadSub,orc:loadOrc,mon:loadMon,act:loadAct,map:loadMap,brain:loadBrain,graf:loadCharts,musica:loadMusic,clima:loadClima,metas:loadGoals,saude:loadSaude,cofre:loadCofre,painel:loadPainel,loc:loadLoc}[v]||function(){})();}
 // --- Início (command center: painel de uso interativo, pegada JARVIS) ---
 function ovTile(spanCls,icon,title,view,key){
   const c=el('div','ov-card '+spanCls);c.dataset.key=key||view||'';
@@ -2971,6 +2982,38 @@ function editMon(w){openForm('Editar monitor',[
   async v=>{if(!v.url)return;await fetch('/api/watches/update',{method:'POST',headers:H(),body:JSON.stringify({id:w.id,url:v.url,keyword:v.keyword})});loadMon();});}
 $('#monform').onsubmit=async e=>{e.preventDefault();const url=$('#mon-url').value.trim();if(!url)return;
   await fetch('/api/watches',{method:'POST',headers:H(),body:JSON.stringify({url,keyword:$('#mon-kw').value.trim()})});$('#mon-url').value='';$('#mon-kw').value='';loadMon();};
+const LOC_KIND_LABEL={script:'script',open:'abrir',browser:'navegador',shell:'shell'};
+const LOC_STATUS_LABEL={pending:'aguardando aprovação',approved:'aprovado · na fila',running:'executando',done:'concluído',failed:'falhou',rejected:'recusado'};
+function locRow(t,withActions){const row=el('div','tv-row');const txt=el('div','txt');
+  txt.appendChild(document.createTextNode('['+(LOC_KIND_LABEL[t.kind]||t.kind)+'] '+t.label));
+  txt.appendChild(subline(LOC_STATUS_LABEL[t.status]||t.status));
+  if(t.result&&t.result.output)txt.appendChild(subline(String(t.result.output).slice(0,180)));
+  row.appendChild(txt);
+  if(withActions){const ok=el('button','tv-ic');ok.title='aprovar';ok.appendChild(ficon('check'));
+    ok.onclick=async()=>{await fetch('/api/local-tasks/approve',{method:'POST',headers:H(),body:JSON.stringify({id:t.id})});loadLoc();};
+    const no=el('button','tv-ic');no.title='recusar';no.appendChild(ficon('x'));
+    no.onclick=async()=>{await fetch('/api/local-tasks/reject',{method:'POST',headers:H(),body:JSON.stringify({id:t.id})});loadLoc();};
+    row.appendChild(ok);row.appendChild(no);}
+  return row;}
+async function loadLoc(){try{
+  const items=(await (await fetch('/api/local-tasks',{headers:H()})).json()).items||[];
+  const pend=items.filter(t=>t.status==='pending'),hist=items.filter(t=>t.status!=='pending');
+  const pbox=$('#loc-pending');pbox.textContent='';
+  if(!pend.length)pbox.appendChild(emptyState('shield-check','Nada pendente','Quando a E.V. pedir pra rodar algo no seu PC, aparece aqui.'));
+  else pend.forEach(t=>pbox.appendChild(locRow(t,true)));
+  const hbox=$('#loc-hist');hbox.textContent='';
+  if(!hist.length)hbox.appendChild(emptyState('history','Sem histórico ainda','Tarefas aprovadas/recusadas aparecem aqui.'));
+  else hist.slice(0,20).forEach(t=>hbox.appendChild(locRow(t,false)));
+  const scripts=(await (await fetch('/api/local-scripts',{headers:H()})).json()).items||[];
+  const sbox=$('#loc-scripts');sbox.textContent='';
+  if(!scripts.length)sbox.appendChild(emptyState('terminal','Nenhum script cadastrado','Cadastre um acima pra E.V. poder pedir pra rodar por nome.'));
+  else scripts.forEach(s=>{const row=el('div','tv-row');const t=el('div','txt');t.appendChild(document.createTextNode(s.name));t.appendChild(subline(s.command));
+    const dl=el('button','tv-ic');dl.appendChild(ficon('trash-2'));
+    dl.onclick=async()=>{if(await confirmDialog('Remover script '+s.name+'?')){await fetch('/api/local-scripts/delete',{method:'POST',headers:H(),body:JSON.stringify({id:s.id})});loadLoc();}};
+    row.appendChild(t);row.appendChild(dl);sbox.appendChild(row);});
+  window.lucide&&lucide.createIcons();}catch(e){}}
+$('#locscriptform').onsubmit=async e=>{e.preventDefault();const name=$('#locs-name').value.trim(),command=$('#locs-cmd').value.trim();if(!name||!command)return;
+  await fetch('/api/local-scripts',{method:'POST',headers:H(),body:JSON.stringify({name,command})});$('#locs-name').value='';$('#locs-cmd').value='';loadLoc();};
 async function loadLinks(){try{const items=(await (await fetch('/api/links',{headers:H()})).json()).items||[];const box=$('#lnklist');box.textContent='';
   window._lcats=[...new Set(items.map(l=>l.category))];
   if(!items.length){box.appendChild(emptyState('link','Nenhum link salvo','Cole uma URL acima para guardar.'));window.lucide&&lucide.createIcons();return;}
@@ -3216,7 +3259,7 @@ function filterRows(box,q){if(!box)return;q=(q||'').trim().toLowerCase();let cur
 [['tasks-search','tasklist'],['exp-search','explist'],['rem-search','remlist'],['mem-search','memlist'],['kb-search','kblist'],['lnk-search','lnklist'],['hab-search','hablist'],['jou-search','joulist'],['sub-search','sublist'],['orc-search','orclist'],['mon-search','monlist'],['act-search','actlist']].forEach(p=>{const inp=document.getElementById(p[0]);if(inp)inp.oninput=()=>filterRows(document.getElementById(p[1]),inp.value);});
 // command palette (Ctrl/Cmd+K)
 const CK=$('#cmdk'),CKI=$('#ck-input'),CKL=$('#ck-list');let ckItems=[],ckSel=0;
-function ckBuild(){const nav=[['Conversa',()=>switchView('chat')],['Tarefas',()=>switchView('tasks')],['Gastos',()=>switchView('exp')],['Lembretes',()=>switchView('rem')],['Agenda',()=>switchView('cal')],['Memórias',()=>switchView('mem')],['Links',()=>switchView('lnk')],['Hábitos',()=>switchView('hab')],['Diário',()=>switchView('jou')],['Assinaturas',()=>switchView('sub')],['Orçamentos',()=>switchView('orc')],['Monitores',()=>switchView('mon')],['Base',()=>switchView('kb')],['Cérebro',()=>switchView('brain')],['Pomodoro',()=>openPomo(25)],['Terminal de ação da E.V.',()=>openTerminal()],['Voz ao vivo',()=>$('#vcopen').click()],['Modo foco (liga/desliga)',()=>toggleSerious()],['Chaves de API',()=>openKeys()],['Captura rápida',()=>openQuickCapture()]];
+function ckBuild(){const nav=[['Conversa',()=>switchView('chat')],['Tarefas',()=>switchView('tasks')],['Gastos',()=>switchView('exp')],['Lembretes',()=>switchView('rem')],['Agenda',()=>switchView('cal')],['Memórias',()=>switchView('mem')],['Links',()=>switchView('lnk')],['Hábitos',()=>switchView('hab')],['Diário',()=>switchView('jou')],['Assinaturas',()=>switchView('sub')],['Orçamentos',()=>switchView('orc')],['Monitores',()=>switchView('mon')],['Base',()=>switchView('kb')],['Cérebro',()=>switchView('brain')],['Executor local',()=>switchView('loc')],['Pomodoro',()=>openPomo(25)],['Terminal de ação da E.V.',()=>openTerminal()],['Voz ao vivo',()=>$('#vcopen').click()],['Modo foco (liga/desliga)',()=>toggleSerious()],['Chaves de API',()=>openKeys()],['Captura rápida',()=>openQuickCapture()]];
   return nav.map(n=>({k:'ir',label:n[0],desc:'abrir',run:n[1]})).concat((COMMANDS||[]).map(c=>({k:'/'+c.name,label:c.name,desc:c.desc,run:()=>runCmd(c.name)})));}
 let _ckSeq=0;
 function ckRender(q){ckItems=ckBuild().filter(i=>(i.label+' '+i.k+' '+i.desc).toLowerCase().includes((q||'').toLowerCase())).slice(0,40);ckSel=0;CKL.textContent='';
@@ -4902,6 +4945,79 @@ def create_app(config: Config, brain: Brain | None = None):
     async def vault_del(request: Request):
         _check(request.headers.get("authorization"))
         memory.delete_document(owner, int((await _body(request)).get("id") or 0))
+        return {"ok": True}
+
+    # --- local execution agent (runs on the user's own PC) -----------------
+    # Every task requires explicit human approval — no kind auto-runs, ever.
+    _LOCAL_TASK_KINDS = {"script", "open", "browser", "shell"}
+
+    @app.get("/api/local-tasks")
+    async def local_tasks_list(request: Request):
+        _check(request.headers.get("authorization"))
+        status = (request.query_params.get("status") or "").strip() or None
+        return {"items": memory.list_local_tasks(owner, status)}
+
+    @app.post("/api/local-tasks")
+    async def local_tasks_create(request: Request):
+        _check(request.headers.get("authorization"))
+        d = await _body(request)
+        kind = (d.get("kind") or "").strip().lower()
+        label = (d.get("label") or "").strip()
+        if kind not in _LOCAL_TASK_KINDS or not label:
+            raise HTTPException(status_code=400, detail="kind/label inválidos")
+        tid = memory.add_local_task(owner, kind, label[:200], {"command": d.get("command") or ""})
+        return {"ok": True, "id": tid}
+
+    @app.post("/api/local-tasks/approve")
+    async def local_tasks_approve(request: Request):
+        _check(request.headers.get("authorization"))
+        tid = int((await _body(request)).get("id") or 0)
+        ok = memory.set_local_task_status(owner, tid, "approved")
+        return {"ok": ok}
+
+    @app.post("/api/local-tasks/reject")
+    async def local_tasks_reject(request: Request):
+        _check(request.headers.get("authorization"))
+        tid = int((await _body(request)).get("id") or 0)
+        ok = memory.set_local_task_status(owner, tid, "rejected")
+        return {"ok": ok}
+
+    @app.get("/api/local-tasks/claim")
+    async def local_tasks_claim(request: Request):
+        # The local daemon polls this from the user's own machine using the
+        # same bearer token as the web console — it only ever receives tasks
+        # a human already approved.
+        _check(request.headers.get("authorization"))
+        task = memory.claim_local_task(owner)
+        return {"task": task}
+
+    @app.post("/api/local-tasks/result")
+    async def local_tasks_result(request: Request):
+        _check(request.headers.get("authorization"))
+        d = await _body(request)
+        tid = int(d.get("id") or 0)
+        ok = memory.finish_local_task(owner, tid, bool(d.get("ok")), d.get("output") or {})
+        return {"ok": ok}
+
+    @app.get("/api/local-scripts")
+    async def local_scripts_list(request: Request):
+        _check(request.headers.get("authorization"))
+        return {"items": memory.list_local_scripts(owner)}
+
+    @app.post("/api/local-scripts")
+    async def local_scripts_add(request: Request):
+        _check(request.headers.get("authorization"))
+        d = await _body(request)
+        name = (d.get("name") or "").strip()
+        command = (d.get("command") or "").strip()
+        if not name or not command:
+            raise HTTPException(status_code=400, detail="nome e comando obrigatórios")
+        return {"ok": True, "id": memory.add_local_script(owner, name[:60], command)}
+
+    @app.post("/api/local-scripts/delete")
+    async def local_scripts_del(request: Request):
+        _check(request.headers.get("authorization"))
+        memory.delete_local_script(owner, int((await _body(request)).get("id") or 0))
         return {"ok": True}
 
     # --- Spotify OAuth + Web API (Premium: read playlists + control playback) --

--- a/local_agent.py
+++ b/local_agent.py
@@ -1,0 +1,123 @@
+"""Local execution agent for E.V. — runs on YOUR OWN computer, not on the
+server. It polls E.V. (over your Tailscale network) for tasks that you have
+already approved (via the web console or the Telegram fallback) and executes
+them locally, then reports the result back.
+
+It NEVER runs anything by itself: the server only ever hands out tasks whose
+status is already 'approved', and a human always made that call first.
+
+Usage:
+    python3 local_agent.py
+
+Requires EV_WEB_BASE_URL and EV_WEB_TOKEN in the .env at the project root
+(the same ones the web console uses).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import requests
+from dotenv import load_dotenv
+import os
+
+_PROJECT_ROOT = Path(__file__).resolve().parent
+load_dotenv(_PROJECT_ROOT / ".env")
+
+BASE_URL = os.getenv("EV_WEB_BASE_URL", "").strip().rstrip("/")
+TOKEN = os.getenv("EV_WEB_TOKEN", "").strip()
+POLL_SECONDS = 5
+SHELL_TIMEOUT = 120
+
+
+def _headers() -> dict:
+    return {"Authorization": f"Bearer {TOKEN}", "Content-Type": "application/json"}
+
+
+def _claim() -> dict | None:
+    r = requests.get(f"{BASE_URL}/api/local-tasks/claim", headers=_headers(), timeout=15)
+    r.raise_for_status()
+    return r.json().get("task")
+
+
+def _report(task_id: int, ok: bool, output: str) -> None:
+    requests.post(
+        f"{BASE_URL}/api/local-tasks/result",
+        headers=_headers(),
+        json={"id": task_id, "ok": ok, "output": {"output": output[:4000]}},
+        timeout=15,
+    )
+
+
+def _resolve_script(name: str) -> str | None:
+    r = requests.get(f"{BASE_URL}/api/local-scripts", headers=_headers(), timeout=15)
+    r.raise_for_status()
+    for s in r.json().get("items", []):
+        if s["name"].strip().lower() == name.strip().lower():
+            return s["command"]
+    return None
+
+
+def _run_shell(command: str) -> tuple[bool, str]:
+    try:
+        p = subprocess.run(
+            command, shell=True, capture_output=True, text=True, timeout=SHELL_TIMEOUT,
+        )
+        out = (p.stdout or "") + (p.stderr or "")
+        return p.returncode == 0, out or f"(sem saída, código {p.returncode})"
+    except subprocess.TimeoutExpired:
+        return False, f"comando excedeu {SHELL_TIMEOUT}s e foi cancelado"
+    except Exception as exc:
+        return False, f"erro ao executar: {exc}"
+
+
+def _run_open(target: str) -> tuple[bool, str]:
+    if sys.platform != "darwin":
+        return False, "abrir app/arquivo/URL só está implementado no macOS por enquanto"
+    try:
+        p = subprocess.run(["open", target], capture_output=True, text=True, timeout=15)
+        return p.returncode == 0, p.stderr or "aberto"
+    except Exception as exc:
+        return False, f"erro ao abrir: {exc}"
+
+
+def execute(task: dict) -> tuple[bool, str]:
+    kind = task["kind"]
+    command = (task.get("payload") or {}).get("command", "")
+    if kind == "shell":
+        return _run_shell(command)
+    if kind in ("open", "browser"):
+        return _run_open(command)
+    if kind == "script":
+        resolved = _resolve_script(command)
+        if not resolved:
+            return False, f"nenhum script cadastrado chamado '{command}'"
+        return _run_shell(resolved)
+    return False, f"tipo de tarefa desconhecido: {kind}"
+
+
+def main() -> None:
+    if not BASE_URL or not TOKEN:
+        print("EV_WEB_BASE_URL e EV_WEB_TOKEN precisam estar no .env")
+        sys.exit(1)
+    print(f"Executor local da E.V. rodando — apontando pra {BASE_URL}")
+    while True:
+        try:
+            task = _claim()
+            if task:
+                print(f"Executando tarefa #{task['id']}: [{task['kind']}] {task['label']}")
+                ok, output = execute(task)
+                _report(task["id"], ok, output)
+                print(f"  -> {'ok' if ok else 'falhou'}: {output[:200]}")
+        except requests.RequestException as exc:
+            print(f"erro de rede, tentando de novo: {exc}")
+        except Exception as exc:
+            print(f"erro inesperado: {exc}")
+        time.sleep(POLL_SECONDS)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,5 +44,8 @@ pillow>=10.0.0
 # Web Push notifications (reminders with the app closed)
 pywebpush>=1.14.0
 
+# HTTP client for local_agent.py (the PC-side task executor)
+requests>=2.31.0
+
 # Tests (dev)
 pytest>=8.0.0


### PR DESCRIPTION
## 🤔 Context

The user wanted E.V. to be able to run tasks on their own computer (not the Oracle VM it lives on), but only ever with explicit human authorization — never as an autonomous remote-execution capability.

This PR adds that pipeline end-to-end:
- A new AI tool, `solicitar_tarefa_local`, that only ever files a **pending** request (script / open app-file / browser / free shell) — it cannot execute anything itself.
- A new **"Executor local"** view in the web console (primary approval surface): pending approvals with Aprovar/Recusar, history, and an allowlist manager for pre-registered scripts.
- A **Telegram fallback**: a background loop nudges the owner with an inline Aprovar/Recusar keyboard for any request not yet decided, so nothing gets missed if the console isn't open.
- A standalone **`local_agent.py`** daemon meant to run on the user's own machine — it only polls for already-`approved` tasks (via `/api/local-tasks/claim`) and reports results back; it never receives anything that hasn't already been through human approval.

> [!NOTE]
> `local_agent.py`'s "browser" task kind currently just opens a URL via macOS `open` (no real browser-automation driver yet) — flagged as a straightforward follow-up if that's needed later.

> [!WARNING]
> The "shell" task kind runs arbitrary shell commands with no allowlist — by design, per the user's request, but it's gated entirely behind manual approval (console or Telegram) with no auto-run path.

## Verification

Playwright-verified in an isolated scratch environment (fake `.env`, fictional token, port 8096, real `ev_memory.db` untouched — checksum identical before/after): py_compile clean on all changed files, task creation → pending list → approve → history transition, and allowlist add/delete all confirmed working with no new console errors.