### PR TITLE
Real browser-automation agent + second confirmation for WhatsApp/Instagram

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ google_token*.json
 *.sqlite3
 backups/
 
+# Perfil persistente do navegador usado pelo local_agent.py (sessões de login)
+.browser_profile/
+
 # Python
 __pycache__/
 *.py[cod]

--- a/ev/core/brain.py
+++ b/ev/core/brain.py
@@ -955,29 +955,52 @@ class Brain:
         def solicitar_tarefa_local(tipo: str, descricao: str, comando: str = "") -> str:
             """Pede para EXECUTAR algo no computador pessoal do usuário (não no
             servidor da E.V.): rodar um script já cadastrado por ele, abrir um
-            app/arquivo, automatizar o navegador, ou rodar um comando de shell.
-            NUNCA executa nada sozinha — isso só cria um pedido pendente que o
-            usuário precisa aprovar manualmente (no console web, com fallback
-            pelo Telegram). Use quando ele pedir explicitamente para 'rodar no
-            meu pc', 'abrir X no computador', 'executa esse script pra mim'.
+            app/arquivo, navegar/pesquisar/agir de forma autônoma dentro de um
+            navegador de verdade (com sessão de login persistente), ou rodar um
+            comando de shell. NUNCA executa nada sozinha — isso só cria um pedido
+            pendente que o usuário precisa aprovar manualmente (no console web,
+            com fallback pelo Telegram). Use quando ele pedir explicitamente para
+            'rodar no meu pc', 'abrir X no computador', 'pesquisa isso no
+            navegador pra mim', 'executa esse script pra mim'.
+
+            Se o objetivo envolver WhatsApp Web ou Instagram (ex: responder
+            mensagem, enviar DM, postar), a tarefa é marcada como alto risco: além
+            desta aprovação, o executor local vai pedir uma SEGUNDA confirmação
+            explícita bem antes de clicar em enviar/postar — nunca manda nada
+            sozinho, e automatizar essas plataformas pode violar os termos de uso
+            delas (risco real de banimento da conta), então avise o usuário disso
+            se ele pedir algo do tipo.
 
             Args:
                 tipo: 'script' (um script já cadastrado por nome), 'open' (abrir
-                    app/arquivo/pasta), 'browser' (automação de navegador) ou
-                    'shell' (comando livre — maior risco, sempre aprovado à mão).
+                    app/arquivo/pasta), 'browser' (agente autônomo de navegador —
+                    descreva o objetivo em linguagem natural, ex: "pesquisar X no
+                    Google e resumir os 3 melhores resultados" ou "abrir o
+                    WhatsApp Web e responder Fulano com ...") ou 'shell' (comando
+                    livre — maior risco, sempre aprovado à mão).
                 descricao: frase curta explicando o que a tarefa faz, mostrada ao
                     usuário na hora de aprovar (ex: "abrir o VS Code no projeto X").
-                comando: o script/comando/URL/instrução em si.
+                comando: para 'browser', o objetivo em linguagem natural (o
+                    executor local decide sozinho os passos de navegação); para os
+                    demais tipos, o script/comando/caminho em si.
             """
             kind = (tipo or "").strip().lower()
             if kind not in ("script", "open", "browser", "shell"):
                 return "tipo inválido — use script, open, browser ou shell"
+            payload = {"command": comando or ""}
+            risk = self._memory.classify_local_task_risk(kind, comando or "")
             tid = self._memory.add_local_task(
                 user_id, kind, (descricao or comando or "tarefa local")[:200],
-                {"command": comando or ""},
+                payload, risk=risk,
+            )
+            aviso = (
+                " — como envolve WhatsApp/Instagram, vou pedir uma segunda "
+                "confirmação sua bem antes de clicar em enviar/postar qualquer coisa"
+                if risk == "high" else ""
             )
             return (f"pedido #{tid} criado — preciso que você aprove pelo console "
-                    f"da E.V. (ou pelo Telegram) antes de rodar isso no seu computador")
+                    f"da E.V. (ou pelo Telegram) antes de rodar isso no seu computador"
+                    f"{aviso}")
 
         callables: dict = {
             "modo_serio": modo_serio,
@@ -1094,17 +1117,21 @@ class Brain:
             fn(
                 "solicitar_tarefa_local",
                 "Pede para executar algo no computador pessoal do usuário (script "
-                "cadastrado, abrir app/arquivo, automação de navegador ou shell "
-                "livre). NUNCA executa sozinha — cria um pedido pendente que o "
-                "usuário precisa aprovar manualmente (console web, fallback "
-                "Telegram). Use para 'roda isso no meu pc', 'abre X no computador'.",
+                "cadastrado, abrir app/arquivo, agente autônomo de navegador de "
+                "verdade, ou shell livre). NUNCA executa sozinha — cria um pedido "
+                "pendente que o usuário precisa aprovar manualmente (console web, "
+                "fallback Telegram). Tarefas de navegador envolvendo WhatsApp/"
+                "Instagram pedem uma SEGUNDA confirmação antes de enviar/postar "
+                "qualquer coisa. Use para 'roda isso no meu pc', 'abre X no "
+                "computador', 'pesquisa isso no navegador pra mim'.",
                 {
                     "tipo": {"type": s, "description":
                              "script, open, browser ou shell"},
                     "descricao": {"type": s, "description":
                                   "frase curta do que a tarefa faz"},
                     "comando": {"type": s, "description":
-                                "o script/comando/URL/instrução em si"},
+                                "para 'browser', o objetivo em linguagem natural; "
+                                "para os demais, o script/comando/caminho em si"},
                 },
                 ["tipo", "descricao"],
             ),

