### PR TITLE
docs: bring README + onboarding polish to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ hands — loyal, warm, playful, and always on your side.
 ![Telegram](https://img.shields.io/badge/Bot-Telegram-1a1a1a?logo=telegram&logoColor=white)
 ![LLMs](https://img.shields.io/badge/LLMs-Gemini·Groq·OpenRouter-1a1a1a)
 ![SQLite](https://img.shields.io/badge/Memory-SQLite%20+%20vectors-1a1a1a?logo=sqlite&logoColor=white)
-![Tests](https://img.shields.io/badge/tests-185%20passing-2e7d32)
+![Tests](https://img.shields.io/badge/tests-186%20passing-2e7d32)
 [![Deploy](https://github.com/Ryanditko/E.V/actions/workflows/deploy.yml/badge.svg)](https://github.com/Ryanditko/E.V/actions/workflows/deploy.yml)
 
 **[Screenshots](#screenshots) · [Features](#what-she-does) · [Quick start](#quick-start) · [Architecture](#architecture) · [Deploy 24/7](#run-her-24-7) · [Docs](#documentation)**
@@ -24,8 +24,9 @@ hands — loyal, warm, playful, and always on your side.
 
 ---
 
-> **Language note.** This documentation is in English. E.V. **talks to you in Brazilian
-> Portuguese** — chat and voice — on purpose; her personality lives in `ev/personality.py`.
+> [!NOTE]
+> **This documentation is in English. E.V. talks to you in Brazilian Portuguese** —
+> chat and voice — on purpose; her personality lives in `ev/personality.py`.
 
 ---
 
@@ -205,12 +206,12 @@ More: **[docs/WEB.md](docs/WEB.md)**.
 
 ## Quick start
 
-> Full first-machine walkthrough (every key, Google auth, deploy): **[docs/SETUP.md](docs/SETUP.md)**.
+**Requirements:** Python 3.11+ and `git`. That's it — everything else the installer sets up.
 
-### Instalação rápida (1 comando)
-
-The friendly installer checks Python, creates the venv, installs deps and fills in
-your `.env` interactively — you only need the two required keys (see [docs/KEYS.md](docs/KEYS.md)):
+> [!TIP]
+> **Fastest path — one command.** The friendly installer checks Python, creates the venv,
+> installs deps and fills in your `.env` interactively. You only need the **two required
+> keys** (both free, no card): a Telegram bot token and a Gemini key.
 
 ```bash
 git clone https://github.com/Ryanditko/E.V.git ev && cd ev && bash install.sh
@@ -222,8 +223,9 @@ Non-interactive (CI / scripted) — pass the keys as env vars and it won't promp
 TELEGRAM_TOKEN=... GEMINI_API_KEY=... bash install.sh
 ```
 
-It never overwrites an existing `.env`. Prefer to wire things up by hand? The manual
-steps are below.
+It never overwrites an existing `.env`. Prefer to wire things up by hand? Follow the
+manual steps below. Either way, the full first-machine walkthrough (every key, Google
+auth, deploy) lives in **[docs/SETUP.md](docs/SETUP.md)**.
 
 ### Manual
 
@@ -242,15 +244,29 @@ python run_terminal.py        # terminal REPL
 
 Every variable and cost is in **[docs/KEYS.md](docs/KEYS.md)**. The essentials:
 
-| Variable | Where |
-|----------|-------|
-| `TELEGRAM_TOKEN` | [@BotFather](https://t.me/BotFather) |
-| `GEMINI_API_KEY` | https://aistudio.google.com/apikey |
-| `GROQ_API_KEY` | https://console.groq.com/keys |
-| `OPENROUTER_API_KEY` | https://openrouter.ai/keys |
-| `TAVILY_API_KEY` | https://app.tavily.com (better web search) |
-| `EV_WEB_TOKEN` | any long random string (web login) |
-| `EV_OWNER_ID` | your Telegram ID — locks the bot to you |
+| Variable | Where | |
+|----------|-------|---|
+| `TELEGRAM_TOKEN` | [@BotFather](https://t.me/BotFather) | **required** |
+| `GEMINI_API_KEY` | https://aistudio.google.com/apikey | **required** |
+| `EV_OWNER_ID` | your Telegram ID — locks the bot to you | recommended |
+| `GROQ_API_KEY` | https://console.groq.com/keys | optional (fallback + voice) |
+| `OPENROUTER_API_KEY` | https://openrouter.ai/keys | optional (fallback) |
+| `TAVILY_API_KEY` | https://app.tavily.com | optional (better web search) |
+| `EV_WEB_TOKEN` | any long random string | optional (web login) |
+
+> [!IMPORTANT]
+> Only **`TELEGRAM_TOKEN`** and **`GEMINI_API_KEY`** are strictly required — everything
+> else is optional and just unlocks more. Set **`EV_OWNER_ID`** to your Telegram numeric
+> ID to lock the bot to you (send `/start` and read it from the logs).
+
+> [!WARNING]
+> Leave `EV_OWNER_ID` **empty** and the bot answers **anyone** who messages it. Set it
+> before you share the bot's username. Likewise, only enable the web console with a
+> **long, random `EV_WEB_TOKEN`** — it's the key to your data.
+
+> [!CAUTION]
+> Never commit secrets. `.env`, `client_secret*.json`, `google_token*.json` and `*.db`
+> are git-ignored for a reason — keep them that way and never paste them anywhere public.
 
 ---
 
@@ -273,6 +289,11 @@ Type `/` for autocomplete, or `/menu` for a button UI. A taste:
 
 Time formats: `10m`, `2h`, `1d`, `hoje 18:00`, `amanhã 09:00`, `25/12 14:30`.
 
+> [!NOTE]
+> Integrations like **Google** (Calendar + Gmail) and **Spotify** are **opt-in** — they
+> stay dormant until you add their keys and run the one-time OAuth. Everything else works
+> without them. See **[docs/KEYS.md](docs/KEYS.md)** for what each one unlocks.
+
 ---
 
 ## AI providers (all free tiers)
@@ -287,6 +308,11 @@ Time formats: `10m`, `2h`, `1d`, `hoje 18:00`, `amanhã 09:00`, `25/12 14:30`.
 | Embeddings | **Gemini / Ollama** | `gemini-embedding-001` | Semantic memory + knowledge base |
 
 Switch or force a provider at runtime with `/provedor` and `/modelo`.
+
+> [!TIP]
+> Add a **local Ollama** model (`ollama pull llama3.1`) and E.V. **never runs out of
+> quota** — when every cloud provider is rate-limited, she falls back to your own machine.
+> It's optional, but it's the difference between "she went quiet" and "she never does".
 
 ---
 
@@ -419,7 +445,7 @@ E.V/
 │       └── terminal.py      # terminal REPL
 ├── deploy/                  # setup_vm.sh · watchdog.sh · HTTPS runbooks
 ├── docs/                    # full documentation (index below)
-└── tests/                   # 185 tests
+└── tests/                   # 186 tests
 ```
 
 ---
@@ -427,7 +453,7 @@ E.V/
 ## Testing
 
 ```bash
-./.venv/bin/python -m pytest -q      # 185 passing
+./.venv/bin/python -m pytest -q      # 186 passing
 ```
 
 CI runs the suite as a **gate before every deploy** — a red test never ships.

--- a/docs/KEYS.md
+++ b/docs/KEYS.md
@@ -10,8 +10,16 @@ it maps to, and whether it costs anything. Fill keys in `.env` (never commit it)
 | **Telegram BotFather** | Create the bot, get its token | https://t.me/BotFather | `TELEGRAM_TOKEN` | Free, no card |
 | **Google AI Studio** | Gemini API key (main brain + embeddings) | https://aistudio.google.com/apikey | `GEMINI_API_KEY` | Free, no card (use a personal @gmail) |
 
+> [!IMPORTANT]
+> These **two keys are all you need to start** — both free, neither asks for a card.
+> Everything below is optional and only adds resilience or features.
+
 Your Telegram numeric ID (for `EV_OWNER_ID`, to lock the bot to you): message
 **@userinfobot** on Telegram, or run the bot and read it from the logs after `/start`.
+
+> [!WARNING]
+> If `EV_OWNER_ID` is left empty, the bot replies to **anyone** who messages it. Set it
+> to your own numeric ID before sharing the bot's username.
 
 ## Recommended fallback AI providers (free, no card)
 
@@ -19,6 +27,10 @@ Your Telegram numeric ID (for `EV_OWNER_ID`, to lock the bot to you): message
 |---------|----------|------|-----------------|--------------|
 | **Groq** | Fast fallback LLM + Whisper (audio) | https://console.groq.com/keys | `GROQ_API_KEY` | Free, no card |
 | **OpenRouter** | Extra fallback LLM | https://openrouter.ai/keys | `OPENROUTER_API_KEY` | Free, no card |
+
+> [!NOTE]
+> Optional but worth it: `GROQ_API_KEY` also powers **voice transcription** (Whisper),
+> and each extra provider is one more layer keeping E.V. from ever going silent.
 
 ## Web search (optional — better than the free default)
 
@@ -102,4 +114,6 @@ Deploy guide: [DEPLOY.md](DEPLOY.md) · phone: [TERMUX.md](TERMUX.md) · PC serv
 - Configured providers: Gemini + Groq + OpenRouter; Tavily web search; open-meteo weather.
 - Pending: Google OAuth (run `authorize_google.py` on your PC, then copy the token to the VM).
 
-> Reminder: never commit `.env`, `client_secret*.json`, `google_token*.json`, `*.db`, or the SSH key.
+> [!CAUTION]
+> Keep every key secret. Never commit `.env`, `client_secret*.json`, `google_token*.json`,
+> `*.db`, or the SSH key — they're git-ignored, so keep them out of any public place.

--- a/docs/SELF_HOST.md
+++ b/docs/SELF_HOST.md
@@ -41,8 +41,10 @@ launchctl start com.ev.bot
 ```
 3. Logs: `tail -f ~/ev/ev.log`. Stop: `launchctl unload ~/Library/LaunchAgents/com.ev.bot.plist`.
 
-> The Mac must be on and awake. To keep it running with the lid closed, keep it
-> plugged in (and consider `caffeinate`), or disable sleep in System Settings.
+> [!IMPORTANT]
+> The Mac must be on and awake for E.V. to answer. To keep it running with the lid
+> closed, keep it plugged in (and consider `caffeinate`), or disable sleep in System
+> Settings — otherwise she goes offline the moment the machine sleeps.
 
 ## Linux (systemd)
 
@@ -88,7 +90,9 @@ journalctl --user -u ev -f        # logs
    - Settings: check **If the task fails, restart every 1 minute**.
 3. Save. It starts with Windows and stays running in the background.
 
-> The PC must be on. Set power options so it doesn't sleep while plugged in.
+> [!IMPORTANT]
+> The PC must be on. Set power options so it doesn't sleep while plugged in, or E.V.
+> stops responding until it wakes.
 
 ## Update to the latest code (any OS)
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -19,6 +19,7 @@ git clone https://github.com/Ryanditko/E.V.git ev
 cd ev
 ```
 
+> [!TIP]
 > **Shortcut:** `bash install.sh` does steps 3–5 for you (checks Python, creates the
 > venv, installs deps, fills in `.env` interactively, and offers to start E.V.). It's
 > the fastest local self-host path; the manual steps below are still here if you prefer.
@@ -31,8 +32,9 @@ source .venv/bin/activate          # Windows: .venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
-> **Note (corporate machines):** if `pip` points to a private registry and fails,
-> install from the public PyPI: `pip install -i https://pypi.org/simple/ -r requirements.txt`.
+> [!NOTE]
+> **Corporate machines:** if `pip` points to a private registry and fails, install from
+> the public PyPI: `pip install -i https://pypi.org/simple/ -r requirements.txt`.
 
 ## 4. Configuration (.env)
 
@@ -40,8 +42,12 @@ pip install -r requirements.txt
 cp .env.example .env
 ```
 
-Fill in the keys below. Only `TELEGRAM_TOKEN` and `GEMINI_API_KEY` are strictly
-required; everything else is optional and enables more features.
+Fill in the keys below.
+
+> [!IMPORTANT]
+> Only **`TELEGRAM_TOKEN`** and **`GEMINI_API_KEY`** are strictly required; everything
+> else is optional and just enables more features. Set **`EV_OWNER_ID`** too — without
+> it the bot answers everyone (see the table).
 
 | Variable | Required? | Where to get it |
 |----------|-----------|-----------------|
@@ -104,8 +110,10 @@ One Google Cloud project/OAuth client serves all your accounts.
 Usage: `/agenda [account]`, `/evento [account] <time> <title>`,
 `/email [account] to@x.com | subject | body`. Omitting the account uses the first.
 
+> [!WARNING]
 > Institutional (faculty/work) accounts may block third-party OAuth apps by admin
 > policy; if so, that account cannot be authorized (nothing we can do client-side).
+> Use a personal Google account for the smoothest path.
 
 ## 7. Deploy 24/7 (Oracle Cloud)
 
@@ -116,8 +124,10 @@ authorize locally first, then copy `google_token_*.json` to the VM.
 
 ## 8. Files that must NOT be committed (secrets)
 
-Already in `.gitignore`, but never share these:
-`.env`, `client_secret*.json`, `google_token*.json`, `ev_memory.db`, `backups/`.
+> [!CAUTION]
+> These are already in `.gitignore`, but never share or commit them anywhere:
+> `.env`, `client_secret*.json`, `google_token*.json`, `ev_memory.db`, `backups/`.
+> They hold your tokens and personal data.
 
 ## 9. Moving to a new computer — checklist
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -42,6 +42,11 @@ This re-ships the code + your keys and restarts. Use it if a change broke someth
 | Service not "active" / crash loop | Code or config error at startup | `journalctl -u ev -n 60` to see the error; then `bash deploy.sh` to restore |
 | Two bots answering / "conflict" | Another copy running (e.g. local + VM) with the same token | Keep only ONE running per Telegram token |
 
+> [!WARNING]
+> A single Telegram token can only be polled by **one** running instance. If you start
+> E.V. locally while the VM copy is up, both fight for updates and you'll see "conflict"
+> errors — stop one of them.
+
 ## Reset just the model (most common self-fix)
 In Telegram: **`/modelo reset`** → back to the default Gemini model. `/modelo`
 (no argument) shows what's active and today's usage.
@@ -100,4 +105,7 @@ The project is standard, documented Python — the logs almost always point stra
 to the cause. See also `docs/EXTENDING.md` and `docs/CAPABILITIES.md`.
 
 ## Golden rule
-**Restart → read logs → redeploy → ask an AI with the logs.** In that order.
+
+> [!TIP]
+> **Restart → read logs → redeploy → ask an AI with the logs.** In that order. A plain
+> `sudo systemctl restart ev` fixes the large majority of hiccups.


### PR DESCRIPTION
## 🤔 Context

The docs-polish work (GitHub alert callouts across the README + onboarding docs, clearer install-first onboarding, and the stale test-count fix 185→186) was originally PR #161, stacked on top of the install-wizard PR #160.

When #160 merged into `main` first and #161 then merged into the `feat/install-wizard` branch, GitHub did **not** re-target #161 to `main` — so commit `e0090cc` (the polish) landed on `feat/install-wizard` but never reached `main`. `install.sh` (from #160) is on `main`, but the README still showed the un-polished version.

This PR cherry-picks that polish commit cleanly onto `main` to finish the job. Docs-only — no code touched.

> [!NOTE]
> Content is byte-identical to the already-reviewed #161 (callouts: NOTE/TIP/IMPORTANT/WARNING/CAUTION in README + SETUP/KEYS/SELF_HOST/TROUBLESHOOTING; test count corrected to 186). Nothing new to re-review beyond confirming it now targets `main`.