### PR TITLE
docs: resync architecture docs with post-refactor package layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,9 +381,9 @@ E.V/
 │   ├── config.py            # configuration (.env)
 │   ├── personality.py       # who E.V. is (PT-BR system prompt)
 │   ├── core/
-│   │   ├── brain.py         # LLM + memory + tools + RAG + fallback
-│   │   ├── memory.py        # SQLite: messages, facts, reminders, tasks, KB…
-│   │   ├── commands.py      # deterministic slash commands (no LLM)
+│   │   ├── brain/          # LLM + memory + tools + RAG + fallback (mixin package)
+│   │   ├── memory/         # SQLite: messages, facts, reminders, tasks, KB… (mixin package)
+│   │   ├── commands/       # deterministic slash commands, no LLM (mixin package)
 │   │   ├── knowledge.py     # PDF/Word/web ingestion + chunking
 │   │   ├── timeparse.py     # natural-time + month-boundary helpers
 │   │   └── health.py        # system + provider health checks
@@ -391,11 +391,11 @@ E.V/
 │   │   ├── llm.py           # Gemini/Groq/OpenRouter/Ollama + Whisper
 │   │   ├── embeddings.py    # semantic embeddings
 │   │   ├── voice.py         # text → speech (edge-tts)
-│   │   ├── tools.py         # web search, calendar, email
+│   │   ├── tools/          # web search, weather, maps, calendar, email (package)
 │   │   └── documents.py     # PDF/Word generation
 │   └── interfaces/
-│       ├── telegram_bot.py  # Telegram adapter + scheduler + automations
-│       ├── web.py           # FastAPI server + single-page console
+│       ├── telegram_bot/   # Telegram adapter + scheduler + automations (mixin package)
+│       ├── web/            # FastAPI server + single-page console (router package)
 │       └── terminal.py      # terminal REPL
 ├── deploy/                  # setup_vm.sh · watchdog.sh · HTTPS runbooks
 ├── docs/                    # full documentation (index below)

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -15,20 +15,43 @@ ev/
 ├── config.py            # settings from .env (add new options here)
 ├── personality.py       # how E.V. talks (edit freely, no coding)
 ├── core/
-│   ├── brain.py         # LLM orchestration + fallback + tools + RAG
-│   ├── memory.py        # SQLite: tables + all data access methods
-│   ├── commands.py      # deterministic slash commands (no LLM)
+│   ├── brain/           # LLM orchestration package (mixins → class Brain in base.py)
+│   │   ├── base.py             # class Brain(TranscriptionMixin, …); __init__
+│   │   ├── ask.py              # the respond()/ask turn logic
+│   │   ├── tools.py            # _tool_callables (Gemini) + _openai_tools (Groq)
+│   │   ├── transcription.py    # audio → text
+│   │   ├── provider_health.py  # health/availability checks
+│   │   └── providers_fallback.py  # Gemini → Groq → OpenRouter → Ollama chain
+│   ├── memory/          # SQLite package (mixins → class Memory in base.py)
+│   │   ├── base.py             # class Memory(SchemaMixin, …); connection
+│   │   ├── schema.py           # table DDL (_init_schema)
+│   │   └── <domain>.py         # one file per domain: tasks, facts, links, …
+│   ├── commands/        # deterministic slash commands (mixins → class Commands)
+│   │   ├── base.py             # class Commands(…); COMMAND_LIST; helpers
+│   │   └── <domain>.py         # one file per domain: tasks, expenses, habits, …
 │   ├── timeparse.py     # time parsing for commands
 │   └── knowledge.py     # document/URL ingestion
 ├── providers/
 │   ├── llm.py           # Gemini/Groq/OpenRouter/Ollama chat + Whisper
 │   ├── embeddings.py    # embeddings (Gemini/Ollama)
 │   ├── voice.py         # text -> speech
-│   └── tools.py         # web search, weather, news, calendar, email, fetch
+│   └── tools/           # package: weather, websearch, maps, calendar, email, google_auth
 └── interfaces/