--- a/ev/core/memory.py
+++ b/ev/core/memory.py
@@ -357,15 +357,32 @@ class Memory:
                 label    TEXT NOT NULL,
                 payload  TEXT NOT NULL DEFAULT '{}',
                 status   TEXT NOT NULL DEFAULT 'pending',
+                risk     TEXT NOT NULL DEFAULT 'normal',
                 result   TEXT,
                 notified INTEGER NOT NULL DEFAULT 0,
                 created  TEXT NOT NULL,
                 decided  TEXT,
                 finished TEXT
             );
+
+            CREATE TABLE IF NOT EXISTS local_confirms (
+                id       INTEGER PRIMARY KEY AUTOINCREMENT,
+                task_id  INTEGER NOT NULL,
+                user_id  TEXT NOT NULL,
+                label    TEXT NOT NULL,
+                status   TEXT NOT NULL DEFAULT 'pending',
+                notified INTEGER NOT NULL DEFAULT 0,
+                created  TEXT NOT NULL,
+                decided  TEXT
+            );
             """
         )
         # Migrations for older DBs.
+        loc_cols = {r["name"] for r in self._conn.execute("PRAGMA table_info(local_tasks)")}
+        if "risk" not in loc_cols:
+            self._conn.execute(
+                "ALTER TABLE local_tasks ADD COLUMN risk TEXT NOT NULL DEFAULT 'normal'"
+            )
         fact_cols = {r["name"] for r in self._conn.execute("PRAGMA table_info(facts)")}
         if "embedding" not in fact_cols:
             self._conn.execute("ALTER TABLE facts ADD COLUMN embedding TEXT")
@@ -562,6 +579,18 @@ class Memory:
 
     # --- local tasks (PC execution queue — always requires approval) -------
 
+    #: platforms where sending/posting on the user's behalf carries real
+    #: account-ban/ToS risk — browser tasks touching them are flagged 'high'
+    #: and additionally gated by a second confirmation before any risky click.
+    _HIGH_RISK_MARKERS = ("whatsapp", "wa.me", "instagram", "instagr.am")
+
+    @classmethod
+    def classify_local_task_risk(cls, kind: str, command: str) -> str:
+        if kind != "browser":
+            return "normal"
+        c = (command or "").lower()
+        return "high" if any(m in c for m in cls._HIGH_RISK_MARKERS) else "normal"
+
     def _local_task_row(self, r) -> dict:
         d = dict(r)
         try:
@@ -574,19 +603,21 @@ class Memory:
             d["result"] = None
         return d
 
-    def add_local_task(self, user_id: str, kind: str, label: str, payload: dict) -> int:
+    def add_local_task(self, user_id: str, kind: str, label: str, payload: dict,
+                        risk: str | None = None) -> int:
+        risk = risk or self.classify_local_task_risk(kind, (payload or {}).get("command", ""))
         cur = self._conn.execute(
-            "INSERT INTO local_tasks (user_id, kind, label, payload, status, created) "
-            "VALUES (?, ?, ?, ?, 'pending', ?)",
-            (user_id, kind, label, json.dumps(payload or {}), self._now()),
+            "INSERT INTO local_tasks (user_id, kind, label, payload, status, risk, created) "
+            "VALUES (?, ?, ?, ?, 'pending', ?, ?)",
+            (user_id, kind, label, json.dumps(payload or {}), risk, self._now()),
         )
         self._conn.commit()
         return int(cur.lastrowid)
 
     def list_local_tasks(self, user_id: str, status: str | None = None,
                           limit: int = 50) -> list[dict]:
-        q = ("SELECT id, kind, label, payload, status, result, created, decided, finished "
-             "FROM local_tasks WHERE user_id = ?")
+        q = ("SELECT id, kind, label, payload, status, risk, result, created, decided, "
+             "finished FROM local_tasks WHERE user_id = ?")
         args: list = [user_id]
         if status:
             q += " AND status = ?"
@@ -598,14 +629,15 @@ class Memory:
 
     def get_local_task(self, user_id: str, task_id: int) -> dict | None:
         row = self._conn.execute(
-            "SELECT id, kind, label, payload, status, result, created, decided, finished "
-            "FROM local_tasks WHERE id = ? AND user_id = ?", (task_id, user_id)).fetchone()
+            "SELECT id, kind, label, payload, status, risk, result, created, decided, "
+            "finished FROM local_tasks WHERE id = ? AND user_id = ?",
+            (task_id, user_id)).fetchone()
         return self._local_task_row(row) if row else None
 
     def unnotified_local_tasks(self) -> list[dict]:
         """Pending local tasks (any user) that still need a Telegram nudge."""
         rows = self._conn.execute(
-            "SELECT id, user_id, kind, label, payload, status, created "
+            "SELECT id, user_id, kind, label, payload, status, risk, created "
             "FROM local_tasks WHERE status = 'pending' AND notified = 0"
         ).fetchall()
         return [self._local_task_row(r) for r in rows]
@@ -646,6 +678,59 @@ class Memory:
              task_id, user_id))
         self._conn.commit()
         return cur.rowcount > 0
+
+    # --- local task confirms (2nd approval for risky in-flight browser actions) --
+    # Used when a 'high' risk browser task is about to do something irreversible
+    # (send a message, post, follow, delete) — the local agent pauses execution
+    # and waits for this SEPARATE approval before clicking, even though the task
+    # itself was already approved once.
+
+    def add_local_confirm(self, user_id: str, task_id: int, label: str) -> int:
+        cur = self._conn.execute(
+            "INSERT INTO local_confirms (task_id, user_id, label, status, created) "
+            "VALUES (?, ?, ?, 'pending', ?)",
+            (task_id, user_id, label[:200], self._now()),
+        )
+        self._conn.commit()
+        return int(cur.lastrowid)
+
+    def get_local_confirm(self, user_id: str, confirm_id: int) -> dict | None:
+        row = self._conn.execute(
+            "SELECT id, task_id, label, status, created, decided FROM local_confirms "
+            "WHERE id = ? AND user_id = ?", (confirm_id, user_id)).fetchone()
+        return dict(row) if row else None
+
+    def list_local_confirms(self, user_id: str, status: str | None = None,
+                             limit: int = 50) -> list[dict]:
+        q = ("SELECT id, task_id, label, status, created, decided FROM local_confirms "
+             "WHERE user_id = ?")
+        args: list = [user_id]
+        if status:
+            q += " AND status = ?"
+            args.append(status)
+        q += " ORDER BY id DESC LIMIT ?"
+        args.append(limit)
+        return [dict(r) for r in self._conn.execute(q, tuple(args)).fetchall()]
+
+    def set_local_confirm_status(self, user_id: str, confirm_id: int, status: str) -> bool:
+        cur = self._conn.execute(
+            "UPDATE local_confirms SET status = ?, decided = ? "
+            "WHERE id = ? AND user_id = ? AND status = 'pending'",
+            (status, self._now(), confirm_id, user_id))
+        self._conn.commit()
+        return cur.rowcount > 0
+
+    def unnotified_local_confirms(self) -> list[dict]:
+        rows = self._conn.execute(
+            "SELECT id, task_id, user_id, label, status, created "
+            "FROM local_confirms WHERE status = 'pending' AND notified = 0"
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def mark_local_confirm_notified(self, confirm_id: int) -> None:
+        self._conn.execute(
+            "UPDATE local_confirms SET notified = 1 WHERE id = ?", (confirm_id,))
+        self._conn.commit()
 
     # --- connectors (user-defined API integrations) ------------------------
 

--- a/ev/interfaces/telegram_bot.py
+++ b/ev/interfaces/telegram_bot.py
@@ -1482,6 +1482,9 @@ class TelegramInterface:
         if section == "loctask":
             await self._handle_loctask(q, uid, action)
             return
+        if section == "locconfirm":
+            await self._handle_locconfirm(q, uid, action)
+            return
         if section == "docsave":
             await self._save_doc_to_kb(q, uid, action)
             return
@@ -1884,6 +1887,30 @@ class TelegramInterface:
             if status == "approved" else "Recusado.",
         )
 
+    async def _handle_locconfirm(self, q, uid: str, action: str) -> None:
+        """Second-tier confirmation: a browser task already approved once is
+        paused mid-execution on a risky step (e.g. WhatsApp/Instagram send)
+        and waiting on this separate decision before it's allowed to click."""
+        decision, _, cid_s = action.partition(":")
+        try:
+            cid = int(cid_s)
+        except ValueError:
+            return
+        status = "approved" if decision == "aprovar" else "rejected"
+        ok = self._memory.set_local_confirm_status(uid, cid, status)
+        try:
+            await q.edit_message_reply_markup(reply_markup=None)
+        except Exception:
+            pass
+        if not ok:
+            await q.answer("Essa confirmação já foi decidida.", show_alert=True)
+            return
+        await q.answer("Confirmado ✅" if status == "approved" else "Recusado")
+        await q.message.reply_text(
+            "Confirmado — o executor local vai prosseguir com essa ação agora."
+            if status == "approved" else "Recusado — o executor local vai cancelar essa ação.",
+        )
+
     async def _confirm_expense(self, q, uid: str, eid: str) -> None:
         exp = self._pending_expense.pop(eid, None)
         if exp is None:
@@ -1987,6 +2014,7 @@ class TelegramInterface:
             asyncio.create_task(self._backup_loop(app)),
             asyncio.create_task(self._watch_loop(app)),
             asyncio.create_task(self._loctask_loop(app)),
+            asyncio.create_task(self._locconfirm_loop(app)),
         ]
         log.info(
             "Schedulers started (reminders every %ss; daily briefing at %sh; daily backup).",
@@ -2552,6 +2580,32 @@ class TelegramInterface:
             except Exception:
                 log.exception("Local task loop error")
             await asyncio.sleep(20)
+
+    async def _locconfirm_loop(self, app: Application) -> None:
+        """Telegram fallback for the SECOND, in-flight confirmation a risky
+        browser task (WhatsApp/Instagram) requests right before it sends or
+        posts anything — polled faster since the local agent is paused and
+        waiting on this decision, not just queued."""
+        while True:
+            try:
+                if self._config.owner_id is not None:
+                    for c in self._memory.unnotified_local_confirms():
+                        b = InlineKeyboardButton
+                        kb = InlineKeyboardMarkup([[
+                            b("✅ Confirmar", callback_data=f"locconfirm:aprovar:{c['id']}"),
+                            b("✖️ Recusar", callback_data=f"locconfirm:recusar:{c['id']}"),
+                        ]])
+                        await self._bot_send(
+                            app.bot, self._config.owner_id,
+                            f"⚠️ Ação de alto risco pausada no seu computador:\n"
+                            f"{c['label']}\n\n"
+                            "A E.V. só vai continuar (ex: enviar/postar) se você confirmar.",
+                            kb,
+                        )
+                        self._memory.mark_local_confirm_notified(c["id"])
+            except Exception:
+                log.exception("Local confirm loop error")
+            await asyncio.sleep(8)
 
     async def _reminder_loop(self, app: Application) -> None:
         while True:

--- a/ev/interfaces/web.py
+++ b/ev/interfaces/web.py
@@ -528,7 +528,7 @@ body.serious #serfx{opacity:1;box-shadow:inset 0 0 150px -50px rgba(255,45,55,.6
   body.v-chat #np-mini{bottom:calc(16px + env(safe-area-inset-bottom))}
   #qc-fab{left:14px;bottom:calc(72px + env(safe-area-inset-bottom))}
   /* espaço p/ o conteúdo não ficar atrás da barra */
-  #taskview,#kbview,#expview,#remview,#memview,#calview,#lnkview,#habview,#jouview,#subview,#orcview,#monview,#actview,#pageview,#musicview,#climaview,#metasview,#saudeview,#cofreview,#painelview,#inicioview{padding-bottom:80px}
+  #taskview,#kbview,#expview,#remview,#memview,#calview,#lnkview,#habview,#jouview,#subview,#orcview,#monview,#actview,#pageview,#musicview,#climaview,#metasview,#saudeview,#cofreview,#painelview,#inicioview,#locview{padding-bottom:80px}
 }
 .lnk{color:var(--fg);text-decoration:underline;text-underline-offset:2px}.lnk:hover{opacity:.75}
 .tab{font-family:var(--mono);font-size:11px;letter-spacing:.06em;color:var(--muted);border:none;background:transparent;border-radius:8px;padding:7px 13px;cursor:pointer;white-space:nowrap}
