### PR TITLE
docs: translate remaining Portuguese docs to English + fix stale references

### DIFF
--- a/deploy/HTTPS_CLOUDFLARE.md
+++ b/deploy/HTTPS_CLOUDFLARE.md
@@ -1,83 +1,83 @@
-# HTTPS para a E.V. via Cloudflare Tunnel
+# HTTPS for E.V. via Cloudflare Tunnel
 
-Coloca a interface web da E.V. em `https://ev.SEUDOMINIO.com` **sem abrir nenhuma
-porta na Oracle**. O `cloudflared` faz uma conexão de saída até a Cloudflare, que
-termina o TLS e encaminha para o `uvicorn` local em `http://localhost:8000`.
+Puts E.V.'s web interface at `https://ev.YOURDOMAIN.com` **without opening any port
+on Oracle**. `cloudflared` makes an outbound connection to Cloudflare, which
+terminates the TLS and forwards to the local `uvicorn` at `http://localhost:8000`.
 
-Isso destrava o que exige "secure context": microfone/voz na web, Picture-in-Picture
-real, notificações do navegador e, mais tarde, login Google/GitHub.
+This unlocks what requires a "secure context": microphone/voice on the web, real
+Picture-in-Picture, browser notifications, and — later — Google/GitHub login.
 
-## Pré-requisitos (do seu lado)
+## Prerequisites (on your side)
 
-1. Conta **Cloudflare** (grátis).
-2. Um **domínio adicionado à Cloudflare** (os nameservers do domínio apontando para
-   a Cloudflare). Cloudflare **não** dá domínio de graça — use um que você já tenha
-   ou registre um barato. O subdomínio (ex.: `ev.`) a gente cria; ele não precisa
-   existir ainda.
-3. Acesso SSH à VM (você já usa pra fazer deploy).
+1. A **Cloudflare** account (free).
+2. A **domain added to Cloudflare** (the domain's nameservers pointing to
+   Cloudflare). Cloudflare does **not** give away a free domain — use one you
+   already own or register a cheap one. The subdomain (e.g. `ev.`) we create; it
+   doesn't need to exist yet.
+3. SSH access to the VM (the same one you already use for deploys).
 
-> Sem um domínio na Cloudflare só dá pra usar os túneis efêmeros `trycloudflare.com`,
-> que geram uma URL aleatória a cada execução — ruim para um assistente fixo. Por isso
-> o domínio é necessário para um endereço estável.
+> Without a domain on Cloudflare you can only use the ephemeral `trycloudflare.com`
+> tunnels, which generate a random URL on every run — bad for a fixed assistant.
+> That's why a domain is required for a stable address.
 
 ---
 
-## Passo 0 — instalar o cloudflared na VM
+## Step 0 — install cloudflared on the VM
 
 ```bash
 cd ~/ev && git pull
 bash deploy/cloudflared/install.sh
-cloudflared --version   # confirme que instalou
+cloudflared --version   # confirm it installed
 ```
 
-Agora escolha **um** dos fluxos abaixo. O **Fluxo A (painel)** é o mais simples.
+Now pick **one** of the flows below. **Flow A (dashboard)** is the simplest.
 
 ---
 
-## Fluxo A — pelo painel da Cloudflare (recomendado)
+## Flow A — via the Cloudflare dashboard (recommended)
 
-1. Painel Cloudflare → **Zero Trust** → **Networks** → **Tunnels** → **Create a tunnel**.
-2. Tipo **Cloudflared**. Dê um nome (ex.: `ev`) e **Save**.
-3. A tela mostra um comando de instalação com um token longo. Na aba **Debian/Red Hat**
-   ela sugere instalar o pacote; como já instalamos o binário, rode **só a parte do
-   serviço** na VM (troque `SEU_TOKEN` pelo token mostrado):
+1. Cloudflare dashboard → **Zero Trust** → **Networks** → **Tunnels** → **Create a tunnel**.
+2. Type **Cloudflared**. Give it a name (e.g. `ev`) and **Save**.
+3. The screen shows an install command with a long token. On the **Debian/Red Hat**
+   tab it suggests installing the package; since we already installed the binary, run
+   **only the service part** on the VM (replace `YOUR_TOKEN` with the token shown):
 
    ```bash
-   sudo cloudflared service install SEU_TOKEN
+   sudo cloudflared service install YOUR_TOKEN
    sudo systemctl enable --now cloudflared
    systemctl status cloudflared --no-pager
    ```
 
-4. Ainda no painel, aba **Public Hostname** → **Add a public hostname**:
+4. Still in the dashboard, **Public Hostname** tab → **Add a public hostname**:
    - **Subdomain**: `ev`
-   - **Domain**: seu domínio
+   - **Domain**: your domain
    - **Type**: `HTTP`
    - **URL**: `localhost:8000`
    - **Save**.
 