-    └── telegram_bot.py  # command handlers, menu, schedulers
+    ├── telegram_bot/    # Telegram adapter package (mixins → class TelegramInterface)
+    │   ├── base.py             # __init__, _post_init, run() + handler registration
+    │   └── <area>.py           # routing, voice, media, pomodoro, keyboards, callbacks, …
+    ├── web/             # FastAPI console package
+    │   ├── app.py              # create_app() + router registration + structural routes
+    │   ├── context.py          # WebContext (shared singletons)
+    │   ├── frontend.py         # static _PAGE / favicon / service-worker
+    │   └── routes/<domain>.py  # one APIRouter per domain, each build_router(ctx)
+    └── terminal.py      # terminal REPL
 tests/                   # pytest — add a test per feature
 ```
+
+Every package's `__init__.py` re-exports the same public names (`Brain`, `Memory`,
+`Commands`, `TelegramInterface`, the tool functions), so **import paths are
+unchanged** despite the split.
 
 Dependency rule: interfaces → core → providers. Never import an interface from
 core, or core from an interface.
@@ -37,16 +60,19 @@ core, or core from an interface.
 
 Example: a `/nota` command to save quick notes. Five small steps.
 
-**1. Storage — `ev/core/memory.py`.** Add a table to `_init_schema` and methods:
+**1. Storage — `ev/core/memory/`.** Add the table DDL to `_init_schema` in
+`ev/core/memory/schema.py`, then put the data-access methods in a domain mixin file
+(e.g. a new `ev/core/memory/notes.py` defining `class NotesMixin`) and list that
+mixin in `class Memory(SchemaMixin, …)` in `ev/core/memory/base.py`:
 
 ```python
-# inside _init_schema executescript:
+# inside _init_schema (ev/core/memory/schema.py) executescript:
 CREATE TABLE IF NOT EXISTS notes (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     user_id TEXT NOT NULL, text TEXT NOT NULL, created TEXT NOT NULL
 );
 
