### PR TITLE
fix(telegram_bot): import tools_mod so /resumir works

### DIFF
--- a/ev/interfaces/telegram_bot/commands_wrappers.py
+++ b/ev/interfaces/telegram_bot/commands_wrappers.py
@@ -15,6 +15,7 @@ from telegram.ext import ContextTypes
 
 from ...core import health
 from ...core.memory import Memory
+from ...providers import tools as tools_mod
 
 
 class CommandsWrappersMixin:


### PR DESCRIPTION
## 🤔 Context

The `/resumir` Telegram command was broken — it raised a `NameError` on **every** invocation.

Its handler `_summarize_url` in `ev/interfaces/telegram_bot/commands_wrappers.py` calls `tools_mod.fetch_text(url)` to download a page's text, but `tools_mod` was never imported in that file. The name went missing when the telegram_bot module was split into mixins during the recent refactor, so the reference had no binding at runtime.

This adds the single missing import:

```python
from ...providers import tools as tools_mod
```

`fetch_text` lives in `ev/providers/tools/websearch.py` and is re-exported from the `ev/providers/tools` package, so `tools_mod.fetch_text` now resolves correctly. No other logic changed.

The full test suite passes (186 passed) and an import/bind sanity check confirms `tools_mod.fetch_text` is now callable — no more `NameError`.