-5. Abra `https://ev.SEUDOMINIO.com` — deve carregar a E.V. com cadeado válido.
+5. Open `https://ev.YOURDOMAIN.com` — it should load E.V. with a valid padlock.
 
 ---
 
-## Fluxo B — pela linha de comando (alternativa)
+## Flow B — via the command line (alternative)
 
 ```bash
-# 1. Autentica (abre uma URL; abra no navegador e autorize o seu domínio)
+# 1. Authenticate (opens a URL; open it in your browser and authorize your domain)
 cloudflared tunnel login
 
-# 2. Cria o túnel (guarda um <TUNNEL_ID> e um arquivo <TUNNEL_ID>.json)
+# 2. Create the tunnel (records a <TUNNEL_ID> and a <TUNNEL_ID>.json file)
 cloudflared tunnel create ev
 
-# 3. Move credenciais e config para /etc/cloudflared
+# 3. Move credentials and config to /etc/cloudflared
 sudo mkdir -p /etc/cloudflared
 sudo cp ~/.cloudflared/*.json /etc/cloudflared/
 sudo cp deploy/cloudflared/config.yml.example /etc/cloudflared/config.yml
-sudo nano /etc/cloudflared/config.yml   # ponha o TUNNEL_ID e o hostname reais
+sudo nano /etc/cloudflared/config.yml   # put in the real TUNNEL_ID and hostname
 
-# 4. Cria o registro DNS (CNAME) apontando o hostname para o túnel
-cloudflared tunnel route dns ev ev.SEUDOMINIO.com
+# 4. Create the DNS record (CNAME) pointing the hostname at the tunnel
+cloudflared tunnel route dns ev ev.YOURDOMAIN.com
 
-# 5. Sobe como serviço
+# 5. Bring it up as a service
 sudo cloudflared service install
 sudo systemctl enable --now cloudflared
 systemctl status cloudflared --no-pager
@@ -85,11 +85,11 @@ systemctl status cloudflared --no-pager
 
 ---
 
-## Passo final — fechar o HTTP público (recomendado)
+## Final step — close the public HTTP (recommended)
 
-Hoje a E.V. web escuta em `0.0.0.0:8000`, ou seja, o `http://IP:8000` fica exposto
-em texto puro (o token trafega sem TLS). Depois que o túnel estiver funcionando,
-force o app a escutar só localmente — o túnel continua acessando por `localhost`:
+Today E.V. web listens on `0.0.0.0:8000`, so `http://IP:8000` is exposed in
+cleartext (the token travels without TLS). Once the tunnel is working, force the
+app to listen locally only — the tunnel still reaches it via `localhost`:
 
 ```bash
 cd ~/ev
@@ -97,11 +97,12 @@ grep -q '^EV_WEB_HOST=' .env && sed -i 's/^EV_WEB_HOST=.*/EV_WEB_HOST=127.0.0.1/
 sudo systemctl restart ev-web
 ```
 
-A partir daí só `https://ev.SEUDOMINIO.com` responde; o `http://IP:8000` para de abrir
-de fora (o que é o certo).
+From then on only `https://ev.YOURDOMAIN.com` answers; `http://IP:8000` stops
+opening from outside (which is the right thing).
 
-## Diagnóstico rápido
+## Quick diagnostics
 
-- `journalctl -u cloudflared -f` — logs do túnel.
-- `curl -I http://localhost:8000` na VM — confirma que o app está de pé localmente.
-- No painel, o túnel deve aparecer como **HEALTHY**.
+- `journalctl -u cloudflared -f` — tunnel logs.
+- `curl -I http://localhost:8000` on the VM — confirms the app is up locally.
+- In the dashboard, the tunnel should show as **HEALTHY**.
+</content>

--- a/deploy/HTTPS_TAILSCALE.md
+++ b/deploy/HTTPS_TAILSCALE.md
@@ -1,77 +1,78 @@
-# HTTPS privado para a E.V. via Tailscale Serve
+# Private HTTPS for E.V. via Tailscale Serve
 
-Coloca a interface web da E.V. em `https://<maquina>.<seu-tailnet>.ts.net`, com
-certificado TLS válido, **sem domínio, sem custo e sem abrir portas na Oracle**.
+Puts E.V.'s web interface at `https://<machine>.<your-tailnet>.ts.net`, with a
+valid TLS certificate, **no domain, no cost, and no open ports on Oracle**.
 
-Modo **Serve** (privado): a E.V. só responde para os **seus aparelhos** logados no
-seu Tailscale (celular + PC). Não vai para a internet pública — é o mais seguro.
-(O modo público seria o `funnel`; aqui usamos `serve` de propósito.)
+**Serve** mode (private): E.V. only answers **your own devices** logged into your
+Tailscale (phone + PC). It never reaches the public internet — this is the most
+secure option. (The public mode would be `funnel`; here we use `serve` on purpose.)
 