@@ -543,7 +543,7 @@ body.serious #serfx{opacity:1;box-shadow:inset 0 0 150px -50px rgba(255,45,55,.6
 .tabs-nav.show{display:flex}
 .tabs-nav:disabled{opacity:.25;cursor:default}
 #chatview{flex:1;display:flex;flex-direction:column;min-height:0}
-#taskview,#kbview,#expview,#remview,#memview,#calview,#lnkview,#habview,#jouview,#subview,#orcview,#monview,#actview,#pageview,#musicview,#climaview,#metasview,#saudeview,#cofreview,#painelview,#inicioview{flex:1;min-height:0;overflow:auto;padding:24px;display:none}
+#taskview,#kbview,#expview,#remview,#memview,#calview,#lnkview,#habview,#jouview,#subview,#orcview,#monview,#actview,#pageview,#musicview,#climaview,#metasview,#saudeview,#cofreview,#painelview,#inicioview,#locview{flex:1;min-height:0;overflow:auto;padding:24px;display:none}
 .ov-grid{display:grid;grid-template-columns:repeat(12,1fr);gap:14px;max-width:1500px;grid-auto-rows:minmax(58px,auto);grid-auto-flow:row dense}
 .sp3{grid-column:span 3}.sp4{grid-column:span 4}.sp5{grid-column:span 5}.sp6{grid-column:span 6}.sp7{grid-column:span 7}.sp8{grid-column:span 8}.sp12{grid-column:span 12}.rw2{grid-row:span 2}
 @media(max-width:1100px){.sp3,.sp4,.sp5,.sp7,.sp8{grid-column:span 6}}
