### PR TITLE
ci: lint (ruff) + run tests on PRs, guard deploy to push-main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,27 @@
 name: Test & deploy E.V.
 
-# On every push to main: run the tests; deploy to the VM ONLY if they pass.
+# On pull requests to main: lint + run the tests (no deploy).
+# On push to main: lint + tests, then deploy to the VM ONLY if they pass.
 # Secrets: SSH_PRIVATE_KEY, VM_IP, VM_USER. Secrets/.env stay on the VM.
 
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch: {}
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+      - run: pip install -q ruff==0.16.3
+      - run: ruff check ev tests
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -20,7 +33,8 @@ jobs:
       - run: python -m pytest -q
 
   deploy:
-    needs: test          # only runs if tests pass
+    needs: [test, lint]  # only runs if tests + lint pass
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/ev/core/commands/base.py
+++ b/ev/core/commands/base.py
@@ -9,7 +9,7 @@ E.V.'s replies here are short PT-BR strings (the assistant speaks Portuguese).
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 try:
     from zoneinfo import ZoneInfo

--- a/ev/core/commands/overview.py
+++ b/ev/core/commands/overview.py
@@ -4,7 +4,7 @@ user's own data."""
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 try:
     from zoneinfo import ZoneInfo

--- a/ev/interfaces/telegram_bot/background_loops.py
+++ b/ev/interfaces/telegram_bot/background_loops.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 try:
     from zoneinfo import ZoneInfo
@@ -261,7 +261,6 @@ class BackgroundLoopsMixin:
                 log.info("Sent rain alert.")
 
     async def _maybe_run_recurring(self, app: Application) -> None:
-        cfg = self._config
         now = datetime.now(self._tz())
         today = now.date().isoformat()
         if self._last_recurring == today:

--- a/ev/providers/tools/email.py
+++ b/ev/providers/tools/email.py
@@ -129,6 +129,5 @@ def inbox_summary(config, account: str = "", query: str = "",
     lines = [f"📥 E-mails ({len(items)}):", ""]
     for i, m in enumerate(items, 1):
         line = f"#{i} {m['from']} — {m['subject']}"
-        when = m.get("date", "")
         lines.append(line)
     return "\n".join(lines)

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,10 @@
+# Focused lint: real-bug rules only (pyflakes + syntax), not style noise.
+# F821 (undefined name) is exactly what caught this project's missing-import bugs.
+target-version = "py311"
+
+[lint]
+select = ["E9", "F"]
+
+[lint.per-file-ignores]
+# Package __init__.py files intentionally re-export public names.
+"__init__.py" = ["F401"]


### PR DESCRIPTION
## 🤔 Context

CI (tests + deploy) previously ran **only on push to main** — so a broken PR could merge before tests ran — and there was **no linter**. The exact class of bug we fixed recently (a missing `import re`, an undefined `tools_mod`) is what `ruff`/pyflakes **F821 (undefined name)** catches instantly.

**What this does**
- Adds a `pull_request` trigger so **lint + tests run before merge**, not just after.
- New `lint` job: `ruff check ev tests` (`ruff.toml` selects `E9` + pyflakes `F`; `__init__.py` re-exports are exempt from F401).
- `deploy` now `needs: [test, lint]` and is guarded so it **never runs from a PR**:

> [!WARNING]
> `deploy` gate: `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` — pull requests run lint + tests only; the VM deploy stays exclusive to push-to-main.

- Fixes the pre-existing lint findings so the baseline is green: dropped unused top-level `timedelta`/`timezone` imports (overview / base / background_loops) and removed two dead locals (`cfg`, `when`).

> [!NOTE]
> Verified locally: pyflakes clean (except intentional `__init__` re-exports), `py_compile` clean, **186 tests pass**. This PR's own checks exercise the new lint + test jobs on the runner.