-Isso destrava o que exige "secure context": microfone/voz na web, Picture-in-Picture
-real, notificações do navegador e, mais tarde, login Google/GitHub.
+This unlocks what requires a "secure context": microphone/voice on the web, real
+Picture-in-Picture, browser notifications, and — later — Google/GitHub login.
 
-## Pré-requisitos (do seu lado)
+## Prerequisites (on your side)
 
-1. Conta **Tailscale** grátis (login com Google/GitHub/e-mail) — https://tailscale.com
-2. App **Tailscale** instalado em cada aparelho seu que vai abrir a E.V.
-   (celular iOS/Android + notebook). No modo privado, o aparelho precisa estar no
-   seu tailnet pra enxergar a URL `.ts.net`.
-3. Acesso SSH à VM (o que você já usa pra deploy).
+1. A free **Tailscale** account (log in with Google/GitHub/email) — https://tailscale.com
+2. The **Tailscale** app installed on every device of yours that will open E.V.
+   (iOS/Android phone + laptop). In private mode, the device must be on your
+   tailnet to reach the `.ts.net` URL.
+3. SSH access to the VM (the same one you already use for deploys).
 
 ---
 
-## Passo 1 — instalar e conectar o Tailscale na VM
+## Step 1 — install and connect Tailscale on the VM
 
 ```bash
 curl -fsSL https://tailscale.com/install.sh | sh
 sudo tailscale up
 ```
 
-`tailscale up` imprime uma URL — abra no navegador, faça login e autorize esta máquina.
+`tailscale up` prints a URL — open it in your browser, log in, and authorize this
+machine.
 
-Confirme o nome da máquina e do seu tailnet (vai compor a URL):
+Confirm the machine name and your tailnet name (they make up the URL):
 
 ```bash
 tailscale status
 ```
 
-## Passo 2 — habilitar HTTPS no tailnet (uma vez, no painel web)
+## Step 2 — enable HTTPS on the tailnet (once, in the web panel)
 