@@ -934,7 +934,7 @@ textarea.minput{resize:vertical;min-height:74px;font-family:var(--body);line-hei
   body.m-left #mbackdrop,body.m-right #mbackdrop{display:block;position:fixed;inset:0;background:rgba(0,0,0,.55);z-index:55}
   .topbar{padding:11px 12px;gap:5px}
   #slash{left:14px;right:14px}
-  #taskview,#kbview,#expview,#remview,#memview,#calview,#lnkview,#habview,#jouview,#subview,#orcview,#monview,#actview,#brainview,#pageview,#musicview,#climaview,#metasview,#saudeview,#cofreview,#painelview,#inicioview{padding:16px 14px}
+  #taskview,#kbview,#expview,#remview,#memview,#calview,#lnkview,#habview,#jouview,#subview,#orcview,#monview,#actview,#brainview,#pageview,#musicview,#climaview,#metasview,#saudeview,#cofreview,#painelview,#inicioview,#locview{padding:16px 14px}
   #log{padding:14px 14px}
   .msg{max-width:92%!important}
   #calgrid{gap:3px}.cal-cell{min-height:62px;padding:4px}
@@ -1156,7 +1156,9 @@ textarea.minput{resize:vertical;min-height:74px;font-family:var(--body);line-hei
     </div>
     <div id="locview">
       <div class="tv-h">Executor local · roda no seu computador</div>
-      <div class="tv-empty" style="margin-bottom:10px">Toda tarefa abaixo só executa depois que você aprovar aqui ou no Telegram — a E.V. nunca roda nada sozinha no seu PC.</div>
+      <div class="tv-empty" style="margin-bottom:10px">Toda tarefa abaixo só executa depois que você aprovar aqui ou no Telegram — a E.V. nunca roda nada sozinha no seu PC. Tarefas de navegador em WhatsApp/Instagram (🔴 alto risco) pedem uma segunda confirmação antes de enviar/postar qualquer coisa.</div>
+      <div class="tv-cat">⚠️ Confirmações de alto risco (ação prestes a acontecer)</div>
+      <div id="loc-confirms"></div>
       <div class="tv-cat">Pendentes de aprovação</div>
       <div id="loc-pending"></div>
       <div class="tv-cat">Histórico</div>
@@ -2985,7 +2987,10 @@ $('#monform').onsubmit=async e=>{e.preventDefault();const url=$('#mon-url').valu
 const LOC_KIND_LABEL={script:'script',open:'abrir',browser:'navegador',shell:'shell'};
 const LOC_STATUS_LABEL={pending:'aguardando aprovação',approved:'aprovado · na fila',running:'executando',done:'concluído',failed:'falhou',rejected:'recusado'};
 function locRow(t,withActions){const row=el('div','tv-row');const txt=el('div','txt');
-  txt.appendChild(document.createTextNode('['+(LOC_KIND_LABEL[t.kind]||t.kind)+'] '+t.label));
+  const head=el('div');head.style.display='flex';head.style.alignItems='center';head.style.gap='6px';
+  if(t.risk==='high'){const b=el('span','');b.textContent='🔴 alto risco';b.style.fontFamily='var(--mono)';b.style.fontSize='10px';b.style.letterSpacing='.06em';b.style.color='#ff6b6b';head.appendChild(b);}
+  head.appendChild(document.createTextNode('['+(LOC_KIND_LABEL[t.kind]||t.kind)+'] '+t.label));
+  txt.appendChild(head);
   txt.appendChild(subline(LOC_STATUS_LABEL[t.status]||t.status));
   if(t.result&&t.result.output)txt.appendChild(subline(String(t.result.output).slice(0,180)));
   row.appendChild(txt);
@@ -2995,9 +3000,23 @@ function locRow(t,withActions){const row=el('div','tv-row');const txt=el('div','
     no.onclick=async()=>{await fetch('/api/local-tasks/reject',{method:'POST',headers:H(),body:JSON.stringify({id:t.id})});loadLoc();};
     row.appendChild(ok);row.appendChild(no);}
   return row;}
+function locConfirmRow(c){const row=el('div','tv-row');row.style.borderColor='rgba(255,107,107,.4)';const txt=el('div','txt');
+  txt.appendChild(document.createTextNode('⚠️ '+c.label));
+  txt.appendChild(subline('tarefa #'+c.task_id+' está pausada aguardando esta confirmação'));
+  row.appendChild(txt);
+  const ok=el('button','tv-ic');ok.title='confirmar e deixar prosseguir';ok.appendChild(ficon('check'));
+  ok.onclick=async()=>{await fetch('/api/local-tasks/confirms/approve',{method:'POST',headers:H(),body:JSON.stringify({id:c.id})});loadLoc();};
+  const no=el('button','tv-ic');no.title='recusar esta ação';no.appendChild(ficon('x'));
+  no.onclick=async()=>{await fetch('/api/local-tasks/confirms/reject',{method:'POST',headers:H(),body:JSON.stringify({id:c.id})});loadLoc();};
+  row.appendChild(ok);row.appendChild(no);
+  return row;}
 async function loadLoc(){try{
   const items=(await (await fetch('/api/local-tasks',{headers:H()})).json()).items||[];
   const pend=items.filter(t=>t.status==='pending'),hist=items.filter(t=>t.status!=='pending');
+  const cbox=$('#loc-confirms');cbox.textContent='';
+  const confirms=(await (await fetch('/api/local-tasks/confirms?status=pending',{headers:H()})).json()).items||[];
+  if(!confirms.length)cbox.appendChild(emptyState('shield-check','Nada aguardando confirmação','Ações de alto risco (WhatsApp/Instagram) pausam aqui antes de enviar/postar.'));
+  else confirms.forEach(c=>cbox.appendChild(locConfirmRow(c)));
   const pbox=$('#loc-pending');pbox.textContent='';
   if(!pend.length)pbox.appendChild(emptyState('shield-check','Nada pendente','Quando a E.V. pedir pra rodar algo no seu PC, aparece aqui.'));
   else pend.forEach(t=>pbox.appendChild(locRow(t,true)));
@@ -3014,6 +3033,7 @@ async function loadLoc(){try{
   window.lucide&&lucide.createIcons();}catch(e){}}
 $('#locscriptform').onsubmit=async e=>{e.preventDefault();const name=$('#locs-name').value.trim(),command=$('#locs-cmd').value.trim();if(!name||!command)return;
   await fetch('/api/local-scripts',{method:'POST',headers:H(),body:JSON.stringify({name,command})});$('#locs-name').value='';$('#locs-cmd').value='';loadLoc();};
+setInterval(()=>{const v=$('#locview');if(v&&v.style.display!=='none')loadLoc();},4000);
 async function loadLinks(){try{const items=(await (await fetch('/api/links',{headers:H()})).json()).items||[];const box=$('#lnklist');box.textContent='';
   window._lcats=[...new Set(items.map(l=>l.category))];
   if(!items.length){box.appendChild(emptyState('link','Nenhum link salvo','Cole uma URL acima para guardar.'));window.lucide&&lucide.createIcons();return;}
@@ -5019,6 +5039,100 @@ def create_app(config: Config, brain: Brain | None = None):
         _check(request.headers.get("authorization"))
         memory.delete_local_script(owner, int((await _body(request)).get("id") or 0))
         return {"ok": True}
+
+    _BROWSER_AGENT_SYSTEM = (
+        "Você controla um navegador de verdade para cumprir um objetivo do "
+        "usuário. Responda SOMENTE com um objeto JSON compacto, sem markdown e "
+        "sem texto fora do JSON. Campos: "
+        "action (um de: goto, click_text, type_text, press_enter, scroll, "
+        "read_more, done), "
+        "value (string — URL para goto, texto visível do elemento para "
+        "click_text, texto a digitar para type_text, ou o resultado final para "
+        "done), "
+        "risky (bool — true se esta ação específica for enviar mensagem, "
+        "publicar, curtir, seguir, comprar, excluir ou qualquer coisa "
+        "irreversível feita em nome do usuário), "
+        "note (string curta, em português, explicando a ação para o usuário). "
+        "Se a tarefa for marcada como alto risco (WhatsApp/Instagram), SEMPRE "
+        "marque risky=true antes de clicar em enviar/postar ou de digitar uma "
+        "mensagem que será enviada. Use 'done' assim que o objetivo estiver "
+        "cumprido ou se for impossível continuar; nesse caso 'value' deve "
+        "resumir o resultado para o usuário."
+    )
+
+    @app.post("/api/local-tasks/decide")
+    async def local_tasks_decide(request: Request):
+        # Called by the local browser agent at each step of an autonomous
+        # browsing task — the LLM only ever picks the NEXT action, it never
+        # executes anything itself (local_agent.py does that, on the user's PC).
+        _check(request.headers.get("authorization"))
+        d = await _body(request)
+        goal = (d.get("goal") or "")[:2000]
+        url = (d.get("url") or "")[:500]
+        page_text = (d.get("page_text") or "")[:6000]
+        history = d.get("history") or []
+        high_risk = bool(d.get("high_risk"))
+        prompt = (
+            f"Objetivo: {goal}\n"
+            f"Alto risco (WhatsApp/Instagram): {'sim' if high_risk else 'não'}\n"
+            f"URL atual: {url}\n"
+            f"Últimas ações: {json.dumps(history[-8:], ensure_ascii=False)}\n"
+            f"Texto visível da página (truncado):\n{page_text}"
+        )
+        raw = await brain.ask(_BROWSER_AGENT_SYSTEM, prompt)
+        action = {"action": "done", "value": "não consegui decidir o próximo passo",
+                  "risky": False, "note": "erro ao interpretar a resposta do modelo"}
+        if raw:
+            text = raw.strip()
+            if text.startswith("```"):
+                text = text.strip("`")
+                text = text.split("\n", 1)[1] if "\n" in text else text
+                text = text.rsplit("```", 1)[0] if "```" in text else text
+            try:
+                parsed = json.loads(text)
+                if isinstance(parsed, dict) and parsed.get("action"):
+                    action = parsed
+            except (ValueError, TypeError):
+                pass
+        return {"action": action}
+
+    @app.post("/api/local-tasks/confirms")
+    async def local_confirms_create(request: Request):
+        # The local agent calls this right before a 'risky' in-flight action —
+        # a SECOND, separate approval on top of the task's original approval.
+        _check(request.headers.get("authorization"))
+        d = await _body(request)
+        tid = int(d.get("task_id") or 0)
+        label = (d.get("label") or "ação de alto risco").strip()
+        cid = memory.add_local_confirm(owner, tid, label[:200])
+        return {"ok": True, "id": cid}
+
+    @app.get("/api/local-tasks/confirms")
+    async def local_confirms_list(request: Request):
+        _check(request.headers.get("authorization"))
+        status = (request.query_params.get("status") or "").strip() or None
+        return {"items": memory.list_local_confirms(owner, status)}
+
+    @app.get("/api/local-tasks/confirms/status")
+    async def local_confirms_status(request: Request):
+        _check(request.headers.get("authorization"))
+        cid = int(request.query_params.get("id") or 0)
+        c = memory.get_local_confirm(owner, cid)
+        return {"status": (c or {}).get("status") or "unknown"}
+
+    @app.post("/api/local-tasks/confirms/approve")
+    async def local_confirms_approve(request: Request):
+        _check(request.headers.get("authorization"))
+        cid = int((await _body(request)).get("id") or 0)
+        ok = memory.set_local_confirm_status(owner, cid, "approved")
+        return {"ok": ok}
+
+    @app.post("/api/local-tasks/confirms/reject")
+    async def local_confirms_reject(request: Request):
+        _check(request.headers.get("authorization"))
+        cid = int((await _body(request)).get("id") or 0)
+        ok = memory.set_local_confirm_status(owner, cid, "rejected")
+        return {"ok": ok}
 
     # --- Spotify OAuth + Web API (Premium: read playlists + control playback) --
     import time as _time

--- a/local_agent.py
+++ b/local_agent.py
@@ -4,13 +4,22 @@ already approved (via the web console or the Telegram fallback) and executes
 them locally, then reports the result back.
 
 It NEVER runs anything by itself: the server only ever hands out tasks whose
-status is already 'approved', and a human always made that call first.
+status is already 'approved', and a human always made that call first. For
+'browser' tasks it goes further: it drives a real, autonomous browsing agent
+(goal in, LLM decides each click/type step via the server), but before any
+step the model or the risk classifier flags as risky (sending a message,
+posting, following, deleting...) it PAUSES and asks for a SECOND, separate
+confirmation (console or Telegram) before actually doing it.
 
 Usage:
     python3 local_agent.py
 
 Requires EV_WEB_BASE_URL and EV_WEB_TOKEN in the .env at the project root
-(the same ones the web console uses).
+(the same ones the web console uses). For 'browser' tasks you also need:
+    pip install playwright && playwright install chromium
+The first time you use a browser task against a site that needs login
+(WhatsApp Web, Instagram...), a real Chrome window opens — log in there once;
+the session persists in .browser_profile/ (gitignored) for next time.
 """
 
 from __future__ import annotations
@@ -31,6 +40,10 @@ BASE_URL = os.getenv("EV_WEB_BASE_URL", "").strip().rstrip("/")
 TOKEN = os.getenv("EV_WEB_TOKEN", "").strip()
 POLL_SECONDS = 5
 SHELL_TIMEOUT = 120
+BROWSER_PROFILE_DIR = _PROJECT_ROOT / ".browser_profile"
+MAX_BROWSER_STEPS = 12
+CONFIRM_TIMEOUT_SECONDS = 300
+CONFIRM_POLL_SECONDS = 5
 
 
 def _headers() -> dict:
@@ -84,13 +97,118 @@ def _run_open(target: str) -> tuple[bool, str]:
         return False, f"erro ao abrir: {exc}"
 
 
+def _decide_next_action(goal: str, url: str, page_text: str, history: list,
+                         high_risk: bool) -> dict:
+    r = requests.post(
+        f"{BASE_URL}/api/local-tasks/decide",
+        headers=_headers(),
+        json={
+            "goal": goal, "url": url, "page_text": page_text,
+            "history": history[-8:], "high_risk": high_risk,
+        },
+        timeout=30,
+    )
+    r.raise_for_status()
+    return r.json().get("action") or {"action": "done", "value": "sem resposta do servidor"}
+
+
+def _request_risky_confirmation(task_id: int, label: str) -> bool:
+    """Pauses execution to ask for a SEPARATE, second approval before a risky
+    step (send/post/follow/delete). Times out to 'refused' — never assumes
+    consent when the user hasn't actively responded."""
+    r = requests.post(
+        f"{BASE_URL}/api/local-tasks/confirms", headers=_headers(),
+        json={"task_id": task_id, "label": label[:200]}, timeout=15,
+    )
+    r.raise_for_status()
+    cid = r.json().get("id")
+    print(f"  ⚠️  ação de alto risco pausada, aguardando confirmação: {label}")
+    deadline = CONFIRM_TIMEOUT_SECONDS
+    while deadline > 0:
+        time.sleep(CONFIRM_POLL_SECONDS)
+        deadline -= CONFIRM_POLL_SECONDS
+        r2 = requests.get(
+            f"{BASE_URL}/api/local-tasks/confirms/status",
+            headers=_headers(), params={"id": cid}, timeout=15,
+        )
+        status = r2.json().get("status")
+        if status == "approved":
+            return True
+        if status == "rejected":
+            return False
+    return False  # timed out with no explicit answer -> treat as refused
+
+
+def _apply_browser_action(page, action: str, value: str) -> None:
+    if action == "goto":
+        page.goto(value, wait_until="load", timeout=30000)
+    elif action == "click_text":
+        page.get_by_text(value, exact=False).first.click(timeout=10000)
+    elif action == "type_text":
+        page.keyboard.type(value)
+    elif action == "press_enter":
+        page.keyboard.press("Enter")
+    elif action == "scroll":
+        page.mouse.wheel(0, 1500)
+    # 'read_more' and unknown actions: no-op, just re-observe the page.
+
+
+def _page_text(page) -> str:
+    try:
+        return page.inner_text("body")[:6000]
+    except Exception:
+        return ""
+
+
+def _run_browser(task: dict) -> tuple[bool, str]:
+    goal = (task.get("payload") or {}).get("command", "")
+    if not goal:
+        return False, "tarefa de navegador sem objetivo (comando vazio)"
+    high_risk = task.get("risk") == "high"
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        return False, (
+            "playwright não instalado no executor local — rode "
+            "'pip install playwright && playwright install chromium'"
+        )
+    history: list = []
+    with sync_playwright() as p:
+        ctx = p.chromium.launch_persistent_context(str(BROWSER_PROFILE_DIR), headless=False)
+        page = ctx.pages[0] if ctx.pages else ctx.new_page()
+        try:
+            for step in range(MAX_BROWSER_STEPS):
+                decision = _decide_next_action(
+                    goal, page.url, _page_text(page), history, high_risk)
+                action = decision.get("action") or "done"
+                value = decision.get("value") or ""
+                note = decision.get("note") or ""
+                risky = bool(decision.get("risky")) or (
+                    high_risk and action in ("click_text", "press_enter", "type_text"))
+                print(f"  [{step + 1}/{MAX_BROWSER_STEPS}] {action}: {note or value[:80]}")
+                history.append({"action": action, "value": value, "note": note})
+                if action == "done":
+                    return True, value or note or "objetivo concluído"
+                if risky and not _request_risky_confirmation(
+                    task["id"], note or f"{action}: {value}"[:200]
+                ):
+                    return False, "usuário recusou a confirmação de segurança da ação de alto risco"
+                _apply_browser_action(page, action, value)
+                time.sleep(1)
+            return False, f"atingiu o limite de {MAX_BROWSER_STEPS} passos sem concluir"
+        finally:
+            ctx.close()
+
+
 def execute(task: dict) -> tuple[bool, str]:
     kind = task["kind"]
     command = (task.get("payload") or {}).get("command", "")
     if kind == "shell":
         return _run_shell(command)
-    if kind in ("open", "browser"):
+    if kind == "open":
         return _run_open(command)
+    if kind == "browser":
+        return _run_browser(task)
     if kind == "script":
         resolved = _resolve_script(command)
         if not resolved:

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,5 +47,10 @@ pywebpush>=1.14.0
 # HTTP client for local_agent.py (the PC-side task executor)
 requests>=2.31.0
 
+# Real browser automation for local_agent.py 'browser' tasks (optional — only
+# needed on the machine running local_agent.py, not on the server). After
+# installing, also run: playwright install chromium
+playwright>=1.40.0
+
 # Tests (dev)
 pytest>=8.0.0


### PR DESCRIPTION
## 🤔 Context

The local-PC execution feature (#144) shipped with a stub: the `browser` task kind just did `open <url>` on macOS — no real navigation, clicking, typing, or reading. It couldn't actually act as an autonomous agent in the browser.

This PR replaces the stub with a real, autonomous Playwright-based agent in `local_agent.py`: given a goal in natural language (e.g. "pesquisar X no Google e resumir os 3 melhores resultados"), it launches a persistent, logged-in browser profile and loops — each step it asks the server (`POST /api/local-tasks/decide`, using the existing LLM provider chain via `Brain.ask`) what to do next (`goto`, `click_text`, `type_text`, `press_enter`, `scroll`, `read_more`, `done`) — until the goal is done or it hits a step cap.

Because unofficial automation of WhatsApp Web / Instagram carries real account-ban / ToS risk, any browser task whose command mentions those platforms is auto-classified as **high risk** (`Memory.classify_local_task_risk`). On top of the task's original approval, any in-flight step the model (or the risk classifier) flags as irreversible — sending, posting, following, deleting — pauses execution and creates a **second, separate confirmation** (`local_confirms` table) that must be approved via the web console or Telegram before the agent is allowed to actually click/type. No task kind, including this one, ever auto-runs.

Also fixed a real pre-existing bug while in there: the "Executor local" tab (`#locview`) was missing from three shared CSS selector groups that every other tab has (padding, `overflow:auto`, and the narrow-viewport padding rule) — its content was rendering flush against the viewport edges with no responsive behavior. Added it to all three.

> [!NOTE]
> The browser agent's action set is intentionally small (goto/click_text/type_text/press_enter/scroll) and capped at 12 steps per task — it's a first pass at real automation, not a polished one. `type_text` types into whatever currently has focus, so it depends on the model clicking into the right field first; DOM structure on real sites (especially WhatsApp Web/Instagram) isn't guaranteed to match what the model expects.

> [!WARNING]
> This was verified end-to-end against a harmless goal (searching a neutral term) in an isolated scratch environment — not against a live WhatsApp/Instagram session, since that would mean actually automating those platforms. The real production database was checksummed before and after verification and is unchanged. First real use against a site requiring login (WhatsApp Web, Instagram) will need you to log in once in the real Chromium window that opens — the session then persists in `.browser_profile/` (gitignored).

```mermaid
sequenceDiagram
    participant U as Você
    participant EV as E.V. (chat)
    participant DB as local_tasks / local_confirms
    participant Agent as local_agent.py (seu PC)
    participant LLM as /api/local-tasks/decide

    U->>EV: "abre o navegador e pesquisa X"
    EV->>DB: cria local_task (pending, risk=normal|high)
    U->>DB: aprova (console ou Telegram)
    Agent->>DB: claim (approved -> running)
    loop até "done" ou limite de passos
        Agent->>LLM: objetivo + estado da página
        LLM-->>Agent: próxima ação (+ risky?)
        alt ação arriscada
            Agent->>DB: cria local_confirm (pending)
            U->>DB: confirma ou recusa
        end
        Agent->>Agent: executa ação no navegador real
    end
    Agent->>DB: reporta resultado
```