-# methods on the Memory class:
+# methods on the NotesMixin (ev/core/memory/notes.py):
 def add_note(self, user_id, text):
     cur = self._conn.execute(
         "INSERT INTO notes (user_id, text, created) VALUES (?, ?, ?)",
@@ -59,7 +85,9 @@ def list_notes(self, user_id):
     return [dict(r) for r in rows]
 ```
 
-**2. Command logic — `ev/core/commands.py`.** Add a method returning a PT-BR string:
+**2. Command logic — `ev/core/commands/`.** Add the method to the matching domain
+mixin (e.g. `ev/core/commands/tasks.py`), or a new `<domain>.py` mixin listed in
+`class Commands(…)` in `ev/core/commands/base.py`. It returns a PT-BR string:
 
 ```python
 def nota(self, user_id, argstr):
@@ -70,13 +98,16 @@ def nota(self, user_id, argstr):
     return f"Nota #{nid} salva."
 ```
 
-Also add it to `COMMAND_LIST` (populates the Telegram `/` menu):
+Also add it to `COMMAND_LIST` in `ev/core/commands/base.py` (populates the Telegram
+`/` menu):
 
 ```python
 ("nota", "Salvar uma nota: /nota comprar leite"),
 ```
 
-**3. Telegram handler — `ev/interfaces/telegram_bot.py`.** Copy an existing handler:
+**3. Telegram handler — `ev/interfaces/telegram_bot/`.** Add the `cmd_*` wrapper to
+the `CommandsWrappersMixin` in `ev/interfaces/telegram_bot/commands_wrappers.py`,
+copying an existing handler:
 
 ```python
 async def cmd_nota(self, update, c):
@@ -85,7 +116,9 @@ async def cmd_nota(self, update, c):
         await self._cmd_out(update, self._commands.nota(uid, self._args(c)))
 ```
 
-**4. Register it** in `run()` next to the others:
+**4. Register it** in `run()` (in `ev/interfaces/telegram_bot/base.py`) next to the
+others — keep the handler registration order Document → Photo → Audio → Voice → Text
+intact:
 
 ```python
 app.add_handler(CommandHandler("nota", self.cmd_nota))
@@ -101,21 +134,32 @@ def test_nota(tmp_path):
 
 Run `python -m pytest -q`. Done.
 
+> **Web console equivalent.** To surface the same data in the web UI, add an
+> APIRouter at `ev/interfaces/web/routes/notes.py` exposing `build_router(ctx)`
+> (read `ctx.memory` / `ctx.commands`), then include the module in the router loop
+> in `ev/interfaces/web/app.py`. Copy an existing `routes/<domain>.py`.
+
 ## Recipe B: add a scheduled/proactive automation
 
-Automations live in `telegram_bot.py`. The `_briefing_loop` runs every 60s — add
-a `_maybe_do_x(app)` method and call it there (guard with a `self._last_x` date so
-it fires once). For frequent polling (like web monitors), add a separate loop in
-`_post_init`'s `self._bg_tasks` list. Use `EV_*` config for hours/intervals.
+Automations live in the `BackgroundLoopsMixin`
+(`ev/interfaces/telegram_bot/background_loops.py`). The `_briefing_loop` runs every
+60s — add a `_maybe_do_x(app)` method and call it there (guard with a `self._last_x`
+date so it fires once). For frequent polling (like web monitors), add a separate loop
+in `_post_init` (`ev/interfaces/telegram_bot/base.py`) via the `self._bg_tasks` list.
+Use `EV_*` config for hours/intervals.
 
 ## Recipe C: add a real-world tool (web/API)
 
-Put the raw call in `ev/providers/tools.py` (use `httpx`; the OS trust store is
+Put the raw call in the matching submodule under `ev/providers/tools/` (or a new one,
+re-exported from `ev/providers/tools/__init__.py`; use `httpx`, the OS trust store is
 already injected). Then either expose it as a slash command (Recipe A) or as an
-LLM tool so E.V. calls it in conversation:
+LLM tool so E.V. calls it in conversation. Both tool schemas live together in
+`ev/core/brain/tools.py` and must stay in sync (a test,
+`tests/test_brain_tools_sync.py`, guards this):
 
-- In `brain._tool_callables`, add a Python function (name, docstring, typed args).
-- Mirror it in `brain._openai_tools()` (same name/params) so Groq can call it too.
+- In `_tool_callables`, add a Python function (name, docstring, typed args) — the
+  Gemini-native path.
+- Mirror it in `_openai_tools()` (same name/params) so Groq can call it too.
 
 ## Recipe D: change behavior with NO code
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,20 +14,20 @@ about inner ones, never the reverse.
 ```mermaid
 flowchart LR
     subgraph OUT["Interfaces (I/O adapters)"]
-        TG["telegram_bot.py"]
-        WEB["web.py (FastAPI SPA)"]
+        TG["telegram_bot/ (mixin package)"]
+        WEB["web/ (FastAPI SPA, router package)"]
         TE["terminal.py"]
     end
     subgraph CORE["Core (reusable logic)"]
-        B["brain.py"]
-        CM["commands.py"]
-        M["memory.py"]
+        B["brain/ (mixin package)"]
+        CM["commands/ (mixin package)"]
+        M["memory/ (mixin package)"]
     end
     subgraph PROV["Providers (external services)"]
         L["llm.py"]
         E["embeddings.py"]
         V["voice.py"]
-        T["tools.py"]
+        T["tools/ (package)"]
         D["documents.py"]
     end
     TG --> B
@@ -45,7 +45,7 @@ flowchart LR
 ```
 
 - **Interfaces** (`ev/interfaces`): receive input and deliver output — **Telegram**,
-  the **web console** (`web.py`, FastAPI serving a single-page app), and **Terminal**.
+  the **web console** (`web/`, FastAPI serving a single-page app), and **Terminal**.
   They only call `Brain.respond()` (and `Commands.run()` for deterministic actions).
 - **Core** (`ev/core`): `Brain` orchestrates; `Memory` holds state. They know
   nothing about Telegram or HTTP.
@@ -56,6 +56,21 @@ flowchart LR
 
 Adding an interface = writing a new adapter that calls `Brain.respond()`. Zero
 changes to the core.
+
+> **Each layer box above is now a package, not a single file.** `brain/`,
+> `commands/`, and `memory/` are composed by **mixins** — one file per domain
+> (e.g. `ev/core/memory/tasks.py`, `ev/core/commands/expenses.py`) merged into a
+> single class in that package's `base.py` (`class Memory(SchemaMixin, …)`).
+> `telegram_bot/` follows the same mixin pattern
+> (`class TelegramInterface(RoutingMixin, VoiceMixin, …)` in `base.py`), while
+> `web/` splits into **FastAPI routers** — one `ev/interfaces/web/routes/<domain>.py`
+> per domain, each exposing `build_router(ctx)` and registered in `web/app.py`.
+> `ev/providers/tools/` is likewise a package (weather / websearch / maps /
+> calendar / email / google_auth submodules). Every package's `__init__.py`
+> re-exports the same public names, so **import paths are unchanged**. To add a new
+> domain: drop a mixin file and list it in that package's `base.py` class bases
+> (for `web/`, add a `routes/<domain>.py` with `build_router` and include it in
+> `app.py`).
 
 ## Multi-provider strategy (resilience)
 
@@ -174,7 +189,8 @@ the scheduler as a background task and delivers due reminders to the user's chat
 
 ## Tools
 
-Exposed to the model via function calling (`ev/providers/tools.py`):
+Exposed to the model via function calling (`ev/providers/tools/`, one submodule
+per tool — weather, websearch, maps, calendar, email, google_auth):
 
 - **web search** — DuckDuckGo, no API key.
 - **calendar / email** — Google APIs; require one-time OAuth setup by the user
@@ -182,7 +198,8 @@ Exposed to the model via function calling (`ev/providers/tools.py`):
 
 ## Slash commands (no LLM)
 
-`ev/core/commands.py` implements deterministic commands that never touch the LLM:
+`ev/core/commands/` (a mixin package, one file per domain) implements deterministic
+commands that never touch the LLM:
 reminders, tasks, memory, links (named/categorized), and the knowledge base. The
 Telegram interface maps each `/command` to a method; the logic is interface-agnostic
 so a terminal/web interface can reuse it. Times are parsed by `ev/core/timeparse.py`
@@ -206,7 +223,7 @@ and works on any network. Outside a corporate proxy, it's harmless.
 
 ## Web access & private HTTPS
 
-The web console (`web.py`) runs as its own process/service and binds to
+The web console (`ev/interfaces/web/`) runs as its own process/service and binds to
 `EV_WEB_HOST:EV_WEB_PORT` (default `127.0.0.1:8000` in production). It is fronted by
 **Tailscale Serve**, which terminates TLS with a valid `*.ts.net` certificate and
 proxies to the local port — so the UI is reachable at `https://ev.<tailnet>.ts.net`


### PR DESCRIPTION
## 🤔 Context

The recent 6-phase architecture refactor split the large monolithic files into packages while **keeping every public import path unchanged**:

- `ev/core/brain.py` → `ev/core/brain/` (mixins → `class Brain` in `base.py`; `tools.py` holds `_tool_callables` + `_openai_tools` together, kept in sync)
- `ev/core/memory.py` → `ev/core/memory/` (mixins → `class Memory(SchemaMixin, …)`)
- `ev/core/commands.py` → `ev/core/commands/` (per-domain mixins → `class Commands`)
- `ev/interfaces/telegram_bot.py` → `ev/interfaces/telegram_bot/` (mixins → `class TelegramInterface`)
- `ev/interfaces/web.py` → `ev/interfaces/web/` (`app.py` + `context.py` + `frontend.py` + `routes/<domain>.py`, each `build_router(ctx)`)
- `ev/providers/tools.py` → `ev/providers/tools/` (weather/websearch/maps/calendar/email/google_auth submodules)

The docs were left describing the old flat-file layout (flowchart boxes labeled `brain.py`, `web.py`, …; EXTENDING's "Where things live" tree and Recipe A/B/C flat paths). This PR resyncs them with the real file layout — a correction pass, not a rewrite.

What changed:
- **docs/architecture.md** — diagram labels now name the packages; a short note under "Core principle" explains the mixin/router composition and where to add a new domain; `tools` / `commands` / `web` prose references corrected.
- **docs/EXTENDING.md** — "Where things live" tree expanded to the package structure; Recipe A/B/C now point at the right mixin files (`memory/`, `commands/`, `telegram_bot/`), the web `routes/<domain>.py` + `build_router` path, and `ev/core/brain/tools.py` with the `_tool_callables`/`_openai_tools` sync requirement.
- **README.md** — stale `.py` filenames in the Project structure tree fixed (the Architecture mermaid labels were already generic and left as-is).

> [!NOTE]
> Documentation only — no code under `ev/`, `tests/`, or `.github/` was touched. Every path in the updated trees was cross-checked against the actual on-disk layout (directory listings of `ev/core/{brain,memory,commands}/`, `ev/interfaces/{telegram_bot,web,web/routes}/`, and `ev/providers/tools/`), including the real mixin class-base lists and the `web/app.py` router registration loop.