-No admin console (https://login.tailscale.com/admin/dns):
-- Ative **MagicDNS**.
-- Ative **HTTPS Certificates** (necessário pro certificado `*.ts.net`).
+In the admin console (https://login.tailscale.com/admin/dns):
+- Enable **MagicDNS**.
+- Enable **HTTPS Certificates** (required for the `*.ts.net` certificate).
 
-## Passo 3 — servir a E.V. (privado)
+## Step 3 — serve E.V. (private)
 
 ```bash
-# Forma atual (Tailscale recente): publica https -> localhost:8000, em background
+# Current form (recent Tailscale): publishes https -> localhost:8000, in the background
 sudo tailscale serve --bg 8000
 
-# Se o comando acima reclamar da sintaxe, confira as opções da sua versão:
+# If the command above complains about the syntax, check your version's options:
 tailscale serve --help
-# Alternativa em versões um pouco mais antigas:
+# Alternative on slightly older versions:
 #   sudo tailscale serve https / http://127.0.0.1:8000
 
-# Ver o que está publicado e a URL exata:
+# See what's published and the exact URL:
 tailscale serve status
 ```
 
-A URL final é `https://<nome-da-maquina>.<seu-tailnet>.ts.net` (aparece no
+The final URL is `https://<machine-name>.<your-tailnet>.ts.net` (shown by
 `tailscale serve status` / `tailscale status`).
 
-## Passo 4 — instalar o Tailscale nos seus aparelhos
+## Step 4 — install Tailscale on your devices
 
-- **Celular**: app Tailscale (iOS/Android) → login com a MESMA conta → ligar.
-- **PC**: app desktop Tailscale → login → ligar.
+- **Phone**: Tailscale app (iOS/Android) → log in with the SAME account → turn on.
+- **PC**: Tailscale desktop app → log in → turn on.
 
-Com o Tailscale ligado no aparelho, abra a URL `.ts.net` no navegador. Como agora é
-HTTPS de verdade, o microfone/voz, PiP e notificações passam a funcionar.
+With Tailscale on the device, open the `.ts.net` URL in the browser. Since it's now
+real HTTPS, microphone/voice, PiP and notifications start working.
 
-## Passo 5 — fechar o HTTP público (recomendado)
+## Step 5 — close the public HTTP (recommended)
 
-Hoje a E.V. web escuta em `0.0.0.0:8000`, então `http://IP:8000` fica exposto em texto
-puro (o token trafega sem TLS). Depois que o Serve estiver ok, force o app a escutar só
-localmente — o Tailscale continua acessando por `localhost`:
+Today E.V. web listens on `0.0.0.0:8000`, so `http://IP:8000` is exposed in
+cleartext (the token travels without TLS). Once Serve is working, force the app to
+listen locally only — Tailscale still reaches it via `localhost`:
 
 ```bash
 cd ~/ev
@@ -79,12 +80,14 @@ grep -q '^EV_WEB_HOST=' .env && sed -i 's/^EV_WEB_HOST=.*/EV_WEB_HOST=127.0.0.1/
 sudo systemctl restart ev-web
 ```
 
-A partir daí só a URL `.ts.net` (pelos seus aparelhos) responde; o `http://IP:8000`
-para de abrir de fora.
+From then on only the `.ts.net` URL (from your devices) answers; `http://IP:8000`
+stops opening from outside.
 
-## Diagnóstico rápido
+## Quick diagnostics
 
-- `tailscale serve status` — o que está sendo servido e a URL.
-- `sudo tailscale status` — máquinas do tailnet e conectividade.
-- `curl -I http://localhost:8000` na VM — confirma o app de pé localmente.
-- `journalctl -u tailscaled -f` — logs do Tailscale.
+- `tailscale serve status` — what is being served and the URL.
+- `sudo tailscale status` — tailnet machines and connectivity.
+- `curl -I http://localhost:8000` on the VM — confirms the app is up locally.
+- `journalctl -u tailscaled -f` — Tailscale logs.
+</content>
+</invoke>

--- a/docs/GROUPS.md
+++ b/docs/GROUPS.md
@@ -42,7 +42,7 @@ say "anota um gasto" in any group, it lands in the same (shared) ledger.
 
 Only **you** (the `EV_OWNER_ID`) are answered — even if other people are in the
 group, E.V. ignores their messages. To change this, adjust `_authorized` in
-`ev/interfaces/telegram_bot.py`.
+`ev/interfaces/telegram_bot/routing.py`.
 
 ## Tip: one supergroup with Topics
 

--- a/docs/STACK.md
+++ b/docs/STACK.md
@@ -36,7 +36,8 @@ throughout; nothing here requires a paid plan for personal use.
 - Semantic recall is a lightweight in-DB vector store (cosine similarity over embeddings).
 
 ## Web frontend (no build step)
-- Self-contained **HTML/CSS/vanilla JS** embedded in `web.py` (single-page app).
+- Self-contained **HTML/CSS/vanilla JS** served from the `ev/interfaces/web/` package
+  (`frontend.py`) as a single-page app.
 - **Lucide** icons (CDN); fonts **Space Grotesk**, **JetBrains Mono**, **Inter**.
 - **Leaflet** (map tab, CartoDB dark tiles + Esri satellite), **Three.js** (Cérebro
   3D graph), **Chart.js** (Gráficos tab), **Mapillary JS** (optional street view,

--- a/docs/WEB.md
+++ b/docs/WEB.md
@@ -1,7 +1,7 @@
 # E.V. on the web (use her from any browser)
 
 A second "door" to the same E.V. — one core, many access points. A FastAPI server
-(`ev/interfaces/web.py`, entry `run_web.py`) serves a self-contained single-page
+(`ev/interfaces/web/` package, entry `run_web.py`) serves a self-contained single-page
 console (no build step) backed by the **same brain, memory and tools** as the
 Telegram bot.
 


### PR DESCRIPTION
## 🤔 Context

The docs convention is **English prose, Portuguese product**. Two deploy guides were still written entirely in Brazilian Portuguese, and a few docs still pointed at pre-refactor flat module files. This audit sweeps `docs/` and `deploy/` to fix both.

**Translated PT → EN (prose only):**
- `deploy/HTTPS_TAILSCALE.md` — full translation; all shell commands, env vars (`EV_WEB_HOST`, etc.) and paths kept verbatim.
- `deploy/HTTPS_CLOUDFLARE.md` — full translation; same preservation rules.

**Stale flat-file references corrected (post package refactor):**
- `docs/GROUPS.md`: `ev/interfaces/telegram_bot.py` → `ev/interfaces/telegram_bot/routing.py` (where `_authorized` is now defined).
- `docs/STACK.md`: `web.py` → the `ev/interfaces/web/` package (`frontend.py`).
- `docs/WEB.md`: `ev/interfaces/web.py` → the `ev/interfaces/web/` package.

The rest of `docs/` was already English and accurate (verified against current source): `architecture.md` and `EXTENDING.md` already use the package paths; `SETUP.md` already documents `install.sh`; the `/pessoas` command still exists in `ev/core/commands/people.py` so its references are correct; people also correctly appear in the web Cérebro graph (no stale standalone "Pessoas" web tab found). No stale test-count references exist in these docs.

> [!NOTE]
> Brazilian-Portuguese **product/UI strings were intentionally kept** — example bot commands (`/lembrete`, `/gasto`), demonstrated outputs, and tab names the console actually renders (Tarefas, Cérebro, Metas, …). Only explanatory prose was translated.