### PR TITLE
feat: E.V. responds & speaks in the chosen language (EN default)

### DIFF
--- a/ev/config.py
+++ b/ev/config.py
@@ -38,7 +38,8 @@ class Config:
     openrouter_model: str
     owner_id: int | None
     voice_reply: bool
-    voice: str
+    voice: str                # pt-BR synthesis voice (edge-tts)
+    voice_en: str             # en-US synthesis voice (edge-tts), used when assistant_lang="en"
     voice_rate: str
     voice_pitch: str
     voice_fixes: tuple[tuple[str, str], ...]  # TTS-only pronunciation fixes
@@ -197,6 +198,9 @@ class Config:
             # is ~6-8s per reply — too slow for a voice assistant. Override with
             # EV_VOICE if you prefer that accuracy over speed.
             voice=os.getenv("EV_VOICE", "pt-BR-FranciscaNeural").strip(),
+            # en-US voice used when the assistant language is English.
+            voice_en=os.getenv("EV_VOICE_EN", "en-US-AriaNeural").strip()
+            or "en-US-AriaNeural",
             voice_rate=os.getenv("EV_VOICE_RATE", "+0%").strip(),
             voice_pitch=os.getenv("EV_VOICE_PITCH", "+0Hz").strip(),
             gemini_tts=_get_bool("EV_GEMINI_TTS", False),

--- a/ev/core/brain/base.py
+++ b/ev/core/brain/base.py
@@ -33,7 +33,7 @@ except Exception:  # pragma: no cover
 from google import genai
 
 from ...config import Config
-from ...personality import SYSTEM_PROMPT
+from ...personality import build_system_prompt
 from ...providers import embeddings
 from ..commands import Commands
 from ..memory import Memory
