### PR TITLE
test: make test_subscriptions_due timezone-robust

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -127,8 +127,12 @@ def test_budget_alerts(tmp_path):
 
 def test_subscriptions_due(tmp_path):
     from datetime import datetime
+    from zoneinfo import ZoneInfo
     c = _commands(tmp_path)
-    tomorrow = datetime.now().day + 1
+    # Use the SAME timezone the command computes "today" in, so this test isn't
+    # off-by-one when CI runs near a UTC/local day boundary.
+    today = datetime.now(ZoneInfo(c._config.timezone)).day
+    tomorrow = today + 1
     c._memory.add_recurring("u", 50, "Netflix", "lazer", tomorrow)
     due = c.subscriptions_due("u")
     # a charge set for "day 32+" won't happen this month; guard on that


### PR DESCRIPTION
## 🤔 Context

`tests/test_commands.py::test_subscriptions_due` was flaky on CI. It computed the subscription's due day with **naive `datetime.now()`**, but `subscriptions_due` computes "today" in the **config timezone** (`America/Sao_Paulo`). When CI runs (UTC) near a day boundary, the two disagree by a day, so `days_until` comes back `2` instead of `1` and the test fails — unrelated to whatever PR happens to trigger it.

Fix: compute the day in the same timezone the command uses (`c._config.timezone`), so the test is stable regardless of where/when CI runs.

> [!NOTE]
> Verified: passes locally and under `TZ=UTC` (the CI scenario); full suite 189 passed. This unblocks CI for open PRs (e.g. #179, which was red only because of this).