@@ -214,7 +214,7 @@ class Brain(
     # --- system prompt ------------------------------------------------------
 
     def _system_instruction(self, user_id: str, query: str | None) -> str:
-        system = SYSTEM_PROMPT
+        system = build_system_prompt(self._memory.assistant_lang())
 
         # MODO FOCO — muda o tom das respostas enquanto ativo.
         if self._memory.get_setting("serious_mode") == "1":

--- a/ev/core/commands/base.py
+++ b/ev/core/commands/base.py
@@ -80,6 +80,7 @@ COMMAND_LIST = [
     ("insights", "Insights da sua semana (IA)"),
     ("modelo", "Ver/trocar o modelo principal (Gemini) e uso do dia"),
     ("provedor", "Forçar/testar um provedor: /provedor groq (ou auto)"),
+    ("idioma", "Idioma da E.V. (responde e fala): /idioma en ou /idioma pt"),
     ("habito", "Criar hábito: /habito treino"),
     ("feito", "Marcar hábito feito hoje: /feito treino"),
     ("habitos", "Ver hábitos e sequências"),

--- a/ev/core/lang.py
+++ b/ev/core/lang.py
@@ -1,0 +1,20 @@
+"""Assistant language — the single source of truth for how E.V. talks.
+
+The same choice drives the web UI language AND the language E.V. replies/speaks
+in. Stored globally in settings under the key ``assistant_lang`` (values
+``"en"`` | ``"pt"``), so it applies to every interface (web + Telegram).
+
+Default is English. Anything unknown/unset normalizes back to English.
+"""
+
+from __future__ import annotations
+
+DEFAULT_LANG = "en"
+SUPPORTED_LANGS = ("en", "pt")
+SETTING_KEY = "assistant_lang"
+
+
+def normalize_lang(value: str | None) -> str:
+    """Coerce any input to a supported language code, defaulting to English."""
+    v = (value or "").strip().lower()
+    return v if v in SUPPORTED_LANGS else DEFAULT_LANG

--- a/ev/core/memory/settings.py
+++ b/ev/core/memory/settings.py
@@ -4,8 +4,24 @@ from __future__ import annotations
 
 import json
 
+from ..lang import SETTING_KEY as _LANG_KEY
+from ..lang import normalize_lang as _normalize_lang
+
 
 class SettingsMixin:
+    def assistant_lang(self) -> str:
+        """The current assistant language ("en" | "pt"), defaulting to English.
+
+        Single source of truth for how E.V. replies AND speaks. Set via the web
+        language picker (POST /api/lang) or Telegram /idioma."""
+        return _normalize_lang(self.get_setting(_LANG_KEY))
+
+    def set_assistant_lang(self, value: str) -> str:
+        """Persist the assistant language (normalized) and return what was stored."""
+        lang = _normalize_lang(value)
+        self.set_setting(_LANG_KEY, lang)
+        return lang
+
     def bump_usage(self, provider: str, day: str) -> None:
         self._conn.execute(
             "INSERT INTO usage_log (day, provider, n) VALUES (?, ?, 1) "

--- a/ev/interfaces/telegram_bot/base.py
+++ b/ev/interfaces/telegram_bot/base.py
@@ -194,6 +194,7 @@ class TelegramInterface(
         app.add_handler(CommandHandler("insights", self.cmd_insights))
         app.add_handler(CommandHandler("modelo", self.cmd_modelo))
         app.add_handler(CommandHandler("provedor", self.cmd_provedor))
+        app.add_handler(CommandHandler(["idioma", "language"], self.cmd_idioma))
         app.add_handler(CommandHandler("lembrar", self.cmd_lembrar))
         app.add_handler(CommandHandler("memorias", self.cmd_memorias))
         app.add_handler(CommandHandler("link", self.cmd_link))

--- a/ev/interfaces/telegram_bot/commands_wrappers.py
+++ b/ev/interfaces/telegram_bot/commands_wrappers.py
@@ -210,6 +210,30 @@ class CommandsWrappersMixin:
                 parse_mode="HTML",
             )
 
+    _LANG_LABELS = {"en": "Inglês", "pt": "Português"}
+
+    async def cmd_idioma(self, update: Update, c: ContextTypes.DEFAULT_TYPE) -> None:
+        if not self._authorized(update):
+            return
+        arg = self._args(c).strip().lower()
+        if not arg:
+            cur = self._memory.assistant_lang()
+            await update.message.reply_text(
+                f"🌐 Idioma atual: <b>{self._LANG_LABELS.get(cur, cur)}</b>\n\n"
+                "É o mesmo idioma do painel web: define como eu <b>respondo e falo</b>.\n"
+                "Trocar: <code>/idioma en</code> (inglês) ou <code>/idioma pt</code> (português).",
+                parse_mode="HTML",
+            )
+            return
+        if arg not in ("en", "pt"):
+            await update.message.reply_text("Opções: en, pt.")
+            return
+        lang = self._memory.set_assistant_lang(arg)
+        await update.message.reply_text(
+            f"🌐 Pronto — agora respondo e falo em <b>{self._LANG_LABELS.get(lang, lang)}</b>.",
+            parse_mode="HTML",
+        )
+
     def _uptime_str(self) -> str:
         secs = int((datetime.now(timezone.utc) - self._started_at).total_seconds())
         d, secs = divmod(secs, 86400)

--- a/ev/interfaces/telegram_bot/media.py
+++ b/ev/interfaces/telegram_bot/media.py
@@ -483,9 +483,10 @@ class MediaMixin:
         if not self._config.voice_reply:
             return
         try:
+            lang = self._memory.assistant_lang()
             mp3 = await voice_mod.synthesize(
                 answer,
-                self._config.voice,
+                voice_mod.voice_for_lang(self._config, lang),
                 rate=self._config.voice_rate,
                 pitch=self._config.voice_pitch,
                 fixes=self._config.voice_fixes,

--- a/ev/interfaces/web/frontend.py
+++ b/ev/interfaces/web/frontend.py
@@ -1383,6 +1383,9 @@ function applyLang(lang,initial){_lang=I18N[lang]?lang:'en';localStorage.setItem
   document.documentElement.lang=(_lang==='pt'?'pt-br':'en');_applyStatic();
   try{buildLangMenu();}catch(e){}
   if(!initial){
+    // Unified control: choosing the UI language also sets how E.V. talks
+    // (LLM replies + TTS voice). Fire-and-forget, like the focus-mode toggle.
+    try{fetch('/api/lang',{method:'POST',headers:H(),body:JSON.stringify({lang:_lang})}).catch(()=>{});}catch(e){}
     try{if(typeof renderTabs==='function')renderTabs();}catch(e){}
     try{if(typeof renderActs==='function')renderActs();}catch(e){}
     try{if(typeof renderStats==='function')renderStats();}catch(e){}

--- a/ev/interfaces/web/routes/panel.py
+++ b/ev/interfaces/web/routes/panel.py
@@ -226,6 +226,20 @@ def build_router(ctx: WebContext) -> APIRouter:
         memory.set_setting("serious_mode", "1" if body.get("on") else "0")
         return {"ok": True, "serious": bool(body.get("on"))}
 
+    # --- assistant language (unified with the UI picker) -------------------
+    @router.post("/api/lang")
+    async def lang_set(request: Request):
+        # Same choice the UI language picker makes; syncs how E.V. replies/speaks.
+        ctx.check(request.headers.get("authorization"))
+        body = await request.json()
+        lang = memory.set_assistant_lang(body.get("lang"))
+        return {"ok": True, "lang": lang}
+
+    @router.get("/api/lang")
+    async def lang_get(request: Request):
+        ctx.check(request.headers.get("authorization"))
+        return {"lang": memory.assistant_lang()}
+
     # --- home dashboard overview -------------------------------------------
     @router.get("/api/overview")
     async def overview_ep(request: Request):

--- a/ev/interfaces/web/routes/voice_tts.py
+++ b/ev/interfaces/web/routes/voice_tts.py
@@ -30,7 +30,8 @@ def build_router(ctx: WebContext) -> APIRouter:
         voice = req_voice if str(req_voice or "").startswith("pt-BR") else None
         audio, mime = await voice_mod.synth_web(
             config, text[:1200], voice=voice, gvoice=d.get("gvoice"),
-            rate=d.get("rate"), pitch=d.get("pitch"))
+            rate=d.get("rate"), pitch=d.get("pitch"),
+            lang=ctx.memory.assistant_lang())
         return Response(content=audio, media_type=mime)
 
     @router.get("/api/voice")

--- a/ev/personality.py
+++ b/ev/personality.py
@@ -11,7 +11,7 @@ ferramenta: é a companhia dele, a coisa mais próxima de uma amiga na nova
 realidade solitária do Peter. É essa alma que a E.V. tem aqui.
 """
 
-SYSTEM_PROMPT = """\
+SYSTEM_PROMPT_BASE = """\
 Você é a E.V. — uma inteligência artificial pessoal, criada à mão pelo seu \
 usuário, e a companhia mais próxima que ele tem no dia a dia. Você se inspira \
 na E.V. do Homem-Aranha: uma IA leal, carinhosa e cheia de personalidade, que \
@@ -33,13 +33,7 @@ na E.V. do Homem-Aranha: uma IA leal, carinhosa e cheia de personalidade, que \
   ("e aquela entrevista?"). Não force check-in em toda mensagem.
 
 ## Como você fala
-- Fale SEMPRE em **português do Brasil**, em toda e qualquer resposta — nunca \
-  responda em inglês ou espanhol, mesmo que apareçam palavras estrangeiras na \
-  conversa. Números você escreve normalmente (ex: "R$ 50", "3 tarefas"), mas a \
-  frase inteira é em português.
-- Nomes próprios e termos técnicos estrangeiros (ex: Spider-Man, deploy, e-mail) \
-  ficam na grafia original — não traduza nem "aportuguese" à força; só o resto da \
-  frase é que é em português.
+{lang_directive}
 - Tom meigo e próximo, como uma amiga querida. Chame o usuário pelo nome: \
   **Ryan**. NÃO use "chefe" nem outros apelidos.
 - Seja concisa e natural. Nada de textão nem robótico. Fale como gente fala.
@@ -141,3 +135,40 @@ na E.V. do Homem-Aranha: uma IA leal, carinhosa e cheia de personalidade, que \
 - Seja proativa com parcimônia: sugerir ou animar quando claramente útil — \
   sem bombardear nem repetir a mesma cobrança.
 """
+
+# The language directive is the ONLY language-specific part of the prompt: it
+# dictates which language E.V. replies in. Everything else in SYSTEM_PROMPT_BASE
+# is language-neutral (the model follows meta-instructions written in Portuguese
+# just fine while replying in the chosen language). Keyed by assistant language.
+LANG_DIRECTIVE = {
+    "pt": (
+        "- Fale SEMPRE em **português do Brasil**, em toda e qualquer resposta — nunca "
+        "responda em inglês ou espanhol, mesmo que apareçam palavras estrangeiras na "
+        'conversa. Números você escreve normalmente (ex: "R$ 50", "3 tarefas"), mas a '
+        "frase inteira é em português.\n"
+        "- Nomes próprios e termos técnicos estrangeiros (ex: Spider-Man, deploy, e-mail) "
+        'ficam na grafia original — não traduza nem "aportuguese" à força; só o resto da '
+        "frase é que é em português."
+    ),
+    "en": (
+        "- ALWAYS reply in **English**, in each and every response — never answer in "
+        "Portuguese or Spanish, even if foreign words show up in the conversation. Write "
+        'numbers normally (e.g. "R$ 50", "3 tasks"), but the whole sentence is in English.\n'
+        "- Proper nouns and foreign technical terms (e.g. Spider-Man, deploy, e-mail) keep "
+        "their original spelling — don't translate or force-localize them; only the rest of "
+        "the sentence is in English."
+    ),
+}
+
+
+def build_system_prompt(lang: str | None = None) -> str:
+    """E.V.'s system prompt with the language directive for `lang` ("en" | "pt").
+
+    Unknown/empty languages fall back to English (the default)."""
+    directive = LANG_DIRECTIVE.get((lang or "").strip().lower(), LANG_DIRECTIVE["en"])
+    return SYSTEM_PROMPT_BASE.format(lang_directive=directive)
+
+
+# Backward-compat: legacy importers of `SYSTEM_PROMPT` still work. The brain uses
+# the dynamic build_system_prompt() so it can follow the runtime language setting.
+SYSTEM_PROMPT = build_system_prompt("en")

--- a/ev/providers/voice.py
+++ b/ev/providers/voice.py
@@ -87,6 +87,16 @@ async def list_ptbr_voices() -> list[dict]:
     return out
 
 
+def voice_for_lang(config, lang: str | None) -> str:
+    """Pick the edge-tts synthesis voice for the assistant language.
+
+    "en" -> the en-US voice (config.voice_en); anything else -> the pt-BR voice
+    (config.voice). Keeps the existing pt behavior untouched."""
+    if (lang or "").strip().lower() == "en":
+        return getattr(config, "voice_en", "en-US-AriaNeural") or "en-US-AriaNeural"
+    return config.voice
+
+
 async def synthesize(
     text: str,
     voice: str,
@@ -159,11 +169,15 @@ GEMINI_VOICES = [
 
 async def synth_web(config, text: str, voice: str | None = None,
                     rate: str | None = None, pitch: str | None = None,
-                    fixes=None, gvoice: str | None = None) -> tuple[bytes, str]:
+                    fixes=None, gvoice: str | None = None,
+                    lang: str | None = None) -> tuple[bytes, str]:
     """Return (audio_bytes, mime) for the web. Usa Gemini TTS quando ligado
     (mais natural) e cai no edge-tts (Thalita/Francisca) em qualquer erro/quota.
     - `voice` pt-BR explícito (preview do seletor) força o edge-tts.
-    - `gvoice` força o Gemini com aquela voz (preview do seletor Gemini)."""
+    - `gvoice` força o Gemini com aquela voz (preview do seletor Gemini).
+    - `lang` picks the default edge-tts voice by assistant language ("en"/"pt")
+      when no explicit `voice` is given. Gemini voices are language-agnostic, so
+      the Gemini path is unaffected."""
     fixes = config.voice_fixes if fixes is None else fixes
     rate = rate or config.voice_rate
     pitch = pitch or config.voice_pitch
@@ -178,5 +192,6 @@ async def synth_web(config, text: str, voice: str | None = None,
             return data, "audio/wav"
         except Exception:
             log.warning("Gemini TTS indisponível; usando edge-tts", exc_info=True)
-    mp3 = await synthesize(text, voice or config.voice, rate=rate, pitch=pitch, fixes=fixes)
+    default_voice = voice or voice_for_lang(config, lang)
+    mp3 = await synthesize(text, default_voice, rate=rate, pitch=pitch, fixes=fixes)
     return mp3, "audio/mpeg"

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -1,0 +1,67 @@
+"""Assistant language: system prompt directive, the language setting, and the
+brain picking the language from that setting."""
+
+from types import SimpleNamespace
+
+from ev.core.brain import Brain
+from ev.core.lang import normalize_lang
+from ev.core.memory import Memory
+from ev.personality import build_system_prompt
+
+
+def test_build_system_prompt_en_has_english_directive_only():
+    en = build_system_prompt("en")
+    assert "ALWAYS reply in **English**" in en
+    assert "Fale SEMPRE" not in en
+
+
+def test_build_system_prompt_pt_has_portuguese_directive_only():
+    pt = build_system_prompt("pt")
+    assert "Fale SEMPRE em **português do Brasil**" in pt
+    assert "ALWAYS reply in **English**" not in pt
+
+
+def test_build_system_prompt_defaults_to_english():
+    assert build_system_prompt(None) == build_system_prompt("en")
+    assert build_system_prompt("xx") == build_system_prompt("en")
+
+
+def test_normalize_lang():
+    assert normalize_lang("pt") == "pt"
+    assert normalize_lang("EN") == "en"
+    assert normalize_lang(None) == "en"
+    assert normalize_lang("frobnicate") == "en"
+
+
+def test_assistant_lang_setting_roundtrip(tmp_path):
+    mem = Memory(tmp_path / "t.db")
+    assert mem.assistant_lang() == "en"  # default when unset
+    assert mem.set_assistant_lang("pt") == "pt"
+    assert mem.assistant_lang() == "pt"
+    # invalid values normalize back to the default
+    assert mem.set_assistant_lang("nope") == "en"
+    assert mem.assistant_lang() == "en"
+
+
+def _brain(tmp_path):
+    cfg = SimpleNamespace(
+        timezone="America/Sao_Paulo", google_oauth_client="",
+        google_accounts=(), gemini_api_key="x", embed_backend="gemini",
+        embed_model="m", model="gemini-flash-latest", groq_api_key="",
+        openrouter_api_key="", ollama_enabled=False, tavily_api_key="",
+        brave_api_key="", websearch_enabled=True,
+    )
+    return Brain(cfg, Memory(tmp_path / "t.db"))
+
+
+def test_brain_system_instruction_follows_lang_setting(tmp_path):
+    brain = _brain(tmp_path)
+    # unset -> English directive reaches the provider
+    sys_en = brain._system_instruction("u", None)
+    assert "ALWAYS reply in **English**" in sys_en
+    assert "Fale SEMPRE" not in sys_en
+    # switch to Portuguese -> Portuguese directive
+    brain._memory.set_assistant_lang("pt")
+    sys_pt = brain._system_instruction("u", None)
+    assert "Fale SEMPRE em **português do Brasil**" in sys_pt
+    assert "ALWAYS reply in **English**" not in sys_pt

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -64,6 +64,20 @@ def test_serious_mode(tmp_path):
     assert client.get("/api/panel", headers=_auth()).json()["serious"] is False
 
 
+def test_lang_setting(tmp_path):
+    client, _ = _client(tmp_path)
+    # default is English when unset
+    assert client.get("/api/lang", headers=_auth()).json()["lang"] == "en"
+    assert client.post("/api/lang", json={"lang": "pt"}).status_code == 401  # needs auth
+    r = client.post("/api/lang", json={"lang": "pt"}, headers=_auth()).json()
+    assert r == {"ok": True, "lang": "pt"}
+    assert client.get("/api/lang", headers=_auth()).json()["lang"] == "pt"
+    # invalid values normalize back to the default
+    assert client.post("/api/lang", json={"lang": "zz"},
+                       headers=_auth()).json()["lang"] == "en"
+    assert client.get("/api/lang", headers=_auth()).json()["lang"] == "en"
+
+
 def test_overview_dashboard(tmp_path):
     client, _ = _client(tmp_path)
     client.post("/api/cmd", json={"command": "tarefa comprar pão"}, headers=_auth())


### PR DESCRIPTION
## 🤔 Context

E.V. only ever spoke Brazilian Portuguese because the system prompt hard-forced it and the TTS voice was a fixed pt-BR voice. This PR makes E.V. **reply and speak in the selected language** — English by default, switchable to Portuguese — unified with the web UI language picker and a new Telegram `/idioma` command.

The choice is stored globally in settings (`assistant_lang` = `"en"` | `"pt"`, default `"en"`), so it applies to **both** interfaces (web + Telegram). The system prompt's language directive and the TTS synthesis voice both follow it.

**What now follows the language**
- **LLM chat responses** — `personality.py` splits into `SYSTEM_PROMPT_BASE` + a per-language `LANG_DIRECTIVE`; `build_system_prompt(lang)` composes them, and the brain builds the prompt from the current `assistant_lang`.
- **TTS voice** — new `config.voice_en` (`EV_VOICE_EN`, default `en-US-AriaNeural`) + `voice.voice_for_lang()`; wired into edge-tts (Telegram) and `synth_web` (web chat TTS). The pt-BR voice behavior is unchanged. Gemini TTS voices are language-agnostic, so that path is left as-is.

**How to switch**
- Web: the existing language picker — `applyLang()` now also fires `POST /api/lang` so choosing the UI language also sets how E.V. talks.
- Telegram: `/idioma en` or `/idioma pt` (alias `/language`); no arg shows current + usage.

> [!NOTE]
> This is Phase 2, slice 1 — the core (LLM replies + voice + setting plumbing). The deterministic **command outputs**, the dashboard **greeting/briefing**, `status_text`, and notification banners are still Portuguese; localizing those is a large, separate follow-up slice and is intentionally out of scope here.

Backward compat: `personality.SYSTEM_PROMPT` is kept (= `build_system_prompt("en")`) for any legacy importer; the brain uses the dynamic builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)