### PR TITLE
feat: localize all command outputs to the chosen language (EN default)

### DIFF
--- a/ev/core/automations.py
+++ b/ev/core/automations.py
@@ -6,10 +6,11 @@ module only decides *whether* a trigger fires and describes automations.
 """
 from __future__ import annotations
 
+from .i18n import DEFAULT_LANG
+from .i18n import t as _t
+
 TRIGGERS = ("time", "expense_over", "task_overdue")
 ACTIONS = ("notify", "command", "reschedule", "play")
-
-_WD_PT = ["segunda", "terça", "quarta", "quinta", "sexta", "sábado", "domingo"]
 
 
 def time_due(cfg: dict, now, last_fired: str | None) -> bool:
@@ -35,31 +36,33 @@ def expense_matches(cfg: dict, expense: dict) -> bool:
     return True
 
 
-def describe(auto: dict) -> str:
-    """Human-readable one-liner for listings."""
+def describe(auto: dict, lang: str | None = DEFAULT_LANG) -> str:
+    """Human-readable one-liner for listings, localized to ``lang``."""
     t, c = auto.get("trig"), auto.get("trig_cfg") or {}
     a, ac = auto.get("act"), auto.get("act_cfg") or {}
     if t == "time":
         wd = c.get("weekday", -1)
-        when = "todo dia" if wd == -1 else f"toda {_WD_PT[wd]}"
-        quando = f"{when} às {int(c.get('hour', 0)):02d}:{int(c.get('minute', 0)):02d}"
+        when = (_t(lang, "auto.when_everyday") if wd == -1
+                else _t(lang, "auto.when_weekday", wd=_t(lang, f"wd.{wd}")))
+        hm = f"{int(c.get('hour', 0)):02d}:{int(c.get('minute', 0)):02d}"
+        quando = _t(lang, "auto.time_when", when=when, hm=hm)
     elif t == "expense_over":
         cat = c.get("category")
-        quando = f"quando gastar mais de R$ {float(c.get('amount', 0)):.0f}" + (
-            f" em '{cat}'" if cat else "")
+        quando = _t(lang, "auto.expense_when", amount=f"{float(c.get('amount', 0)):.0f}") + (
+            _t(lang, "auto.expense_cat", cat=cat) if cat else "")
     elif t == "task_overdue":
-        quando = "quando uma tarefa vencer"
+        quando = _t(lang, "auto.task_overdue")
     else:
         quando = t or "?"
     if a == "notify":
-        faca = f"me avisar: \"{ac.get('message', '')}\""
+        faca = _t(lang, "auto.do_notify", message=ac.get("message", ""))
     elif a == "command":
-        faca = f"rodar /{ac.get('command', '')}"
+        faca = _t(lang, "auto.do_command", command=ac.get("command", ""))
     elif a == "reschedule":
-        faca = "remarcar pro dia seguinte"
+        faca = _t(lang, "auto.do_reschedule")
     elif a == "play":
-        faca = f"tocar '{ac.get('playlist') or ac.get('query') or '?'}' no Spotify"
+        faca = _t(lang, "auto.do_play", what=ac.get("playlist") or ac.get("query") or "?")
     else:
         faca = a or "?"
-    status = "" if auto.get("enabled", True) else " (pausada)"
-    return f"#{auto.get('id', '?')} — {quando} → {faca}{status}"
+    status = "" if auto.get("enabled", True) else _t(lang, "auto.paused")
+    return _t(lang, "auto.line", id=auto.get("id", "?"), quando=quando, faca=faca, status=status)

--- a/ev/core/commands/automations.py
+++ b/ev/core/commands/automations.py
@@ -2,25 +2,29 @@
 
 from __future__ import annotations
 
+from ..i18n import t as _t
+
 
 class AutomationsMixin:
     def automacoes(self, user_id: str) -> str:
         from ..automations import describe
+        lang = self._memory.assistant_lang()
         items = self._memory.list_automations(user_id)
         if not items:
-            return ("Nenhuma automação ainda. Me diga algo como 'quando eu gastar "
-                    "mais de 200, me avisa' ou 'toda sexta 18h, me manda o resumo'.")
-        return ("🤖 Suas automações:\n" + "\n".join(describe(a) for a in items)
-                + "\n\nApagar: /automacaorm <id>")
+            return _t(lang, "auto.none")
+        return (_t(lang, "auto.title") + "\n"
+                + "\n".join(describe(a, lang) for a in items)
+                + _t(lang, "auto.footer"))
 
     def automacao_rm(self, user_id: str, arg: str) -> str:
+        lang = self._memory.assistant_lang()
         try:
             aid = int(str(arg).strip())
         except (ValueError, TypeError):
-            return "Uso: /automacaorm <id> (veja os ids em /automacoes)."
+            return _t(lang, "auto.rm_usage")
         if self._memory.delete_automation(user_id, aid):
-            return f"Automação #{aid} removida."
-        return "Não achei essa automação."
+            return _t(lang, "auto.removed", aid=aid)
+        return _t(lang, "auto.rm_not_found")
 
     def create_automation(self, user_id: str, trigger: str, action: str, *,
                           hour=None, minute=0, weekday=-1, amount=None,
@@ -30,44 +34,45 @@ class AutomationsMixin:
         seeds trigger state (e.g. current max expense id, so it never fires on
         past data). Returns (id_or_None, human_message)."""
         from ..automations import TRIGGERS, ACTIONS, describe
+        lang = self._memory.assistant_lang()
         if trigger not in TRIGGERS:
-            return None, f"gatilho inválido ({trigger})"
+            return None, _t(lang, "auto.bad_trigger", trigger=trigger)
         if action not in ACTIONS:
-            return None, f"ação inválida ({action})"
+            return None, _t(lang, "auto.bad_action", action=action)
         trig_cfg, state = {}, {}
         if trigger == "time":
             if hour is None:
-                return None, "faltou a hora do gatilho"
+                return None, _t(lang, "auto.missing_hour")
             trig_cfg = {"hour": int(hour), "minute": int(minute or 0),
                         "weekday": int(weekday if weekday is not None else -1)}
         elif trigger == "expense_over":
             if amount is None:
-                return None, "faltou o valor do gatilho"
+                return None, _t(lang, "auto.missing_amount")
             trig_cfg = {"amount": float(amount)}
             if category:
                 trig_cfg["category"] = category
             state = {"last_id": self._memory.max_expense_id(user_id)}
         act_cfg = {}
         if action == "notify":
-            act_cfg = {"message": message or "lembrete da automação"}
+            act_cfg = {"message": message or _t(lang, "auto.notify_default")}
         elif action == "command":
             if not command:
-                return None, "faltou o comando a rodar"
+                return None, _t(lang, "auto.missing_command")
             act_cfg = {"command": command.lstrip("/")}
         elif action == "reschedule":
             if trigger != "task_overdue":
-                return None, "‘remarcar’ só funciona com o gatilho de tarefa vencida"
+                return None, _t(lang, "auto.reschedule_only")
         elif action == "play":
             if playlist:
                 act_cfg = {"playlist": playlist}
             elif musica:
                 act_cfg = {"query": musica}
             else:
-                return None, "diga a playlist ou a música pra tocar"
+                return None, _t(lang, "auto.play_target")
         name = (message or ("tocar " + (playlist or musica) if action == "play" and (playlist or musica)
                             else (f"/{command}" if command else action)))[:80]
         aid = self._memory.add_automation(
             user_id, name, trigger, trig_cfg, action, act_cfg, state)
         a = {"id": aid, "trig": trigger, "trig_cfg": trig_cfg, "act": action,
              "act_cfg": act_cfg, "enabled": True}
-        return aid, describe(a)
+        return aid, describe(a, lang)

--- a/ev/core/commands/base.py
+++ b/ev/core/commands/base.py
@@ -17,6 +17,8 @@ except Exception:  # pragma: no cover
     ZoneInfo = None  # type: ignore
 
 from ...config import Config
+from ..i18n import DEFAULT_LANG
+from ..i18n import t as _t
 from ..memory import Memory
 from ..timeparse import add_months
 from .reminders_calendar import RemindersCalendarMixin
@@ -180,7 +182,7 @@ class Commands(
         return default, argstr
 
     @staticmethod
-    def _pick(items, arg, textkey, label):
+    def _pick(items, arg, textkey, label, lang=DEFAULT_LANG):
         """Find one item by id or by a case-insensitive substring of `textkey`.
         Returns (item|None, error_msg|None). Lets voice/chat act by name."""
         arg = (arg or "").strip().lstrip("#")
@@ -188,57 +190,22 @@ class Commands(
             for it in items:
                 if it.get("id") == int(arg):
                     return it, None
-            return None, f"Não achei {label} #{arg}."
+            return None, _t(lang, "pick.not_found_id", label=label, arg=arg)
         if not arg:
-            return None, f"Preciso do nome ou número ({label})."
+            return None, _t(lang, "pick.need_name", label=label)
         low = arg.lower()
         matches = [it for it in items if low in str(it.get(textkey, "")).lower()]
         if not matches:
-            return None, f"Não achei {label} com \"{arg}\"."
+            return None, _t(lang, "pick.not_found_name", label=label, arg=arg)
         if len(matches) > 1:
             opts = ", ".join(f"#{it['id']} {str(it.get(textkey, ''))[:30]}" for it in matches[:6])
-            return None, f"Achei mais de um parecido: {opts}. Qual? (me diz o número)"
+            return None, _t(lang, "pick.ambiguous", opts=opts)
         return matches[0], None
 
     # --- help ---------------------------------------------------------------
 
     def help(self) -> str:
-        return (
-            "🕷️ E.V. — todos os comandos\n"
-            "━━━━━━━━━━━━━━━━━━\n"
-            "🏠 Geral\n"
-            "   /menu · /ajuda · /modelo · /status · /silenciar\n"
-            "   /dados (armazenamento) · /limpar (memória) · /limparchat (bolhas)\n\n"
-            "🎯 Foco & Web\n"
-            "   /foco (pomodoro) · /resumir (link)\n\n"
-            "📋 Tarefas\n"
-            "   /tarefa · /tarefas · /concluir\n\n"
-            "⏰ Lembretes & Agenda\n"
-            "   /lembrete · /rotina · /lembretes · /cancelar · /calendario\n\n"
-            "🧠 Memória\n"
-            "   /lembrar · /memorias · /esquecer\n\n"
-            "🔗 Links\n"
-            "   /link · /links · /linkrm\n\n"
-            "📄 Conhecimento & Estudo\n"
-            "   envie um PDF/Word/txt · /kb · /kbweb · /kbrm · /quiz\n"
-            "   /documento (criar) · /exportar (dados) · /transcrever (áudio)\n\n"
-            "💰 Finanças\n"
-            "   /gasto · /gastos · /gastorm · /relatorio\n"
-            "   /orcamento · /orcamentos · /orcamentorm\n"
-            "   /assinatura · /assinaturas · /assinaturarm\n\n"
-            "✅ Hábitos\n"
-            "   /habito · /feito · /habitos · /habitorm\n\n"
-            "📔 Diário\n"
-            "   /diario · /diariorm\n\n"
-            "📊 Resumos & Automação\n"
-            "   /semana · /insights · /vigiar · /vigias · /vigiarm\n\n"
-            "🔎 Busca, Notícias & Clima\n"
-            "   /buscar (web) · /procurar (seus dados) · /noticias · /clima\n\n"
-            "📅 Google\n"
-            "   /agenda · /evento · /email\n"
-            "━━━━━━━━━━━━━━━━━━\n"
-            "💬 Ou toque em /menu pra usar por botões. Também entendo mensagem, áudio, foto e PDF!"
-        )
+        return _t(self._memory.assistant_lang(), "help.text")
 
     # --- generic dispatcher (lets the AI run any command hands-free) --------
 
@@ -306,12 +273,12 @@ class Commands(
 
     def run(self, user_id: str, name: str, argstr: str = "") -> str:
         """Run a command by name (as if the user typed /name argstr)."""
+        lang = self._memory.assistant_lang()
         key = (name or "").strip().lower().lstrip("/")
         fn = self._dispatch().get(key)
         if not fn:
-            return (f"Não conheço o comando '{name}'. Comandos que posso executar: "
-                    + ", ".join(self.runnable()))
+            return _t(lang, "cmd.unknown", name=name, cmds=", ".join(self.runnable()))
         try:
             return fn(user_id, argstr or "")
         except Exception as exc:  # never crash the chat turn
-            return f"Erro ao executar {key}: {exc}"
+            return _t(lang, "cmd.error", key=key, exc=exc)

--- a/ev/core/commands/budgets.py
+++ b/ev/core/commands/budgets.py
@@ -2,26 +2,30 @@
 
 from __future__ import annotations
 
+from ..i18n import t as _t
+
 
 class BudgetsMixin:
     def orcamento(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         tokens = argstr.strip().split()
         if len(tokens) < 2:
-            return "Uso: /orcamento <categoria> <valor>\nEx: /orcamento comida 800"
+            return _t(lang, "bud.usage")
         category = tokens[0].lstrip("#").lower()
         try:
             amount = float(tokens[1].replace(",", "."))
         except ValueError:
-            return "Valor inválido. Ex: /orcamento comida 800"
+            return _t(lang, "bud.invalid_amount")
         self._memory.set_budget(user_id, category, amount)
-        return f"💰 Orçamento de '{category}' definido: R$ {amount:.2f}/mês."
+        return _t(lang, "bud.set", category=category, amount=f"{amount:.2f}")
 
     def orcamentos(self, user_id: str) -> str:
+        lang = self._memory.assistant_lang()
         budgets = self._memory.list_budgets(user_id)
         if not budgets:
-            return "Nenhum orçamento. Crie com /orcamento <categoria> <valor>."
+            return _t(lang, "bud.none")
         _, since, _ = self._month_bounds(0)
-        lines = ["💰 Orçamentos do mês:"]
+        lines = [_t(lang, "bud.title")]
         for b in budgets:
             spent = self._memory.category_total_since(user_id, b["category"], since)
             pct = spent / b["amount"] * 100 if b["amount"] else 0
@@ -29,12 +33,13 @@ class BudgetsMixin:
             lines.append(
                 f"{dot} {b['category']}: R$ {spent:.2f} / R$ {b['amount']:.2f} ({pct:.0f}%)"
             )
-        lines.append("\nApagar: /orcamentorm <categoria>")
+        lines.append(_t(lang, "bud.footer"))
         return "\n".join(lines)
 
     def orcamentorm(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         cat = argstr.strip().lstrip("#").lower()
         if not cat:
-            return "Uso: /orcamentorm <categoria>."
+            return _t(lang, "bud.rm_usage")
         ok = self._memory.delete_budget(user_id, cat)
-        return f"Orçamento de '{cat}' removido." if ok else f"Não achei orçamento pra '{cat}'."
+        return _t(lang, "bud.removed", cat=cat) if ok else _t(lang, "bud.not_found", cat=cat)

--- a/ev/core/commands/expenses.py
+++ b/ev/core/commands/expenses.py
@@ -4,25 +4,29 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+from ..i18n import plural as _plural
+from ..i18n import t as _t
+
 
 class ExpensesMixin:
     def gasto(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         tokens = argstr.strip().split()
         if not tokens:
-            return "Uso: /gasto <valor> <descrição> [#categoria]\nEx: /gasto 50 mercado #casa"
+            return _t(lang, "exp.usage")
         try:
             amount = float(tokens[0].replace(",", "."))
         except ValueError:
-            return "Valor inválido. Ex: /gasto 50 mercado"
+            return _t(lang, "exp.invalid_amount")
         rest = tokens[1:]
         category = "geral"
         tags = [t for t in rest if t.startswith("#") and len(t) > 1]
         if tags:
             category = tags[0][1:].lower()
             rest = [t for t in rest if not (t.startswith("#") and len(t) > 1)]
-        desc = " ".join(rest).strip() or "(sem descrição)"
+        desc = " ".join(rest).strip() or _t(lang, "exp.no_desc")
         self._memory.add_expense(user_id, amount, desc, category)
-        msg = f"Gasto registrado: R$ {amount:.2f} em {desc} ({category})"
+        msg = _t(lang, "exp.registered", amount=f"{amount:.2f}", desc=desc, category=category)
         # Budget alert (if a limit is set for this category).
         budget = self._memory.get_budget(user_id, category)
         if budget:
@@ -30,53 +34,59 @@ class ExpensesMixin:
             spent = self._memory.category_total_since(user_id, category, since)
             pct = spent / budget * 100 if budget else 0
             if pct >= 100:
-                alert = f"Estourou o orçamento de {category}: R$ {spent:.2f} / R$ {budget:.2f}."
-                msg += f"\n🔴 {alert}"
-                self._memory.add_notification(user_id, "🔴 Orçamento estourado", alert)
+                alert = _t(lang, "exp.budget_over", category=category,
+                           spent=f"{spent:.2f}", budget=f"{budget:.2f}")
+                msg += _t(lang, "exp.budget_over_line", alert=alert)
+                self._memory.add_notification(user_id, _t(lang, "exp.notif_over_title"), alert)
             elif pct >= 80:
-                alert = f"{pct:.0f}% do orçamento de {category} (R$ {spent:.2f} / R$ {budget:.2f})."
-                msg += f"\n🟡 Atenção: {alert}"
-                self._memory.add_notification(user_id, "🟡 Orçamento em atenção", alert)
+                alert = _t(lang, "exp.budget_warn", pct=f"{pct:.0f}", category=category,
+                           spent=f"{spent:.2f}", budget=f"{budget:.2f}")
+                msg += _t(lang, "exp.budget_warn_line", alert=alert)
+                self._memory.add_notification(user_id, _t(lang, "exp.notif_warn_title"), alert)
         return msg
 
     def gastos(self, user_id: str, argstr: str = "") -> str:
+        lang = self._memory.assistant_lang()
         _, since, _ = self._month_bounds(0)
         items = self._memory.expenses_since(user_id, since)
         if not items:
-            return "Nenhum gasto registrado neste mês."
+            return _t(lang, "exp.list_empty")
         total = sum(i["amount"] for i in items)
         by: dict[str, float] = {}
         for i in items:
             by[i["category"]] = by.get(i["category"], 0) + i["amount"]
-        lines = [f"💰 Gastos do mês: R$ {total:.2f} ({len(items)} lançamentos)"]
+        lines = [_t(lang, "exp.list_title", total=f"{total:.2f}",
+                    count=_plural(lang, "count.entries", len(items)))]
         for cat, v in sorted(by.items(), key=lambda x: -x[1]):
             lines.append(f"- {cat}: R$ {v:.2f}")
-        lines.append("\nLançamentos recentes:")
+        lines.append(_t(lang, "exp.recent_header"))
         for i in items[-10:]:
             lines.append(f"#{i['id']} R$ {i['amount']:.2f} {i['description']} ({i['category']})")
-        lines.append("\nApagar: /gastorm <id>")
+        lines.append(_t(lang, "exp.list_footer"))
         return "\n".join(lines)
 
     def gastorm(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         since = (datetime.now(timezone.utc) - timedelta(days=120)).isoformat()
         it, err = self._pick(self._memory.expenses_since(user_id, since),
-                             argstr, "description", "o gasto")
+                             argstr, "description", _t(lang, "exp.pick"))
         if err:
             return err
         self._memory.delete_expense(user_id, it["id"])
-        return f"Gasto \"{it['description']}\" (R$ {it['amount']:.2f}) apagado."
+        return _t(lang, "exp.deleted", desc=it["description"], amount=f"{it['amount']:.2f}")
 
     def gastoeditar(self, user_id: str, argstr: str) -> str:
         """Edit an expense by id or name: '<nome/id> | <valor> [descrição] [#cat]'."""
+        lang = self._memory.assistant_lang()
         alvo, _, resto = argstr.partition("|")
         since = (datetime.now(timezone.utc) - timedelta(days=120)).isoformat()
         it, err = self._pick(self._memory.expenses_since(user_id, since),
-                             alvo, "description", "o gasto")
+                             alvo, "description", _t(lang, "exp.pick"))
         if err:
             return err
         toks = resto.split()
         if not toks:
-            return "Uso: gastoeditar <nome ou id> | <novo valor> [descrição] [#cat]"
+            return _t(lang, "exp.edit_usage")
         cat = next((t[1:] for t in toks if t.startswith("#") and len(t) > 1), None)
         toks = [t for t in toks if not t.startswith("#")]
         amount = None
@@ -89,7 +99,7 @@ class ExpensesMixin:
                 pass
         desc = " ".join(toks).strip() or None
         if amount is None and desc is None and cat is None:
-            return "Nada pra mudar. Ex: gastoeditar mercado | 60 pão #casa"
+            return _t(lang, "exp.edit_nothing")
         self._memory.update_expense(user_id, it["id"], amount=amount,
                                     description=desc, category=cat)
         parts = []
@@ -99,22 +109,26 @@ class ExpensesMixin:
             parts.append(desc)
         if cat:
             parts.append(f"#{cat}")
-        return f"Gasto \"{it['description']}\" atualizado: " + " · ".join(parts)
+        return _t(lang, "exp.updated", desc=it["description"], parts=" · ".join(parts))
 
     def relatorio(self, user_id: str, offset: int = 0) -> str:
         """Financial report for a calendar month, by category vs budget.
         offset 0 = current month (on-demand default), -1 = previous month."""
+        lang = self._memory.assistant_lang()
         label, start_iso, end_iso = self._month_bounds(offset)
         items = self._memory.expenses_between(user_id, start_iso, end_iso)
         if not items:
-            return f"📈 Relatório de {label}: nenhum gasto registrado."
+            return _t(lang, "exp.report_empty", label=label)
         total = sum(i["amount"] for i in items)
         by: dict[str, float] = {}
         for i in items:
             by[i["category"]] = by.get(i["category"], 0) + i["amount"]
-        lines = [f"📈 Relatório de {label}", f"Total: R$ {total:.2f} ({len(items)} lançamentos)", ""]
+        lines = [_t(lang, "exp.report_title", label=label),
+                 _t(lang, "exp.report_total", total=f"{total:.2f}",
+                    count=_plural(lang, "count.entries", len(items))), ""]
         for cat, v in sorted(by.items(), key=lambda x: -x[1]):
             budget = self._memory.get_budget(user_id, cat)
-            vs = f" · orçamento R$ {budget:.0f} ({v / budget * 100:.0f}%)" if budget else ""
+            vs = _t(lang, "exp.report_budget", budget=f"{budget:.0f}",
+                    pct=f"{v / budget * 100:.0f}") if budget else ""
             lines.append(f"- {cat}: R$ {v:.2f}{vs}")
         return "\n".join(lines)

--- a/ev/core/commands/expenses.py
+++ b/ev/core/commands/expenses.py
@@ -69,7 +69,7 @@ class ExpensesMixin:
         lang = self._memory.assistant_lang()
         since = (datetime.now(timezone.utc) - timedelta(days=120)).isoformat()
         it, err = self._pick(self._memory.expenses_since(user_id, since),
-                             argstr, "description", _t(lang, "exp.pick"))
+                             argstr, "description", _t(lang, "exp.pick"), lang)
         if err:
             return err
         self._memory.delete_expense(user_id, it["id"])
@@ -81,7 +81,7 @@ class ExpensesMixin:
         alvo, _, resto = argstr.partition("|")
         since = (datetime.now(timezone.utc) - timedelta(days=120)).isoformat()
         it, err = self._pick(self._memory.expenses_since(user_id, since),
-                             alvo, "description", _t(lang, "exp.pick"))
+                             alvo, "description", _t(lang, "exp.pick"), lang)
         if err:
             return err
         toks = resto.split()

--- a/ev/core/commands/google_integration.py
+++ b/ev/core/commands/google_integration.py
@@ -5,41 +5,43 @@ from __future__ import annotations
 from datetime import timedelta
 
 from ...providers import tools as tools_mod
+from ..i18n import t as _t
 from ..timeparse import parse_when
 
 
 class GoogleIntegrationMixin:
     def agenda(self, argstr: str = "") -> str:
         if not self._google_ready():
-            return "Agenda do Google ainda não configurada. Conecte sua conta primeiro."
+            return _t(self._memory.assistant_lang(), "gcal.not_configured_cal")
         account, _ = self._resolve_account(argstr)
         header = f"[{account}]\n" if len(self._config.google_accounts) > 1 else ""
         return header + tools_mod.calendar_upcoming(self._config, account)
 
     def evento(self, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         if not self._google_ready():
-            return "Agenda do Google ainda não configurada. Conecte sua conta primeiro."
+            return _t(lang, "gcal.not_configured_cal")
         account, rest = self._resolve_account(argstr)
         when, title = parse_when(rest.strip(), self._now())
         if when is None or not title.strip():
-            return "Uso: /evento [conta] <tempo> <título>. Ex: /evento pessoal amanhã 15:00 Dentista"
+            return _t(lang, "gcal.event_usage")
         end = when + timedelta(hours=1)
         return tools_mod.calendar_create(
             self._config, account, title.strip(), when.isoformat(), end.isoformat()
         )
 
     def email(self, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         if not self._google_ready():
-            return "E-mail do Google ainda não configurado. Conecte sua conta primeiro."
+            return _t(lang, "gcal.email_not_configured")
         account, rest = self._resolve_account(argstr)
         parts = [p.strip() for p in rest.split("|")]
         if len(parts) != 3 or not all(parts):
-            return "Uso: /email [conta] destinatário | assunto | corpo"
+            return _t(lang, "gcal.email_usage")
         to, subject, body = parts
         return tools_mod.send_email(self._config, account, to, subject, body)
 
     def emails(self, argstr: str = "") -> str:
         if not self._config.imap_ready():
-            return ("Leitura de e-mail ainda não configurada. Defina EV_IMAP_ADDRESS "
-                    "e EV_IMAP_PASSWORD (senha de app do Gmail).")
+            return _t(self._memory.assistant_lang(), "gcal.imap_not_configured")
         return tools_mod.inbox_summary(self._config, "", argstr.strip())

--- a/ev/core/commands/habits.py
+++ b/ev/core/commands/habits.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from ..i18n import plural as _plural
+from ..i18n import t as _t
+
 
 class HabitsMixin:
     def _streak(self, habit_id: int, today) -> int:
@@ -17,47 +20,52 @@ class HabitsMixin:
         return streak
 
     def habito(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         name = argstr.strip()
         if not name:
-            return "Uso: /habito <nome>. Ex: /habito treino"
+            return _t(lang, "hab.create_usage")
         if self._memory.find_habit(user_id, name):
-            return f"O hábito '{name}' já existe."
+            return _t(lang, "hab.exists", name=name)
         self._memory.add_habit(user_id, name)
-        return f"Hábito '{name}' criado. Marque como feito com /feito {name}"
+        return _t(lang, "hab.created", name=name)
 
     def feito(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         name = argstr.strip()
         if not name:
-            return "Uso: /feito <nome do hábito>. Ex: /feito treino"
+            return _t(lang, "hab.done_usage")
         h = self._memory.find_habit(user_id, name)
         if not h:
-            return f"Não achei o hábito '{name}'. Crie com /habito {name}"
+            return _t(lang, "hab.not_found_create", name=name)
         today = self._now().date()
         ok = self._memory.log_habit(h["id"], today.strftime("%Y-%m-%d"))
-        streak = self._streak(h["id"], today)
+        streak = _plural(lang, "count.days", self._streak(h["id"], today))
         if not ok:
-            return f"'{h['name']}' já estava marcado hoje. Sequência: {streak} dia(s)."
-        return f"Boa! '{h['name']}' feito hoje. Sequência: {streak} dia(s)."
+            return _t(lang, "hab.already", name=h["name"], streak=streak)
+        return _t(lang, "hab.done", name=h["name"], streak=streak)
 
     def habitos(self, user_id: str) -> str:
+        lang = self._memory.assistant_lang()
         habits = self._memory.list_habits(user_id)
         if not habits:
-            return "Você não tem hábitos. Crie com /habito <nome>."
+            return _t(lang, "hab.none")
         today = self._now().date()
         today_s = today.strftime("%Y-%m-%d")
-        lines = ["✅ Seus hábitos (hoje):"]
+        lines = [_t(lang, "hab.list_title")]
         for h in habits:
             done = "[x]" if today_s in self._memory.habit_days(h["id"]) else "[ ]"
-            lines.append(f"{done} {h['name']} — sequência: {self._streak(h['id'], today)} dia(s)")
-        lines.append("\nMarcar: /feito <nome> · Apagar: /habitorm <nome>")
+            streak = _plural(lang, "count.days", self._streak(h["id"], today))
+            lines.append(_t(lang, "hab.list_line", done=done, name=h["name"], streak=streak))
+        lines.append(_t(lang, "hab.list_footer"))
         return "\n".join(lines)
 
     def habitorm(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         name = argstr.strip()
         if not name:
-            return "Uso: /habitorm <nome>. Ex: /habitorm treino"
+            return _t(lang, "hab.rm_usage")
         h = self._memory.find_habit(user_id, name)
         if not h:
-            return f"Não achei o hábito '{name}'."
+            return _t(lang, "hab.not_found", name=name)
         self._memory.delete_habit(user_id, h["id"])
-        return f"Hábito '{h['name']}' removido."
+        return _t(lang, "hab.removed", name=h["name"])

--- a/ev/core/commands/journal.py
+++ b/ev/core/commands/journal.py
@@ -4,15 +4,18 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from ..i18n import t as _t
+
 
 class JournalMixin:
     def diario(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         text = argstr.strip()
         if not text:
             entries = self._memory.recent_journal(user_id, 5)
             if not entries:
-                return "Diário vazio. Escreva com /diario <texto>."
-            lines = ["📔 Últimas entradas do diário:"]
+                return _t(lang, "jour.empty")
+            lines = [_t(lang, "jour.list_title")]
             for e in entries:
                 day = ""
                 try:
@@ -20,14 +23,15 @@ class JournalMixin:
                 except Exception:
                     pass
                 lines.append(f"#{e['id']} [{day}] {e['text']}")
-            lines.append("\nApagar: /diariorm <id>")
+            lines.append(_t(lang, "jour.list_footer"))
             return "\n".join(lines)
         self._memory.add_journal(user_id, text)
-        return "Anotado no diário."
+        return _t(lang, "jour.saved")
 
     def diariorm(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         arg = argstr.strip()
         if not arg.isdigit():
-            return "Uso: /diariorm <id>. Veja os ids em /diario."
+            return _t(lang, "jour.rm_usage")
         ok = self._memory.delete_journal(user_id, int(arg))
-        return f"Entrada #{arg} apagada." if ok else f"Não achei a entrada #{arg}."
+        return _t(lang, "jour.removed", arg=arg) if ok else _t(lang, "jour.not_found", arg=arg)

--- a/ev/core/commands/kb_docs.py
+++ b/ev/core/commands/kb_docs.py
@@ -5,58 +5,67 @@ from __future__ import annotations
 from datetime import timedelta
 
 from .. import knowledge
+from ..i18n import plural as _plural
+from ..i18n import t as _t
 
 
 class KbDocsMixin:
     def kb(self, user_id: str) -> str:
+        lang = self._memory.assistant_lang()
         sources = self._memory.list_sources(user_id)
         if not sources:
-            return (
-                "Base de conhecimento vazia. Envie um PDF aqui no chat que eu "
-                "indexo e passo a responder com base nele."
-            )
-        lines = ["📄 Documentos na base de conhecimento:"]
+            return _t(lang, "kb.empty")
+        lines = [_t(lang, "kb.title")]
         for s in sources:
-            lines.append(f"- {s['source']} ({s['chunks']} trechos)")
-        lines.append("\nEnvie um PDF para adicionar. Remover: /kbrm <nome>")
+            lines.append(_t(lang, "kb.item", source=s["source"],
+                            chunks=_plural(lang, "count.chunks", s["chunks"])))
+        lines.append(_t(lang, "kb.footer"))
         return "\n".join(lines)
 
     def kbrm(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         source = argstr.strip()
         if not source:
-            return "Uso: /kbrm <nome do documento>. Veja os nomes em /kb."
+            return _t(lang, "kb.rm_usage")
         n = self._memory.delete_source(user_id, source)
-        return f"Removi '{source}' ({n} trechos)." if n else f"Não achei '{source}' na base."
+        if n:
+            return _t(lang, "kb.removed", source=source,
+                      chunks=_plural(lang, "count.chunks", n))
+        return _t(lang, "kb.not_found", source=source)
 
     def kbweb(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         url = argstr.strip()
         if not url.lower().startswith("http"):
-            return "Uso: /kbweb <url>. Ex: /kbweb https://pt.wikipedia.org/..."
+            return _t(lang, "kb.web_usage")
         try:
             stored, truncated = knowledge.ingest_url(
                 url, self._config, self._memory, user_id
             )
         except Exception as exc:
-            return f"Não consegui ler essa página ({exc})."
+            return _t(lang, "kb.web_error", exc=exc)
         if stored == 0:
-            return "Não achei texto útil nessa página."
-        extra = " (página grande — indexei o começo)" if truncated else ""
-        return f"Página indexada: {stored} trechos{extra}. Pode me perguntar sobre ela!"
+            return _t(lang, "kb.no_text")
+        extra = _t(lang, "kb.large_page") if truncated else ""
+        return _t(lang, "kb.web_indexed",
+                  stored=_plural(lang, "count.chunks", stored), extra=extra)
 
     def ingest_document(self, user_id: str, data: bytes, filename: str) -> str:
         """Ingest an uploaded document (PDF, Word or plain text) into the KB."""
+        lang = self._memory.assistant_lang()
         if not filename.lower().endswith(knowledge.READABLE_EXTS):
-            return "Consigo ler PDF, Word (.docx) e texto (.txt, .md). Manda um desses."
+            return _t(lang, "kb.bad_ext")
         try:
             stored, truncated = knowledge.ingest_file(
                 data, filename, self._config, self._memory, user_id
             )
         except Exception as exc:
-            return f"Não consegui ler esse arquivo ({exc})."
+            return _t(lang, "kb.file_error", exc=exc)
         if stored == 0:
-            return "Esse arquivo parece não ter texto extraível (talvez seja escaneado/imagem)."
-        extra = " (documento grande — indexei o começo)" if truncated else ""
-        return f"Documento '{filename}' indexado: {stored} trechos{extra}. Pode me perguntar sobre ele!"
+            return _t(lang, "kb.no_text_file")
+        extra = _t(lang, "kb.large_doc") if truncated else ""
+        return _t(lang, "kb.file_indexed", filename=filename,
+                  stored=_plural(lang, "count.chunks", stored), extra=extra)
 
     # --- data export (feature B) -------------------------------------------
 
@@ -69,7 +78,7 @@ class KbDocsMixin:
         since = (self._now() - timedelta(days=30 * months)).isoformat()
         rows = self._memory.expenses_since(user_id, since)
         if not rows:
-            return "Você ainda não tem gastos registrados nesse período."
+            return _t(self._memory.assistant_lang(), "kb.export_empty")
         buf = _io.StringIO()
         w = csv.writer(buf)
         w.writerow(["data", "categoria", "valor", "descricao"])
@@ -86,23 +95,24 @@ class KbDocsMixin:
     def data_digest(self, user_id: str) -> tuple[str, str]:
         """Human-readable digest of the user's data. Returns (title, content)."""
         m = self._memory
+        lang = m.assistant_lang()
         lines: list[str] = []
 
         tasks = m.open_tasks(user_id)
-        lines.append(f"TAREFAS EM ABERTO ({len(tasks)})")
-        lines += [f"- [{t['category']}] {t['text']}" for t in tasks] or ["- (nenhuma)"]
+        lines.append(_t(lang, "kb.digest_tasks", n=len(tasks)))
+        lines += [f"- [{t['category']}] {t['text']}" for t in tasks] or [_t(lang, "kb.digest_none_f")]
 
         facts = m.all_facts(user_id)
-        lines.append(f"\nMEMÓRIAS ({len(facts)})")
-        lines += [f"- {f}" for f in facts] or ["- (nenhuma)"]
+        lines.append(_t(lang, "kb.digest_memories", n=len(facts)))
+        lines += [f"- {f}" for f in facts] or [_t(lang, "kb.digest_none_f")]
 
         habits = m.list_habits(user_id)
-        lines.append(f"\nHÁBITOS ({len(habits)})")
-        lines += [f"- {h['name']}" for h in habits] or ["- (nenhum)"]
+        lines.append(_t(lang, "kb.digest_habits", n=len(habits)))
+        lines += [f"- {h['name']}" for h in habits] or [_t(lang, "kb.digest_none_m")]
 
         journ = m.recent_journal(user_id, 30)
-        lines.append(f"\nDIÁRIO (últimas {len(journ)} entradas)")
-        lines += [f"- {e['text']}" for e in journ] or ["- (vazio)"]
+        lines.append(_t(lang, "kb.digest_journal", n=len(journ)))
+        lines += [f"- {e['text']}" for e in journ] or [_t(lang, "kb.digest_empty")]
 
-        title = f"Meus dados — E.V. ({self._now().strftime('%d/%m/%Y')})"
+        title = _t(lang, "kb.digest_title", date=self._now().strftime("%d/%m/%Y"))
         return title, "\n".join(lines)

--- a/ev/core/commands/links.py
+++ b/ev/core/commands/links.py
@@ -2,25 +2,30 @@
 
 from __future__ import annotations
 
+from ..i18n import t as _t
+
 
 class LinksMixin:
     def link(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         parts = [p.strip() for p in argstr.split("|")]
         if len(parts) != 3 or not all(parts):
-            return "Uso: /link <categoria> | <nome> | <url>\nEx: /link faculdade | lista de tarefas | https://..."
+            return _t(lang, "link.usage")
         category, name, url = parts
         lid = self._memory.add_link(user_id, category, name, url)
-        return f"Link #{lid} salvo em '{category}': {name}"
+        return _t(lang, "link.saved", lid=lid, category=category, name=name)
 
     def links(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         category = argstr.strip() or None
         items = self._memory.list_links(user_id, category)
         if not items:
             return (
-                f"Nenhum link em '{category}'." if category
-                else "Você ainda não guardou links. Use /link."
+                _t(lang, "link.none_cat", category=category) if category
+                else _t(lang, "link.none")
             )
-        lines = [f"🔗 Links{' em ' + category if category else ''}:"]
+        suffix = _t(lang, "link.in", cat=category) if category else ""
+        lines = [_t(lang, "link.title", suffix=suffix)]
         current = None
         for it in items:
             if not category and it["category"] != current:
@@ -30,8 +35,10 @@ class LinksMixin:
         return "\n".join(lines)
 
     def linkrm(self, user_id: str, argstr: str) -> str:
-        it, err = self._pick(self._memory.list_links(user_id), argstr, "name", "o link")
+        lang = self._memory.assistant_lang()
+        it, err = self._pick(self._memory.list_links(user_id), argstr, "name",
+                             _t(lang, "link.pick"))
         if err:
             return err
         self._memory.delete_link(user_id, it["id"])
-        return f"Link \"{it['name']}\" removido."
+        return _t(lang, "link.removed", name=it["name"])

--- a/ev/core/commands/links.py
+++ b/ev/core/commands/links.py
@@ -37,7 +37,7 @@ class LinksMixin:
     def linkrm(self, user_id: str, argstr: str) -> str:
         lang = self._memory.assistant_lang()
         it, err = self._pick(self._memory.list_links(user_id), argstr, "name",
-                             _t(lang, "link.pick"))
+                             _t(lang, "link.pick"), lang)
         if err:
             return err
         self._memory.delete_link(user_id, it["id"])

--- a/ev/core/commands/long_term_memory.py
+++ b/ev/core/commands/long_term_memory.py
@@ -3,29 +3,34 @@
 from __future__ import annotations
 
 from ...providers import embeddings
+from ..i18n import t as _t
 
 
 class LongTermMemoryMixin:
     def lembrar(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         fact = argstr.strip()
         if not fact:
-            return "Uso: /lembrar <fato>. Ex: /lembrar meu carro é um Civic preto"
+            return _t(lang, "ltm.usage")
         vec = embeddings.embed(fact, self._config)
         self._memory.add_fact(user_id, fact, embedding=vec)
-        return f"Anotado na memória: {fact}"
+        return _t(lang, "ltm.saved", fact=fact)
 
     def memorias(self, user_id: str) -> str:
+        lang = self._memory.assistant_lang()
         facts = self._memory.list_facts(user_id)
         if not facts:
-            return "Ainda não sei nada sobre você. Use /lembrar pra me contar algo."
-        lines = ["🧠 O que eu sei sobre você:"]
+            return _t(lang, "ltm.none")
+        lines = [_t(lang, "ltm.title")]
         lines += [f"#{f['id']} {f['fact']}" for f in facts]
-        lines.append("\nApagar: /esquecer <id>")
+        lines.append(_t(lang, "ltm.footer"))
         return "\n".join(lines)
 
     def esquecer(self, user_id: str, argstr: str) -> str:
-        it, err = self._pick(self._memory.list_facts(user_id), argstr, "fact", "a memória")
+        lang = self._memory.assistant_lang()
+        it, err = self._pick(self._memory.list_facts(user_id), argstr, "fact",
+                             _t(lang, "ltm.pick"))
         if err:
             return err
         self._memory.delete_fact(user_id, it["id"])
-        return f"Esqueci: \"{it['fact']}\"."
+        return _t(lang, "ltm.forgot", fact=it["fact"])

--- a/ev/core/commands/long_term_memory.py
+++ b/ev/core/commands/long_term_memory.py
@@ -29,7 +29,7 @@ class LongTermMemoryMixin:
     def esquecer(self, user_id: str, argstr: str) -> str:
         lang = self._memory.assistant_lang()
         it, err = self._pick(self._memory.list_facts(user_id), argstr, "fact",
-                             _t(lang, "ltm.pick"))
+                             _t(lang, "ltm.pick"), lang)
         if err:
             return err
         self._memory.delete_fact(user_id, it["id"])

--- a/ev/core/commands/overview.py
+++ b/ev/core/commands/overview.py
@@ -259,22 +259,21 @@ class OverviewMixin:
         loops = self.open_loops(user_id, now)
         if not (loops["overdue"] or loops["due_today"] or loops["subs"]):
             return ""
-        parts = ["👋 Ryan, deixa eu te cobrar algumas coisas:"]
+        lang = self._memory.assistant_lang()
+        parts = [_t(lang, "ov.nudge_header")]
         if loops["overdue"]:
-            parts.append("\n⏰ Tarefas atrasadas:")
+            parts.append(_t(lang, "ov.nudge_overdue"))
             parts += [f"- {t}" for t in loops["overdue"][:10]]
         if loops["due_today"]:
-            parts.append("\n📌 Vence hoje:")
+            parts.append(_t(lang, "ov.nudge_due_today"))
             parts += [f"- {t}" for t in loops["due_today"][:10]]
         if loops["subs"]:
-            parts.append("\n💳 Assinatura debitando em breve:")
+            parts.append(_t(lang, "ov.nudge_subs"))
             parts += [f"- {s}" for s in loops["subs"][:10]]
-        parts.append("\nConcluir: /concluir <nome>. Quer que eu te ajude com alguma?")
+        parts.append(_t(lang, "ov.nudge_footer"))
         return "\n".join(parts)
 
     # --- continuous learning (deterministic pattern mining) ----------------
-
-    _WD_PT = ["segunda", "terça", "quarta", "quinta", "sexta", "sábado", "domingo"]
 
     def learned_patterns(self, user_id: str, now=None) -> list[dict]:
         """Deterministically mine the user's own data for patterns worth surfacing.
@@ -283,6 +282,7 @@ class OverviewMixin:
         from datetime import timedelta
         now = now or self._now()
         today = now.date()
+        lang = self._memory.assistant_lang()
         out: list[dict] = []
 
         # 1) Habit weekday-skip: an established habit that keeps failing on one weekday.
@@ -307,13 +307,11 @@ class OverviewMixin:
                 if rate < worst_rate:
                     worst, worst_rate = wd, rate
             if worst is not None and worst_rate <= 0.34 and overall >= 0.4:
-                name = self._WD_PT[worst]
-                suffix = "s-feiras" if worst < 5 else "s"
+                weekday = _t(lang, f"learn.wd.{worst}")
                 out.append({
                     "key": f"habit-skip:{h['id']}:{worst}",
-                    "text": f"Notei um padrão: você quase sempre pula '{h['name']}' "
-                            f"às {name}{suffix}.",
-                    "question": "Quer que eu te dê um empurrãozinho nesse dia?",
+                    "text": _t(lang, "learn.habit_skip", name=h["name"], weekday=weekday),
+                    "question": _t(lang, "learn.habit_skip_q"),
                 })
 
         # 2) Spending: already spent more on a category than ALL of last month.
@@ -332,20 +330,21 @@ class OverviewMixin:
             if tot >= 50 and prev.get(cat, 0) > 0 and tot > prev[cat]:
                 out.append({
                     "key": f"spend-over:{label}:{cat}",
-                    "text": f"Você já gastou R$ {tot:.0f} em '{cat}' este mês — mais "
-                            f"que os R$ {prev[cat]:.0f} do mês passado inteiro.",
-                    "question": "Quer definir um orçamento pra essa categoria?",
+                    "text": _t(lang, "learn.spend_over", tot=f"{tot:.0f}",
+                               cat=cat, prev=f"{prev[cat]:.0f}"),
+                    "question": _t(lang, "learn.spend_over_q"),
                 })
         return out
 
     def learned_text(self, user_id: str) -> str:
         """On-demand view of what E.V. has learned about the user."""
+        lang = self._memory.assistant_lang()
         items = self._memory.list_learned(user_id, 15)
         if items:
-            return "🧠 O que já aprendi sobre você:\n" + "\n".join(
+            return _t(lang, "ov.learned_known") + "\n" + "\n".join(
                 "- " + i["text"] for i in items)
         fresh = self.learned_patterns(user_id)
         if fresh:
-            return "🧠 Comecei a notar:\n" + "\n".join(
+            return _t(lang, "ov.learned_noticing") + "\n" + "\n".join(
                 "- " + p["text"] for p in fresh[:8])
-        return "Ainda estou te conhecendo — em alguns dias começo a notar seus padrões. 🌱"
+        return _t(lang, "ov.learned_humble")

--- a/ev/core/commands/people.py
+++ b/ev/core/commands/people.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+from ..i18n import t as _t
+
 
 class PeopleMixin:
     def pessoas(self, user_id: str) -> str:
+        lang = self._memory.assistant_lang()
         people = self._memory.list_people(user_id)
         if not people:
-            return "Nenhuma pessoa registrada. Use /pessoa <nome> | <sobre> [| <aniversário>]."
-        lines = ["👥 Pessoas:"]
+            return _t(lang, "ppl.none")
+        lines = [_t(lang, "ppl.title")]
         for p in people:
             s = f"#{p['id']} {p['name']}"
             if p.get("notes"):
@@ -19,14 +22,15 @@ class PeopleMixin:
         return "\n".join(lines)
 
     def pessoa(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         parts = [p.strip() for p in (argstr or "").split("|")]
         nome = parts[0] if parts else ""
         if not nome:
-            return "Uso: /pessoa <nome> | <sobre> [| <aniversário>]  (ou só /pessoa <nome> pra ver)"
+            return _t(lang, "ppl.usage")
         if len(parts) == 1:  # view
             p = self._memory.find_person(user_id, nome)
             if not p:
-                return f"Não tenho nada sobre {nome}. Adicione: /pessoa {nome} | <sobre> [| <aniversário>]"
+                return _t(lang, "ppl.not_found", name=nome)
             out = [f"👤 {p['name']}"]
             if p.get("notes"):
                 out.append(p["notes"])
@@ -35,4 +39,4 @@ class PeopleMixin:
             return "\n".join(out)
         self._memory.add_person(user_id, nome, parts[1] if len(parts) > 1 else "",
                                 parts[2] if len(parts) > 2 else "")
-        return f"Anotado sobre {nome}."
+        return _t(lang, "ppl.saved", name=nome)

--- a/ev/core/commands/reminders_calendar.py
+++ b/ev/core/commands/reminders_calendar.py
@@ -121,7 +121,7 @@ class RemindersCalendarMixin:
     def cancelar(self, user_id: str, argstr: str) -> str:
         lang = self._memory.assistant_lang()
         it, err = self._pick(self._memory.open_reminders(user_id), argstr, "text",
-                             _t(lang, "rem.pick_reminder"))
+                             _t(lang, "rem.pick_reminder"), lang)
         if err:
             return err
         self._memory.cancel_reminder(user_id, it["id"])
@@ -132,7 +132,7 @@ class RemindersCalendarMixin:
         lang = self._memory.assistant_lang()
         alvo, _, resto = argstr.partition("|")
         it, err = self._pick(self._memory.open_reminders(user_id), alvo, "text",
-                             _t(lang, "rem.pick_reminder"))
+                             _t(lang, "rem.pick_reminder"), lang)
         if err:
             return err
         novo, _, quando = resto.partition("|")

--- a/ev/core/commands/reminders_calendar.py
+++ b/ev/core/commands/reminders_calendar.py
@@ -5,54 +5,48 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 
 from ...providers import tools as tools_mod
+from ..i18n import t as _t
 from ..timeparse import add_months, parse_when
 
 
 class RemindersCalendarMixin:
     def lembrete(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         argstr = argstr.strip()
         if not argstr:
-            return "Uso: /lembrete <tempo> <texto>\nEx: /lembrete 10m tomar água | /lembrete amanhã 09:00 reunião"
+            return _t(lang, "rem.usage")
         when, text = parse_when(argstr, self._now())
         if when is None:
-            return (
-                "Não entendi o horário. Use algo como: 10m, 2h, 1d, "
-                "'hoje 18:00', 'amanhã 09:00' ou '25/12 14:30'."
-            )
+            return _t(lang, "rem.bad_time")
         if not text.strip():
-            return "Faltou o texto do lembrete. Ex: /lembrete 10m tomar água"
+            return _t(lang, "rem.missing_text")
         rid = self._memory.add_reminder(user_id, text.strip(), when.isoformat())
-        return f"Lembrete #{rid} criado para {when.strftime('%d/%m %H:%M')}: {text.strip()}"
-
-    _USO_ROTINA = (
-        "Uso: /rotina <diario|semanal|mensal> [dia] <HH:MM> <texto>\n"
-        "Ex: /rotina diario 08:00 tomar remédio\n"
-        "Ex: /rotina semanal 09:00 revisar metas\n"
-        "Ex: /rotina mensal 5 10:00 pagar aluguel  (todo dia 5)"
-    )
+        return _t(lang, "rem.created", rid=rid,
+                  when=when.strftime('%d/%m %H:%M'), text=text.strip())
 
     def rotina(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         tokens = argstr.strip().split()
         if len(tokens) < 3:
-            return self._USO_ROTINA
+            return _t(lang, "rem.routine_usage")
         kw = tokens[0].lower()
         now = self._now()
         if kw in ("diario", "diária", "diaria", "diariamente"):
-            recur, label = "daily", "todo dia"
+            recur, label = "daily", _t(lang, "rem.label_daily")
         elif kw in ("semanal", "semana", "semanalmente"):
-            recur, label = "weekly", "toda semana"
+            recur, label = "weekly", _t(lang, "rem.label_weekly")
         elif kw in ("mensal", "mensalmente", "mes", "mês", "monthly"):
             recur = "monthly"
         else:
-            return "Recorrência inválida. Use 'diario', 'semanal' ou 'mensal'."
+            return _t(lang, "rem.recur_invalid")
 
         if recur == "monthly":
             # /rotina mensal <dia> <HH:MM> <texto>
             if len(tokens) < 4 or not tokens[1].isdigit():
-                return "Uso mensal: /rotina mensal <dia> <HH:MM> <texto>\nEx: /rotina mensal 5 10:00 pagar aluguel"
+                return _t(lang, "rem.monthly_usage")
             day = int(tokens[1])
             if not 1 <= day <= 31:
-                return "Dia do mês inválido (use 1 a 31)."
+                return _t(lang, "rem.invalid_day")
             time_tok, text = tokens[2], " ".join(tokens[3:]).strip()
         else:
             time_tok, text = tokens[1], " ".join(tokens[2:]).strip()
@@ -60,13 +54,13 @@ class RemindersCalendarMixin:
         try:
             hm = datetime.strptime(time_tok, "%H:%M")
         except ValueError:
-            return "Horário inválido. Use HH:MM. Ex: 08:00"
+            return _t(lang, "rem.invalid_time")
         if not text:
-            return "Faltou o texto da rotina."
+            return _t(lang, "rem.routine_missing_text")
 
         if recur == "monthly":
             first = self._monthly_first(now, day, hm.hour, hm.minute)
-            label = f"todo dia {day}"
+            label = _t(lang, "rem.label_monthly_day", day=day)
         else:
             step = timedelta(days=1) if recur == "daily" else timedelta(days=7)
             first = now.replace(hour=hm.hour, minute=hm.minute, second=0, microsecond=0)
@@ -74,7 +68,7 @@ class RemindersCalendarMixin:
                 first += step
 
         rid = self._memory.add_reminder(user_id, text, first.isoformat(), recur)
-        return f"Rotina #{rid} criada ({label} às {time_tok}): {text}"
+        return _t(lang, "rem.routine_created", rid=rid, label=label, time=time_tok, text=text)
 
     @staticmethod
     def _clamp_day(dt: datetime, day: int) -> datetime:
@@ -94,10 +88,9 @@ class RemindersCalendarMixin:
             cand = RemindersCalendarMixin._clamp_day(add_months(base.replace(day=1), 1), day)
         return cand
 
-    _WEEKDAYS_PT = ["seg", "ter", "qua", "qui", "sex", "sáb", "dom"]
-
     def calendario(self, user_id: str) -> str:
         """Agenda view: reminders grouped by day (+ Google Calendar if connected)."""
+        lang = self._memory.assistant_lang()
         dated = []
         for r in self._memory.open_reminders(user_id):
             if r["when_iso"]:
@@ -106,36 +99,40 @@ class RemindersCalendarMixin:
                 except Exception:
                     pass
         dated.sort(key=lambda x: x[0])
-        lines = ["📅 Sua agenda"]
+        lines = [_t(lang, "rem.cal_title")]
         if not dated:
-            lines.append("Nada agendado. Crie com /lembrete ou /rotina.")
+            lines.append(_t(lang, "rem.cal_empty"))
         else:
             current = None
             for dt, r in dated:
-                day = f"{dt.strftime('%d/%m')} ({self._WEEKDAYS_PT[dt.weekday()]})"
+                day = f"{dt.strftime('%d/%m')} ({_t(lang, f'cal.wd.{dt.weekday()}')})"
                 if day != current:
                     current = day
                     lines.append(f"\n📌 {day}")
                 recur = " 🔁" if (r.get("recur")) else ""
                 lines.append(f"  {dt.strftime('%H:%M')} — {r['text']}{recur}")
         if self._config.google_authorized():
-            lines.append("\n📆 Google Agenda:")
+            lines.append("\n" + _t(lang, "rem.google_cal"))
             lines.append(
                 tools_mod.calendar_upcoming(self._config, self._config.default_account, 5)
             )
         return "\n".join(lines)
 
     def cancelar(self, user_id: str, argstr: str) -> str:
-        it, err = self._pick(self._memory.open_reminders(user_id), argstr, "text", "o lembrete")
+        lang = self._memory.assistant_lang()
+        it, err = self._pick(self._memory.open_reminders(user_id), argstr, "text",
+                             _t(lang, "rem.pick_reminder"))
         if err:
             return err
         self._memory.cancel_reminder(user_id, it["id"])
-        return f"Lembrete \"{it['text']}\" cancelado."
+        return _t(lang, "rem.canceled", text=it["text"])
 
     def lembreteeditar(self, user_id: str, argstr: str) -> str:
         """Edit a reminder by id or name: '<nome/id> | <novo texto> [| <novo tempo>]'."""
+        lang = self._memory.assistant_lang()
         alvo, _, resto = argstr.partition("|")
-        it, err = self._pick(self._memory.open_reminders(user_id), alvo, "text", "o lembrete")
+        it, err = self._pick(self._memory.open_reminders(user_id), alvo, "text",
+                             _t(lang, "rem.pick_reminder"))
         if err:
             return err
         novo, _, quando = resto.partition("|")
@@ -147,17 +144,21 @@ class RemindersCalendarMixin:
             if dt:
                 when_iso = dt.isoformat()
         if not novo and not when_iso:
-            return "Uso: lembreteeditar <nome ou id> | <novo texto> [| <novo tempo>]"
+            return _t(lang, "rem.edit_usage")
         self._memory.update_reminder(user_id, it["id"], text=(novo or None), when_iso=when_iso)
-        extra = f" (para {when_iso.replace('T', ' ')[:16]})" if when_iso else ""
-        return f"Lembrete atualizado: \"{novo or it['text']}\"{extra}"
+        extra = _t(lang, "rem.updated_extra",
+                   when=when_iso.replace('T', ' ')[:16]) if when_iso else ""
+        return _t(lang, "rem.updated", text=(novo or it["text"]), extra=extra)
 
     def lembretes(self, user_id: str) -> str:
+        lang = self._memory.assistant_lang()
         items = self._memory.open_reminders(user_id)
         if not items:
-            return "Você não tem lembretes em aberto."
-        marks = {"daily": " [todo dia]", "weekly": " [toda semana]", "monthly": " [todo mês]"}
-        lines = ["⏰ Seus lembretes:"]
+            return _t(lang, "rem.list_empty")
+        marks = {"daily": _t(lang, "rem.mark_daily"),
+                 "weekly": _t(lang, "rem.mark_weekly"),
+                 "monthly": _t(lang, "rem.mark_monthly")}
+        lines = [_t(lang, "rem.list_title")]
         for r in items:
             when = ""
             if r["when_iso"]:
@@ -167,5 +168,5 @@ class RemindersCalendarMixin:
                     when = ""
             recur = marks.get(r.get("recur") or "", "")
             lines.append(f"#{r['id']} {r['text']}{when}{recur}")
-        lines.append("\nCancelar: /cancelar <id>")
+        lines.append(_t(lang, "rem.list_footer"))
         return "\n".join(lines)

--- a/ev/core/commands/search_news_weather.py
+++ b/ev/core/commands/search_news_weather.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 from ...providers import tools as tools_mod
+from ..i18n import t as _t
 
 
 class SearchNewsWeatherMixin:
     def buscar(self, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         query = argstr.strip()
         if not query:
-            return "Uso: /buscar <termo>. Ex: /buscar notícias de tecnologia hoje"
-        return "Resultados da web:\n" + tools_mod.web_search(
+            return _t(lang, "snw.buscar_usage")
+        return _t(lang, "snw.web_results") + "\n" + tools_mod.web_search(
             query,
             brave_key=getattr(self._config, "brave_api_key", ""),
             tavily_key=getattr(self._config, "tavily_api_key", ""),
@@ -18,44 +20,47 @@ class SearchNewsWeatherMixin:
 
     def procurar(self, user_id: str, argstr: str) -> str:
         """Unified search across everything the user stored (not the web)."""
+        lang = self._memory.assistant_lang()
         term = argstr.strip()
         if not term:
-            return "Uso: /procurar <termo>. Procuro em tudo que você guardou (memória, tarefas, lembretes, links, diário, documentos)."
+            return _t(lang, "snw.procurar_usage")
         r = self._memory.search_all(user_id, term)
         labels = [
-            ("facts", "🧠 Memórias"), ("tasks", "📋 Tarefas"),
-            ("reminders", "⏰ Lembretes"), ("links", "🔗 Links"),
-            ("journal", "📔 Diário"), ("expenses", "💸 Gastos"),
-            ("messages", "💬 Conversas"), ("knowledge", "📄 Conhecimento"),
+            ("facts", "snw.lbl_facts"), ("tasks", "snw.lbl_tasks"),
+            ("reminders", "snw.lbl_reminders"), ("links", "snw.lbl_links"),
+            ("journal", "snw.lbl_journal"), ("expenses", "snw.lbl_expenses"),
+            ("messages", "snw.lbl_messages"), ("knowledge", "snw.lbl_knowledge"),
         ]
-        lines = [f"🔎 Resultados para '{term}':"]
+        lines = [_t(lang, "snw.results_for", term=term)]
         found = False
-        for key, label in labels:
+        for key, label_key in labels:
             items = r.get(key) or []
             if not items:
                 continue
             found = True
-            lines.append(f"\n{label}:")
+            lines.append("\n" + _t(lang, label_key) + ":")
             for it in items[:5]:
                 lines.append(f"- {it['text']}")
         if not found:
-            return f"Nada encontrado pra '{term}' nos seus dados."
+            return _t(lang, "snw.nothing_found", term=term)
         return "\n".join(lines)
 
     def noticias(self, argstr: str = "") -> str:
+        lang = self._memory.assistant_lang()
         topic = argstr.strip() or getattr(self._config, "news_topic", "") or "Brasil"
         out = tools_mod.news(
             topic, tavily_key=getattr(self._config, "tavily_api_key", "")
         )
-        parts = [f"📰 Notícias — {topic}:", out]
+        parts = [_t(lang, "snw.news_title", topic=topic), out]
         tab = tools_mod.tabnews(5)
         if tab:
-            parts.append("\n💻 TabNews (tech):")
+            parts.append(_t(lang, "snw.tabnews_tech"))
             parts.append(tab)
         return "\n".join(parts)
 
     def clima(self, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         city = argstr.strip() or getattr(self._config, "city", "")
         if not city:
-            return "Uso: /clima <cidade>. Ex: /clima São Paulo"
+            return _t(lang, "snw.clima_usage")
         return tools_mod.weather_forecast(city)

--- a/ev/core/commands/subscriptions.py
+++ b/ev/core/commands/subscriptions.py
@@ -9,16 +9,19 @@ try:
 except Exception:  # pragma: no cover
     ZoneInfo = None  # type: ignore
 
+from ..i18n import t as _t
+
 
 class SubscriptionsMixin:
     def assinatura(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         tokens = argstr.strip().split()
         if len(tokens) < 2:
-            return "Uso: /assinatura <valor> <descrição> [dia] [#categoria]\nEx: /assinatura 39,90 Netflix 15"
+            return _t(lang, "sub.usage")
         try:
             amount = float(tokens[0].replace(",", "."))
         except ValueError:
-            return "Valor inválido. Ex: /assinatura 39,90 Netflix 15"
+            return _t(lang, "sub.invalid_amount")
         rest = tokens[1:]
         category = "assinatura"
         tags = [t for t in rest if t.startswith("#") and len(t) > 1]
@@ -29,28 +32,29 @@ class SubscriptionsMixin:
         if rest and rest[-1].isdigit() and 1 <= int(rest[-1]) <= 28:
             day = int(rest[-1])
             rest = rest[:-1]
-        desc = " ".join(rest).strip() or "(assinatura)"
+        desc = " ".join(rest).strip() or _t(lang, "sub.default_desc")
         rid = self._memory.add_recurring(user_id, amount, desc, category, day)
-        return f"🔁 Assinatura #{rid}: R$ {amount:.2f} em {desc} — lanço todo dia {day}."
+        return _t(lang, "sub.created", rid=rid, amount=f"{amount:.2f}", desc=desc, day=day)
 
     def assinaturas(self, user_id: str) -> str:
+        lang = self._memory.assistant_lang()
         items = self._memory.list_recurring(user_id)
         if not items:
-            return "Nenhuma assinatura recorrente. Crie com /assinatura."
-        lines = ["🔁 Assinaturas (lançadas sozinhas todo mês):"]
+            return _t(lang, "sub.none")
+        lines = [_t(lang, "sub.title")]
         for r in items:
-            lines.append(
-                f"#{r['id']} R$ {r['amount']:.2f} {r['description']} — dia {r['day']} ({r['category']})"
-            )
-        lines.append("\nApagar: /assinaturarm <id>")
+            lines.append(_t(lang, "sub.item", id=r["id"], amount=f"{r['amount']:.2f}",
+                            desc=r["description"], day=r["day"], category=r["category"]))
+        lines.append(_t(lang, "sub.footer"))
         return "\n".join(lines)
 
     def assinaturarm(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         arg = argstr.strip()
         if not arg.isdigit():
-            return "Uso: /assinaturarm <id>. Veja em /assinaturas."
+            return _t(lang, "sub.rm_usage")
         ok = self._memory.delete_recurring(user_id, int(arg))
-        return f"Assinatura #{arg} removida." if ok else f"Não achei a assinatura #{arg}."
+        return _t(lang, "sub.removed", arg=arg) if ok else _t(lang, "sub.not_found", arg=arg)
 
     def subscriptions_due(self, user_id: str, days_ahead: int = 2) -> list:
         """Recurring charges (assinaturas) whose due-day falls within the next

--- a/ev/core/commands/task_editing.py
+++ b/ev/core/commands/task_editing.py
@@ -2,25 +2,28 @@
 
 from __future__ import annotations
 
+from ..i18n import t as _t
+
 
 class TaskEditingMixin:
     def _resolve_task(self, user_id: str, arg: str):
         """Find one open task by id or name; returns (task|None, error_msg|None)."""
+        lang = self._memory.assistant_lang()
         arg = arg.strip().lstrip("#")
         if arg.isdigit():
             for t in self._memory.open_tasks(user_id):
                 if t["id"] == int(arg):
                     return t, None
-            return None, f"Não achei a tarefa #{arg} em aberto."
+            return None, _t(lang, "task.not_found_id", arg=arg)
         if not arg:
-            return None, "Preciso do nome ou id da tarefa."
+            return None, _t(lang, "task.need_name")
         low = arg.lower()
         matches = [t for t in self._memory.open_tasks(user_id) if low in t["text"].lower()]
         if not matches:
-            return None, f"Não achei uma tarefa com \"{arg}\". Veja /tarefas."
+            return None, _t(lang, "task.not_found_name_edit", arg=arg)
         if len(matches) > 1:
             opts = ", ".join(f"#{t['id']} {t['text']}" for t in matches[:6])
-            return None, f"Achei mais de uma parecida: {opts}. Qual? (me diz o número)"
+            return None, _t(lang, "task.ambiguous_generic", opts=opts)
         return matches[0], None
 
     def tarefarm(self, user_id: str, argstr: str) -> str:
@@ -29,17 +32,18 @@ class TaskEditingMixin:
         if err:
             return err
         self._memory.delete_task(user_id, t["id"])
-        return f"Tarefa \"{t['text']}\" apagada."
+        return _t(self._memory.assistant_lang(), "task.deleted", text=t["text"])
 
     def tarefaeditar(self, user_id: str, argstr: str) -> str:
         """Edit a task by name: '<nome/id> | <novo texto> [#categoria]'."""
+        lang = self._memory.assistant_lang()
         alvo, _, novo = argstr.partition("|")
         t, err = self._resolve_task(user_id, alvo)
         if err:
             return err
         novo = novo.strip()
         if not novo:
-            return "Uso: tarefaeditar <nome ou id> | <novo texto> [#categoria]"
+            return _t(lang, "task.edit_usage")
         cat = None
         toks = novo.split()
         cats = [x[1:] for x in toks if x.startswith("#") and len(x) > 1]
@@ -47,4 +51,5 @@ class TaskEditingMixin:
             cat = cats[0]
             novo = " ".join(x for x in toks if not x.startswith("#")).strip()
         self._memory.update_task(user_id, t["id"], text=(novo or None), category=cat)
-        return f"Tarefa atualizada: \"{novo or t['text']}\"" + (f" ({cat})" if cat else "")
+        return _t(lang, "task.updated", text=(novo or t["text"]),
+                  cat=(f" ({cat})" if cat else ""))

--- a/ev/core/commands/tasks.py
+++ b/ev/core/commands/tasks.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from ..i18n import t as _t
+
 
 class TasksMixin:
     def tarefa(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         text = argstr.strip()
         if not text:
-            return "Uso: /tarefa <texto> [#categoria]\nEx: /tarefa estudar cálculo #faculdade"
+            return _t(lang, "task.usage")
         # Extract a #category tag (default 'geral').
         category = "geral"
         tokens = text.split()
@@ -18,45 +21,49 @@ class TasksMixin:
                 t for t in tokens if not (t.startswith("#") and len(t) > 1)
             ).strip()
         if not text:
-            return "Faltou o texto da tarefa."
+            return _t(lang, "task.missing_text")
         tid = self._memory.add_task(user_id, text, category)
-        return f"Tarefa #{tid} adicionada em '{category}': {text}"
+        return _t(lang, "task.added", tid=tid, category=category, text=text)
 
     def tarefas(self, user_id: str, argstr: str = "") -> str:
+        lang = self._memory.assistant_lang()
         category = argstr.strip().lstrip("#").lower() or None
         items = self._memory.open_tasks(user_id, category)
         if not items:
             return (
-                f"Nenhuma tarefa em '{category}'." if category
-                else "Sua lista de tarefas está vazia."
+                _t(lang, "task.none_in_cat", category=category) if category
+                else _t(lang, "task.list_empty")
             )
-        lines = [f"📋 Suas tarefas{' em ' + category if category else ''}:"]
+        suffix = _t(lang, "task.list_in", cat=category) if category else ""
+        lines = [_t(lang, "task.list_title", suffix=suffix)]
         current = None
         for t in items:
             if not category and t["category"] != current:
                 current = t["category"]
                 lines.append(f"[{current}]")
             lines.append(f"#{t['id']} {t['text']}")
-        lines.append("\nConcluir: /concluir <id>")
+        lines.append(_t(lang, "task.list_footer"))
         return "\n".join(lines)
 
     def concluir(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         arg = argstr.strip().lstrip("#")
         if arg.isdigit():
             tid = int(arg)
             ok = self._memory.complete_task(user_id, tid)
-            return f"Tarefa #{arg} concluída!" if ok else f"Não achei a tarefa #{arg} em aberto."
+            return (_t(lang, "task.completed_id", arg=arg) if ok
+                    else _t(lang, "task.not_found_id", arg=arg))
         if not arg:
-            return "Uso: /concluir <id ou nome>. Veja em /tarefas."
+            return _t(lang, "task.complete_usage")
         # Resolve by name (substring, case-insensitive) so voice/chat can complete
         # a task without knowing its id.
         low = arg.lower()
         matches = [t for t in self._memory.open_tasks(user_id) if low in t["text"].lower()]
         if not matches:
-            return f"Não achei uma tarefa com \"{arg}\" em aberto. Veja /tarefas."
+            return _t(lang, "task.not_found_name", arg=arg)
         if len(matches) > 1:
             opts = ", ".join(f"#{t['id']} {t['text']}" for t in matches[:6])
-            return f"Achei mais de uma tarefa parecida: {opts}. Qual? (me diz o número)"
+            return _t(lang, "task.ambiguous", opts=opts)
         t = matches[0]
         self._memory.complete_task(user_id, t["id"])
-        return f"Tarefa \"{t['text']}\" concluída!"
+        return _t(lang, "task.completed_name", text=t["text"])

--- a/ev/core/commands/watches.py
+++ b/ev/core/commands/watches.py
@@ -2,35 +2,40 @@
 
 from __future__ import annotations
 
+from ..i18n import t as _t
+
 
 class WatchesMixin:
     def vigiar(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         parts = [p.strip() for p in argstr.split("|")]
         url = parts[0].strip()
         keyword = parts[1] if len(parts) > 1 and parts[1] else None
         if not url.lower().startswith("http"):
-            return "Uso: /vigiar <url> [| palavra-chave]\nEx: /vigiar https://... | inscrições abertas"
+            return _t(lang, "watch.usage")
         wid = self._memory.add_watch(user_id, url, keyword)
         extra = (
-            f" (te aviso quando aparecer '{keyword}')" if keyword
-            else " (te aviso quando a página mudar)"
+            _t(lang, "watch.extra_kw", keyword=keyword) if keyword
+            else _t(lang, "watch.extra_change")
         )
-        return f"👁️ Monitor #{wid} criado{extra}."
+        return _t(lang, "watch.created", wid=wid, extra=extra)
 
     def vigias(self, user_id: str) -> str:
+        lang = self._memory.assistant_lang()
         items = self._memory.list_watches(user_id)
         if not items:
-            return "Você não tem monitores. Crie com /vigiar <url> [| palavra]."
-        lines = ["👁️ Monitores web:"]
+            return _t(lang, "watch.none")
+        lines = [_t(lang, "watch.title")]
         for w in items:
             k = f" [{w['keyword']}]" if w["keyword"] else ""
             lines.append(f"#{w['id']} {w['url']}{k}")
-        lines.append("\nApagar: /vigiarm <id>")
+        lines.append(_t(lang, "watch.footer"))
         return "\n".join(lines)
 
     def vigiarm(self, user_id: str, argstr: str) -> str:
+        lang = self._memory.assistant_lang()
         arg = argstr.strip()
         if not arg.isdigit():
-            return "Uso: /vigiarm <id>. Veja em /vigias."
+            return _t(lang, "watch.rm_usage")
         ok = self._memory.delete_watch(user_id, int(arg))
-        return f"Monitor #{arg} removido." if ok else f"Não achei o monitor #{arg}."
+        return _t(lang, "watch.removed", arg=arg) if ok else _t(lang, "watch.not_found", arg=arg)

--- a/ev/core/commands/weekly_summary.py
+++ b/ev/core/commands/weekly_summary.py
@@ -4,23 +4,29 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+from ..i18n import plural as _plural
+from ..i18n import t as _t
+
 
 class WeeklySummaryMixin:
     def semana(self, user_id: str) -> str:
+        lang = self._memory.assistant_lang()
         since = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat()
         done = self._memory.tasks_completed_since(user_id, since)
         exp = self._memory.expenses_since(user_id, since)
         total = sum(e["amount"] for e in exp)
         parts = [
-            "📊 Sua semana:",
-            f"✅ Tarefas concluídas: {done}",
-            f"📋 Tarefas em aberto: {len(self._memory.open_tasks(user_id))}",
-            f"💰 Gastos (7 dias): R$ {total:.2f} ({len(exp)} lançamentos)",
+            _t(lang, "week.title"),
+            _t(lang, "week.done", done=done),
+            _t(lang, "week.open", n=len(self._memory.open_tasks(user_id))),
+            _t(lang, "week.spent", total=f"{total:.2f}",
+               count=_plural(lang, "count.entries", len(exp))),
         ]
         habits = self._memory.list_habits(user_id)
         if habits:
             today = self._now().date()
-            parts.append("🔥 Hábitos (sequência):")
+            parts.append(_t(lang, "week.habits"))
             for h in habits:
-                parts.append(f"  • {h['name']}: {self._streak(h['id'], today)} dia(s)")
+                parts.append(_t(lang, "week.habit_line", name=h["name"],
+                                streak=_plural(lang, "count.days", self._streak(h["id"], today))))
         return "\n".join(parts)

--- a/ev/core/i18n.py
+++ b/ev/core/i18n.py
@@ -851,6 +851,10 @@ _CATALOG: dict[str, dict[str, str]] = {
         "en": "Couldn't open the page ({e}).",
         "pt": "Não consegui abrir a página ({e}).",
     },
+    "web.page_no_text": {
+        "en": "Couldn't find useful text on that page.",
+        "pt": "Não achei texto útil nessa página.",
+    },
     "web.summarize_fail": {
         "en": "Couldn't summarize right now, try again?",
         "pt": "Não consegui resumir agora, tenta de novo?",

--- a/ev/core/i18n.py
+++ b/ev/core/i18n.py
@@ -591,6 +591,7 @@ _CATALOG: dict[str, dict[str, str]] = {
         "pt": "diga a playlist ou a música pra tocar",
     },
     # describe() fragments
+    "auto.when_everyday": {"en": "every day", "pt": "todo dia"},
     "auto.when_weekday": {"en": "every {wd}", "pt": "toda {wd}"},
     "auto.time_when": {"en": "{when} at {hm}", "pt": "{when} às {hm}"},
     "auto.expense_when": {

--- a/ev/core/i18n.py
+++ b/ev/core/i18n.py
@@ -98,6 +98,777 @@ _CATALOG: dict[str, dict[str, str]] = {
         "en": "{category}: R$ {spent} of R$ {amount} ({pct}%)",
         "pt": "{category}: R$ {spent} de R$ {amount} ({pct}%)",
     },
+    # ======================================================================
+    # Per-command reply strings (Phase 2, slice 2b). English is the default;
+    # the pt entry is the current text verbatim. Keys are grouped by domain.
+    # ======================================================================
+    # --- reminders / calendar (reminders_calendar.py) ---------------------
+    "rem.usage": {
+        "en": "Usage: /lembrete <time> <text>\nEx: /lembrete 10m drink water | /lembrete tomorrow 09:00 meeting",
+        "pt": "Uso: /lembrete <tempo> <texto>\nEx: /lembrete 10m tomar água | /lembrete amanhã 09:00 reunião",
+    },
+    "rem.bad_time": {
+        "en": "I didn't get the time. Use something like: 10m, 2h, 1d, 'today 18:00', 'tomorrow 09:00' or '25/12 14:30'.",
+        "pt": "Não entendi o horário. Use algo como: 10m, 2h, 1d, 'hoje 18:00', 'amanhã 09:00' ou '25/12 14:30'.",
+    },
+    "rem.missing_text": {
+        "en": "The reminder text is missing. Ex: /lembrete 10m drink water",
+        "pt": "Faltou o texto do lembrete. Ex: /lembrete 10m tomar água",
+    },
+    "rem.created": {
+        "en": "Reminder #{rid} created for {when}: {text}",
+        "pt": "Lembrete #{rid} criado para {when}: {text}",
+    },
+    "rem.routine_usage": {
+        "en": ("Usage: /rotina <diario|semanal|mensal> [day] <HH:MM> <text>\n"
+               "Ex: /rotina diario 08:00 take meds\n"
+               "Ex: /rotina semanal 09:00 review goals\n"
+               "Ex: /rotina mensal 5 10:00 pay rent  (every 5th)"),
+        "pt": ("Uso: /rotina <diario|semanal|mensal> [dia] <HH:MM> <texto>\n"
+               "Ex: /rotina diario 08:00 tomar remédio\n"
+               "Ex: /rotina semanal 09:00 revisar metas\n"
+               "Ex: /rotina mensal 5 10:00 pagar aluguel  (todo dia 5)"),
+    },
+    "rem.recur_invalid": {
+        "en": "Invalid recurrence. Use 'diario', 'semanal' or 'mensal'.",
+        "pt": "Recorrência inválida. Use 'diario', 'semanal' ou 'mensal'.",
+    },
+    "rem.monthly_usage": {
+        "en": "Monthly usage: /rotina mensal <day> <HH:MM> <text>\nEx: /rotina mensal 5 10:00 pay rent",
+        "pt": "Uso mensal: /rotina mensal <dia> <HH:MM> <texto>\nEx: /rotina mensal 5 10:00 pagar aluguel",
+    },
+    "rem.invalid_day": {
+        "en": "Invalid day of month (use 1 to 31).",
+        "pt": "Dia do mês inválido (use 1 a 31).",
+    },
+    "rem.invalid_time": {
+        "en": "Invalid time. Use HH:MM. Ex: 08:00",
+        "pt": "Horário inválido. Use HH:MM. Ex: 08:00",
+    },
+    "rem.routine_missing_text": {
+        "en": "The routine text is missing.",
+        "pt": "Faltou o texto da rotina.",
+    },
+    "rem.routine_created": {
+        "en": "Routine #{rid} created ({label} at {time}): {text}",
+        "pt": "Rotina #{rid} criada ({label} às {time}): {text}",
+    },
+    "rem.label_daily": {"en": "every day", "pt": "todo dia"},
+    "rem.label_weekly": {"en": "every week", "pt": "toda semana"},
+    "rem.label_monthly_day": {"en": "every {day} of the month", "pt": "todo dia {day}"},
+    "rem.cal_title": {"en": "📅 Your calendar", "pt": "📅 Sua agenda"},
+    "rem.cal_empty": {
+        "en": "Nothing scheduled. Create one with /lembrete or /rotina.",
+        "pt": "Nada agendado. Crie com /lembrete ou /rotina.",
+    },
+    "rem.google_cal": {"en": "📆 Google Calendar:", "pt": "📆 Google Agenda:"},
+    "rem.pick_reminder": {"en": "the reminder", "pt": "o lembrete"},
+    "rem.canceled": {
+        "en": "Reminder \"{text}\" canceled.",
+        "pt": "Lembrete \"{text}\" cancelado.",
+    },
+    "rem.edit_usage": {
+        "en": "Usage: lembreteeditar <name or id> | <new text> [| <new time>]",
+        "pt": "Uso: lembreteeditar <nome ou id> | <novo texto> [| <novo tempo>]",
+    },
+    "rem.updated": {
+        "en": "Reminder updated: \"{text}\"{extra}",
+        "pt": "Lembrete atualizado: \"{text}\"{extra}",
+    },
+    "rem.updated_extra": {"en": " (for {when})", "pt": " (para {when})"},
+    "rem.list_empty": {
+        "en": "You have no open reminders.",
+        "pt": "Você não tem lembretes em aberto.",
+    },
+    "rem.mark_daily": {"en": " [every day]", "pt": " [todo dia]"},
+    "rem.mark_weekly": {"en": " [every week]", "pt": " [toda semana]"},
+    "rem.mark_monthly": {"en": " [every month]", "pt": " [todo mês]"},
+    "rem.list_title": {"en": "⏰ Your reminders:", "pt": "⏰ Seus lembretes:"},
+    "rem.list_footer": {"en": "\nCancel: /cancelar <id>", "pt": "\nCancelar: /cancelar <id>"},
+    # weekday abbreviations (calendar view)
+    "cal.wd.0": {"en": "Mon", "pt": "seg"},
+    "cal.wd.1": {"en": "Tue", "pt": "ter"},
+    "cal.wd.2": {"en": "Wed", "pt": "qua"},
+    "cal.wd.3": {"en": "Thu", "pt": "qui"},
+    "cal.wd.4": {"en": "Fri", "pt": "sex"},
+    "cal.wd.5": {"en": "Sat", "pt": "sáb"},
+    "cal.wd.6": {"en": "Sun", "pt": "dom"},
+    # --- tasks (tasks.py, task_editing.py) --------------------------------
+    "task.usage": {
+        "en": "Usage: /tarefa <text> [#category]\nEx: /tarefa study calculus #college",
+        "pt": "Uso: /tarefa <texto> [#categoria]\nEx: /tarefa estudar cálculo #faculdade",
+    },
+    "task.missing_text": {"en": "The task text is missing.", "pt": "Faltou o texto da tarefa."},
+    "task.added": {
+        "en": "Task #{tid} added in '{category}': {text}",
+        "pt": "Tarefa #{tid} adicionada em '{category}': {text}",
+    },
+    "task.none_in_cat": {"en": "No tasks in '{category}'.", "pt": "Nenhuma tarefa em '{category}'."},
+    "task.list_empty": {"en": "Your task list is empty.", "pt": "Sua lista de tarefas está vazia."},
+    "task.list_title": {"en": "📋 Your tasks{suffix}:", "pt": "📋 Suas tarefas{suffix}:"},
+    "task.list_in": {"en": " in {cat}", "pt": " em {cat}"},
+    "task.list_footer": {"en": "\nComplete: /concluir <id>", "pt": "\nConcluir: /concluir <id>"},
+    "task.completed_id": {"en": "Task #{arg} completed!", "pt": "Tarefa #{arg} concluída!"},
+    "task.not_found_id": {
+        "en": "Couldn't find open task #{arg}.",
+        "pt": "Não achei a tarefa #{arg} em aberto.",
+    },
+    "task.complete_usage": {
+        "en": "Usage: /concluir <id or name>. See /tarefas.",
+        "pt": "Uso: /concluir <id ou nome>. Veja em /tarefas.",
+    },
+    "task.not_found_name": {
+        "en": "Couldn't find an open task with \"{arg}\". See /tarefas.",
+        "pt": "Não achei uma tarefa com \"{arg}\" em aberto. Veja /tarefas.",
+    },
+    "task.ambiguous": {
+        "en": "Found more than one similar task: {opts}. Which one? (tell me the number)",
+        "pt": "Achei mais de uma tarefa parecida: {opts}. Qual? (me diz o número)",
+    },
+    "task.completed_name": {"en": "Task \"{text}\" completed!", "pt": "Tarefa \"{text}\" concluída!"},
+    "task.need_name": {
+        "en": "I need the task name or id.",
+        "pt": "Preciso do nome ou id da tarefa.",
+    },
+    "task.not_found_name_edit": {
+        "en": "Couldn't find a task with \"{arg}\". See /tarefas.",
+        "pt": "Não achei uma tarefa com \"{arg}\". Veja /tarefas.",
+    },
+    "task.ambiguous_generic": {
+        "en": "Found more than one similar: {opts}. Which one? (tell me the number)",
+        "pt": "Achei mais de uma parecida: {opts}. Qual? (me diz o número)",
+    },
+    "task.deleted": {"en": "Task \"{text}\" deleted.", "pt": "Tarefa \"{text}\" apagada."},
+    "task.edit_usage": {
+        "en": "Usage: tarefaeditar <name or id> | <new text> [#category]",
+        "pt": "Uso: tarefaeditar <nome ou id> | <novo texto> [#categoria]",
+    },
+    "task.updated": {"en": "Task updated: \"{text}\"{cat}", "pt": "Tarefa atualizada: \"{text}\"{cat}"},
+    # --- expenses (expenses.py) -------------------------------------------
+    "exp.usage": {
+        "en": "Usage: /gasto <amount> <description> [#category]\nEx: /gasto 50 groceries #home",
+        "pt": "Uso: /gasto <valor> <descrição> [#categoria]\nEx: /gasto 50 mercado #casa",
+    },
+    "exp.invalid_amount": {
+        "en": "Invalid amount. Ex: /gasto 50 groceries",
+        "pt": "Valor inválido. Ex: /gasto 50 mercado",
+    },
+    "exp.no_desc": {"en": "(no description)", "pt": "(sem descrição)"},
+    "exp.registered": {
+        "en": "Expense logged: R$ {amount} on {desc} ({category})",
+        "pt": "Gasto registrado: R$ {amount} em {desc} ({category})",
+    },
+    "exp.budget_over": {
+        "en": "You blew the {category} budget: R$ {spent} / R$ {budget}.",
+        "pt": "Estourou o orçamento de {category}: R$ {spent} / R$ {budget}.",
+    },
+    "exp.budget_over_line": {"en": "\n🔴 {alert}", "pt": "\n🔴 {alert}"},
+    "exp.budget_warn": {
+        "en": "{pct}% of the {category} budget (R$ {spent} / R$ {budget}).",
+        "pt": "{pct}% do orçamento de {category} (R$ {spent} / R$ {budget}).",
+    },
+    "exp.budget_warn_line": {"en": "\n🟡 Warning: {alert}", "pt": "\n🟡 Atenção: {alert}"},
+    "exp.notif_over_title": {"en": "🔴 Budget exceeded", "pt": "🔴 Orçamento estourado"},
+    "exp.notif_warn_title": {"en": "🟡 Budget warning", "pt": "🟡 Orçamento em atenção"},
+    "exp.list_empty": {
+        "en": "No expenses logged this month.",
+        "pt": "Nenhum gasto registrado neste mês.",
+    },
+    "exp.list_title": {
+        "en": "💰 This month's expenses: R$ {total} ({count})",
+        "pt": "💰 Gastos do mês: R$ {total} ({count})",
+    },
+    "exp.recent_header": {"en": "\nRecent entries:", "pt": "\nLançamentos recentes:"},
+    "exp.list_footer": {"en": "\nDelete: /gastorm <id>", "pt": "\nApagar: /gastorm <id>"},
+    "exp.pick": {"en": "the expense", "pt": "o gasto"},
+    "exp.deleted": {
+        "en": "Expense \"{desc}\" (R$ {amount}) deleted.",
+        "pt": "Gasto \"{desc}\" (R$ {amount}) apagado.",
+    },
+    "exp.edit_usage": {
+        "en": "Usage: gastoeditar <name or id> | <new amount> [description] [#cat]",
+        "pt": "Uso: gastoeditar <nome ou id> | <novo valor> [descrição] [#cat]",
+    },
+    "exp.edit_nothing": {
+        "en": "Nothing to change. Ex: gastoeditar groceries | 60 bread #home",
+        "pt": "Nada pra mudar. Ex: gastoeditar mercado | 60 pão #casa",
+    },
+    "exp.updated": {
+        "en": "Expense \"{desc}\" updated: {parts}",
+        "pt": "Gasto \"{desc}\" atualizado: {parts}",
+    },
+    "exp.report_empty": {
+        "en": "📈 {label} report: no expenses logged.",
+        "pt": "📈 Relatório de {label}: nenhum gasto registrado.",
+    },
+    "exp.report_title": {"en": "📈 {label} report", "pt": "📈 Relatório de {label}"},
+    "exp.report_total": {"en": "Total: R$ {total} ({count})", "pt": "Total: R$ {total} ({count})"},
+    "exp.report_budget": {
+        "en": " · budget R$ {budget} ({pct}%)",
+        "pt": " · orçamento R$ {budget} ({pct}%)",
+    },
+    # --- budgets (budgets.py) ---------------------------------------------
+    "bud.usage": {
+        "en": "Usage: /orcamento <category> <amount>\nEx: /orcamento comida 800",
+        "pt": "Uso: /orcamento <categoria> <valor>\nEx: /orcamento comida 800",
+    },
+    "bud.invalid_amount": {
+        "en": "Invalid amount. Ex: /orcamento comida 800",
+        "pt": "Valor inválido. Ex: /orcamento comida 800",
+    },
+    "bud.set": {
+        "en": "💰 Budget for '{category}' set: R$ {amount}/month.",
+        "pt": "💰 Orçamento de '{category}' definido: R$ {amount}/mês.",
+    },
+    "bud.none": {
+        "en": "No budgets. Create one with /orcamento <category> <amount>.",
+        "pt": "Nenhum orçamento. Crie com /orcamento <categoria> <valor>.",
+    },
+    "bud.title": {"en": "💰 This month's budgets:", "pt": "💰 Orçamentos do mês:"},
+    "bud.footer": {"en": "\nDelete: /orcamentorm <category>", "pt": "\nApagar: /orcamentorm <categoria>"},
+    "bud.rm_usage": {"en": "Usage: /orcamentorm <category>.", "pt": "Uso: /orcamentorm <categoria>."},
+    "bud.removed": {"en": "Budget for '{cat}' removed.", "pt": "Orçamento de '{cat}' removido."},
+    "bud.not_found": {
+        "en": "Couldn't find a budget for '{cat}'.",
+        "pt": "Não achei orçamento pra '{cat}'.",
+    },
+    # --- habits (habits.py) -----------------------------------------------
+    "hab.create_usage": {
+        "en": "Usage: /habito <name>. Ex: /habito treino",
+        "pt": "Uso: /habito <nome>. Ex: /habito treino",
+    },
+    "hab.exists": {"en": "The habit '{name}' already exists.", "pt": "O hábito '{name}' já existe."},
+    "hab.created": {
+        "en": "Habit '{name}' created. Mark it done with /feito {name}",
+        "pt": "Hábito '{name}' criado. Marque como feito com /feito {name}",
+    },
+    "hab.done_usage": {
+        "en": "Usage: /feito <habit name>. Ex: /feito treino",
+        "pt": "Uso: /feito <nome do hábito>. Ex: /feito treino",
+    },
+    "hab.not_found_create": {
+        "en": "Couldn't find the habit '{name}'. Create it with /habito {name}",
+        "pt": "Não achei o hábito '{name}'. Crie com /habito {name}",
+    },
+    "hab.already": {
+        "en": "'{name}' was already marked today. Streak: {streak}.",
+        "pt": "'{name}' já estava marcado hoje. Sequência: {streak}.",
+    },
+    "hab.done": {
+        "en": "Nice! '{name}' done today. Streak: {streak}.",
+        "pt": "Boa! '{name}' feito hoje. Sequência: {streak}.",
+    },
+    "hab.none": {
+        "en": "You have no habits. Create one with /habito <name>.",
+        "pt": "Você não tem hábitos. Crie com /habito <nome>.",
+    },
+    "hab.list_title": {"en": "✅ Your habits (today):", "pt": "✅ Seus hábitos (hoje):"},
+    "hab.list_line": {
+        "en": "{done} {name} — streak: {streak}",
+        "pt": "{done} {name} — sequência: {streak}",
+    },
+    "hab.list_footer": {
+        "en": "\nMark: /feito <name> · Delete: /habitorm <name>",
+        "pt": "\nMarcar: /feito <nome> · Apagar: /habitorm <nome>",
+    },
+    "hab.rm_usage": {
+        "en": "Usage: /habitorm <name>. Ex: /habitorm treino",
+        "pt": "Uso: /habitorm <nome>. Ex: /habitorm treino",
+    },
+    "hab.not_found": {"en": "Couldn't find the habit '{name}'.", "pt": "Não achei o hábito '{name}'."},
+    "hab.removed": {"en": "Habit '{name}' removed.", "pt": "Hábito '{name}' removido."},
+    # --- journal (journal.py) ---------------------------------------------
+    "jour.empty": {
+        "en": "Journal empty. Write with /diario <text>.",
+        "pt": "Diário vazio. Escreva com /diario <texto>.",
+    },
+    "jour.list_title": {"en": "📔 Latest journal entries:", "pt": "📔 Últimas entradas do diário:"},
+    "jour.list_footer": {"en": "\nDelete: /diariorm <id>", "pt": "\nApagar: /diariorm <id>"},
+    "jour.saved": {"en": "Noted in the journal.", "pt": "Anotado no diário."},
+    "jour.rm_usage": {
+        "en": "Usage: /diariorm <id>. See ids in /diario.",
+        "pt": "Uso: /diariorm <id>. Veja os ids em /diario.",
+    },
+    "jour.removed": {"en": "Entry #{arg} deleted.", "pt": "Entrada #{arg} apagada."},
+    "jour.not_found": {"en": "Couldn't find entry #{arg}.", "pt": "Não achei a entrada #{arg}."},
+    # --- links (links.py) -------------------------------------------------
+    "link.usage": {
+        "en": "Usage: /link <category> | <name> | <url>\nEx: /link faculdade | task list | https://...",
+        "pt": "Uso: /link <categoria> | <nome> | <url>\nEx: /link faculdade | lista de tarefas | https://...",
+    },
+    "link.saved": {"en": "Link #{lid} saved in '{category}': {name}", "pt": "Link #{lid} salvo em '{category}': {name}"},
+    "link.none_cat": {"en": "No links in '{category}'.", "pt": "Nenhum link em '{category}'."},
+    "link.none": {
+        "en": "You haven't saved any links yet. Use /link.",
+        "pt": "Você ainda não guardou links. Use /link.",
+    },
+    "link.title": {"en": "🔗 Links{suffix}:", "pt": "🔗 Links{suffix}:"},
+    "link.in": {"en": " in {cat}", "pt": " em {cat}"},
+    "link.pick": {"en": "the link", "pt": "o link"},
+    "link.removed": {"en": "Link \"{name}\" removed.", "pt": "Link \"{name}\" removido."},
+    # --- knowledge base / docs (kb_docs.py) -------------------------------
+    "kb.empty": {
+        "en": "Knowledge base empty. Send a PDF here in the chat and I'll index it and start answering from it.",
+        "pt": "Base de conhecimento vazia. Envie um PDF aqui no chat que eu indexo e passo a responder com base nele.",
+    },
+    "kb.title": {"en": "📄 Documents in the knowledge base:", "pt": "📄 Documentos na base de conhecimento:"},
+    "kb.item": {"en": "- {source} ({chunks})", "pt": "- {source} ({chunks})"},
+    "kb.footer": {
+        "en": "\nSend a PDF to add one. Remove: /kbrm <name>",
+        "pt": "\nEnvie um PDF para adicionar. Remover: /kbrm <nome>",
+    },
+    "kb.rm_usage": {
+        "en": "Usage: /kbrm <document name>. See names in /kb.",
+        "pt": "Uso: /kbrm <nome do documento>. Veja os nomes em /kb.",
+    },
+    "kb.removed": {"en": "Removed '{source}' ({chunks}).", "pt": "Removi '{source}' ({chunks})."},
+    "kb.not_found": {"en": "Couldn't find '{source}' in the base.", "pt": "Não achei '{source}' na base."},
+    "kb.web_usage": {
+        "en": "Usage: /kbweb <url>. Ex: /kbweb https://en.wikipedia.org/...",
+        "pt": "Uso: /kbweb <url>. Ex: /kbweb https://pt.wikipedia.org/...",
+    },
+    "kb.web_error": {"en": "Couldn't read that page ({exc}).", "pt": "Não consegui ler essa página ({exc})."},
+    "kb.no_text": {"en": "Couldn't find useful text on that page.", "pt": "Não achei texto útil nessa página."},
+    "kb.web_indexed": {
+        "en": "Page indexed: {stored}{extra}. Ask me about it!",
+        "pt": "Página indexada: {stored}{extra}. Pode me perguntar sobre ela!",
+    },
+    "kb.large_page": {
+        "en": " (big page — I indexed the start)",
+        "pt": " (página grande — indexei o começo)",
+    },
+    "kb.bad_ext": {
+        "en": "I can read PDF, Word (.docx) and text (.txt, .md). Send one of those.",
+        "pt": "Consigo ler PDF, Word (.docx) e texto (.txt, .md). Manda um desses.",
+    },
+    "kb.file_error": {"en": "Couldn't read that file ({exc}).", "pt": "Não consegui ler esse arquivo ({exc})."},
+    "kb.no_text_file": {
+        "en": "That file seems to have no extractable text (maybe it's scanned/an image).",
+        "pt": "Esse arquivo parece não ter texto extraível (talvez seja escaneado/imagem).",
+    },
+    "kb.file_indexed": {
+        "en": "Document '{filename}' indexed: {stored}{extra}. Ask me about it!",
+        "pt": "Documento '{filename}' indexado: {stored}{extra}. Pode me perguntar sobre ele!",
+    },
+    "kb.large_doc": {
+        "en": " (big document — I indexed the start)",
+        "pt": " (documento grande — indexei o começo)",
+    },
+    "kb.export_empty": {
+        "en": "You have no expenses logged in that period.",
+        "pt": "Você ainda não tem gastos registrados nesse período.",
+    },
+    "kb.digest_tasks": {"en": "OPEN TASKS ({n})", "pt": "TAREFAS EM ABERTO ({n})"},
+    "kb.digest_none_f": {"en": "- (none)", "pt": "- (nenhuma)"},
+    "kb.digest_memories": {"en": "\nMEMORIES ({n})", "pt": "\nMEMÓRIAS ({n})"},
+    "kb.digest_habits": {"en": "\nHABITS ({n})", "pt": "\nHÁBITOS ({n})"},
+    "kb.digest_none_m": {"en": "- (none)", "pt": "- (nenhum)"},
+    "kb.digest_journal": {"en": "\nJOURNAL (last {n} entries)", "pt": "\nDIÁRIO (últimas {n} entradas)"},
+    "kb.digest_empty": {"en": "- (empty)", "pt": "- (vazio)"},
+    "kb.digest_title": {"en": "My data — E.V. ({date})", "pt": "Meus dados — E.V. ({date})"},
+    # --- subscriptions (subscriptions.py) ---------------------------------
+    "sub.usage": {
+        "en": "Usage: /assinatura <amount> <description> [day] [#category]\nEx: /assinatura 39,90 Netflix 15",
+        "pt": "Uso: /assinatura <valor> <descrição> [dia] [#categoria]\nEx: /assinatura 39,90 Netflix 15",
+    },
+    "sub.invalid_amount": {
+        "en": "Invalid amount. Ex: /assinatura 39,90 Netflix 15",
+        "pt": "Valor inválido. Ex: /assinatura 39,90 Netflix 15",
+    },
+    "sub.default_desc": {"en": "(subscription)", "pt": "(assinatura)"},
+    "sub.created": {
+        "en": "🔁 Subscription #{rid}: R$ {amount} on {desc} — I'll log it on day {day} each month.",
+        "pt": "🔁 Assinatura #{rid}: R$ {amount} em {desc} — lanço todo dia {day}.",
+    },
+    "sub.none": {
+        "en": "No recurring subscriptions. Create one with /assinatura.",
+        "pt": "Nenhuma assinatura recorrente. Crie com /assinatura.",
+    },
+    "sub.title": {
+        "en": "🔁 Subscriptions (logged automatically every month):",
+        "pt": "🔁 Assinaturas (lançadas sozinhas todo mês):",
+    },
+    "sub.item": {
+        "en": "#{id} R$ {amount} {desc} — day {day} ({category})",
+        "pt": "#{id} R$ {amount} {desc} — dia {day} ({category})",
+    },
+    "sub.footer": {"en": "\nDelete: /assinaturarm <id>", "pt": "\nApagar: /assinaturarm <id>"},
+    "sub.rm_usage": {
+        "en": "Usage: /assinaturarm <id>. See /assinaturas.",
+        "pt": "Uso: /assinaturarm <id>. Veja em /assinaturas.",
+    },
+    "sub.removed": {"en": "Subscription #{arg} removed.", "pt": "Assinatura #{arg} removida."},
+    "sub.not_found": {"en": "Couldn't find subscription #{arg}.", "pt": "Não achei a assinatura #{arg}."},
+    # --- watches (watches.py) ---------------------------------------------
+    "watch.usage": {
+        "en": "Usage: /vigiar <url> [| keyword]\nEx: /vigiar https://... | applications open",
+        "pt": "Uso: /vigiar <url> [| palavra-chave]\nEx: /vigiar https://... | inscrições abertas",
+    },
+    "watch.extra_kw": {
+        "en": " (I'll tell you when '{keyword}' shows up)",
+        "pt": " (te aviso quando aparecer '{keyword}')",
+    },
+    "watch.extra_change": {
+        "en": " (I'll tell you when the page changes)",
+        "pt": " (te aviso quando a página mudar)",
+    },
+    "watch.created": {"en": "👁️ Monitor #{wid} created{extra}.", "pt": "👁️ Monitor #{wid} criado{extra}."},
+    "watch.none": {
+        "en": "You have no monitors. Create one with /vigiar <url> [| keyword].",
+        "pt": "Você não tem monitores. Crie com /vigiar <url> [| palavra].",
+    },
+    "watch.title": {"en": "👁️ Web monitors:", "pt": "👁️ Monitores web:"},
+    "watch.footer": {"en": "\nDelete: /vigiarm <id>", "pt": "\nApagar: /vigiarm <id>"},
+    "watch.rm_usage": {"en": "Usage: /vigiarm <id>. See /vigias.", "pt": "Uso: /vigiarm <id>. Veja em /vigias."},
+    "watch.removed": {"en": "Monitor #{arg} removed.", "pt": "Monitor #{arg} removido."},
+    "watch.not_found": {"en": "Couldn't find monitor #{arg}.", "pt": "Não achei o monitor #{arg}."},
+    # --- people (people.py) -----------------------------------------------
+    "ppl.none": {
+        "en": "No people saved. Use /pessoa <name> | <about> [| <birthday>].",
+        "pt": "Nenhuma pessoa registrada. Use /pessoa <nome> | <sobre> [| <aniversário>].",
+    },
+    "ppl.title": {"en": "👥 People:", "pt": "👥 Pessoas:"},
+    "ppl.usage": {
+        "en": "Usage: /pessoa <name> | <about> [| <birthday>]  (or just /pessoa <name> to view)",
+        "pt": "Uso: /pessoa <nome> | <sobre> [| <aniversário>]  (ou só /pessoa <nome> pra ver)",
+    },
+    "ppl.not_found": {
+        "en": "I have nothing about {name}. Add: /pessoa {name} | <about> [| <birthday>]",
+        "pt": "Não tenho nada sobre {name}. Adicione: /pessoa {name} | <sobre> [| <aniversário>]",
+    },
+    "ppl.saved": {"en": "Noted about {name}.", "pt": "Anotado sobre {name}."},
+    # --- weekly summary (weekly_summary.py) -------------------------------
+    "week.title": {"en": "📊 Your week:", "pt": "📊 Sua semana:"},
+    "week.done": {"en": "✅ Tasks completed: {done}", "pt": "✅ Tarefas concluídas: {done}"},
+    "week.open": {"en": "📋 Open tasks: {n}", "pt": "📋 Tarefas em aberto: {n}"},
+    "week.spent": {
+        "en": "💰 Spending (7 days): R$ {total} ({count})",
+        "pt": "💰 Gastos (7 dias): R$ {total} ({count})",
+    },
+    "week.habits": {"en": "🔥 Habits (streak):", "pt": "🔥 Hábitos (sequência):"},
+    "week.habit_line": {"en": "  • {name}: {streak}", "pt": "  • {name}: {streak}"},
+    # --- long-term memory (long_term_memory.py) ---------------------------
+    "ltm.usage": {
+        "en": "Usage: /lembrar <fact>. Ex: /lembrar my car is a black Civic",
+        "pt": "Uso: /lembrar <fato>. Ex: /lembrar meu carro é um Civic preto",
+    },
+    "ltm.saved": {"en": "Noted in memory: {fact}", "pt": "Anotado na memória: {fact}"},
+    "ltm.none": {
+        "en": "I don't know anything about you yet. Use /lembrar to tell me something.",
+        "pt": "Ainda não sei nada sobre você. Use /lembrar pra me contar algo.",
+    },
+    "ltm.title": {"en": "🧠 What I know about you:", "pt": "🧠 O que eu sei sobre você:"},
+    "ltm.footer": {"en": "\nDelete: /esquecer <id>", "pt": "\nApagar: /esquecer <id>"},
+    "ltm.pick": {"en": "the memory", "pt": "a memória"},
+    "ltm.forgot": {"en": "Forgot: \"{fact}\".", "pt": "Esqueci: \"{fact}\"."},
+    # --- automations (commands/automations.py + core/automations.py) ------
+    "auto.none": {
+        "en": ("No automations yet. Tell me something like 'when I spend more than 200, "
+               "warn me' or 'every Friday at 6pm, send me the summary'."),
+        "pt": ("Nenhuma automação ainda. Me diga algo como 'quando eu gastar mais de 200, "
+               "me avisa' ou 'toda sexta 18h, me manda o resumo'."),
+    },
+    "auto.title": {"en": "🤖 Your automations:", "pt": "🤖 Suas automações:"},
+    "auto.footer": {"en": "\n\nDelete: /automacaorm <id>", "pt": "\n\nApagar: /automacaorm <id>"},
+    "auto.rm_usage": {
+        "en": "Usage: /automacaorm <id> (see ids in /automacoes).",
+        "pt": "Uso: /automacaorm <id> (veja os ids em /automacoes).",
+    },
+    "auto.removed": {"en": "Automation #{aid} removed.", "pt": "Automação #{aid} removida."},
+    "auto.rm_not_found": {"en": "Couldn't find that automation.", "pt": "Não achei essa automação."},
+    "auto.bad_trigger": {"en": "invalid trigger ({trigger})", "pt": "gatilho inválido ({trigger})"},
+    "auto.bad_action": {"en": "invalid action ({action})", "pt": "ação inválida ({action})"},
+    "auto.missing_hour": {"en": "the trigger time is missing", "pt": "faltou a hora do gatilho"},
+    "auto.missing_amount": {"en": "the trigger amount is missing", "pt": "faltou o valor do gatilho"},
+    "auto.notify_default": {"en": "automation reminder", "pt": "lembrete da automação"},
+    "auto.missing_command": {"en": "the command to run is missing", "pt": "faltou o comando a rodar"},
+    "auto.reschedule_only": {
+        "en": "'reschedule' only works with the overdue-task trigger",
+        "pt": "‘remarcar’ só funciona com o gatilho de tarefa vencida",
+    },
+    "auto.play_target": {
+        "en": "tell me the playlist or the song to play",
+        "pt": "diga a playlist ou a música pra tocar",
+    },
+    # describe() fragments
+    "auto.when_weekday": {"en": "every {wd}", "pt": "toda {wd}"},
+    "auto.time_when": {"en": "{when} at {hm}", "pt": "{when} às {hm}"},
+    "auto.expense_when": {
+        "en": "when you spend more than R$ {amount}",
+        "pt": "quando gastar mais de R$ {amount}",
+    },
+    "auto.expense_cat": {"en": " in '{cat}'", "pt": " em '{cat}'"},
+    "auto.task_overdue": {"en": "when a task becomes overdue", "pt": "quando uma tarefa vencer"},
+    "auto.do_notify": {"en": "warn me: \"{message}\"", "pt": "me avisar: \"{message}\""},
+    "auto.do_command": {"en": "run /{command}", "pt": "rodar /{command}"},
+    "auto.do_reschedule": {"en": "reschedule to the next day", "pt": "remarcar pro dia seguinte"},
+    "auto.do_play": {"en": "play '{what}' on Spotify", "pt": "tocar '{what}' no Spotify"},
+    "auto.paused": {"en": " (paused)", "pt": " (pausada)"},
+    "auto.line": {"en": "#{id} — {quando} → {faca}{status}", "pt": "#{id} — {quando} → {faca}{status}"},
+    # full weekday names (automations describe, learned patterns)
+    "wd.0": {"en": "Monday", "pt": "segunda"},
+    "wd.1": {"en": "Tuesday", "pt": "terça"},
+    "wd.2": {"en": "Wednesday", "pt": "quarta"},
+    "wd.3": {"en": "Thursday", "pt": "quinta"},
+    "wd.4": {"en": "Friday", "pt": "sexta"},
+    "wd.5": {"en": "Saturday", "pt": "sábado"},
+    "wd.6": {"en": "Sunday", "pt": "domingo"},
+    # --- Google integration (google_integration.py) -----------------------
+    "gcal.not_configured_cal": {
+        "en": "Google Calendar isn't set up yet. Connect your account first.",
+        "pt": "Agenda do Google ainda não configurada. Conecte sua conta primeiro.",
+    },
+    "gcal.event_usage": {
+        "en": "Usage: /evento [account] <time> <title>. Ex: /evento pessoal tomorrow 15:00 Dentist",
+        "pt": "Uso: /evento [conta] <tempo> <título>. Ex: /evento pessoal amanhã 15:00 Dentista",
+    },
+    "gcal.email_not_configured": {
+        "en": "Google email isn't set up yet. Connect your account first.",
+        "pt": "E-mail do Google ainda não configurado. Conecte sua conta primeiro.",
+    },
+    "gcal.email_usage": {
+        "en": "Usage: /email [account] recipient | subject | body",
+        "pt": "Uso: /email [conta] destinatário | assunto | corpo",
+    },
+    "gcal.imap_not_configured": {
+        "en": ("Email reading isn't set up yet. Set EV_IMAP_ADDRESS and "
+               "EV_IMAP_PASSWORD (Gmail app password)."),
+        "pt": ("Leitura de e-mail ainda não configurada. Defina EV_IMAP_ADDRESS "
+               "e EV_IMAP_PASSWORD (senha de app do Gmail)."),
+    },
+    # --- search / news / weather (search_news_weather.py) -----------------
+    "snw.buscar_usage": {
+        "en": "Usage: /buscar <term>. Ex: /buscar tech news today",
+        "pt": "Uso: /buscar <termo>. Ex: /buscar notícias de tecnologia hoje",
+    },
+    "snw.web_results": {"en": "Web results:", "pt": "Resultados da web:"},
+    "snw.procurar_usage": {
+        "en": ("Usage: /procurar <term>. I search everything you saved "
+               "(memory, tasks, reminders, links, journal, documents)."),
+        "pt": ("Uso: /procurar <termo>. Procuro em tudo que você guardou "
+               "(memória, tarefas, lembretes, links, diário, documentos)."),
+    },
+    "snw.lbl_facts": {"en": "🧠 Memories", "pt": "🧠 Memórias"},
+    "snw.lbl_tasks": {"en": "📋 Tasks", "pt": "📋 Tarefas"},
+    "snw.lbl_reminders": {"en": "⏰ Reminders", "pt": "⏰ Lembretes"},
+    "snw.lbl_links": {"en": "🔗 Links", "pt": "🔗 Links"},
+    "snw.lbl_journal": {"en": "📔 Journal", "pt": "📔 Diário"},
+    "snw.lbl_expenses": {"en": "💸 Expenses", "pt": "💸 Gastos"},
+    "snw.lbl_messages": {"en": "💬 Conversations", "pt": "💬 Conversas"},
+    "snw.lbl_knowledge": {"en": "📄 Knowledge", "pt": "📄 Conhecimento"},
+    "snw.results_for": {"en": "🔎 Results for '{term}':", "pt": "🔎 Resultados para '{term}':"},
+    "snw.nothing_found": {
+        "en": "Nothing found for '{term}' in your data.",
+        "pt": "Nada encontrado pra '{term}' nos seus dados.",
+    },
+    "snw.news_title": {"en": "📰 News — {topic}:", "pt": "📰 Notícias — {topic}:"},
+    "snw.tabnews_tech": {"en": "\n💻 TabNews (tech):", "pt": "\n💻 TabNews (tech):"},
+    "snw.clima_usage": {
+        "en": "Usage: /clima <city>. Ex: /clima São Paulo",
+        "pt": "Uso: /clima <cidade>. Ex: /clima São Paulo",
+    },
+    # --- overview: focus mode, nudge, learned (overview.py) ---------------
+    "ov.focus_on": {"en": "🔴 Focus mode on. Full focus.", "pt": "🔴 Modo foco ativado. Foco total."},
+    "ov.focus_off": {
+        "en": "Focus mode off. Back to normal.",
+        "pt": "Modo foco desativado. De volta ao normal.",
+    },
+    "ov.sub_charge": {"en": "{desc} (R$ {amount}, day {day})", "pt": "{desc} (R$ {amount}, dia {day})"},
+    "ov.nudge_header": {
+        "en": "👋 Ryan, let me nudge you on a few things:",
+        "pt": "👋 Ryan, deixa eu te cobrar algumas coisas:",
+    },
+    "ov.nudge_overdue": {"en": "\n⏰ Overdue tasks:", "pt": "\n⏰ Tarefas atrasadas:"},
+    "ov.nudge_due_today": {"en": "\n📌 Due today:", "pt": "\n📌 Vence hoje:"},
+    "ov.nudge_subs": {"en": "\n💳 Subscription charging soon:", "pt": "\n💳 Assinatura debitando em breve:"},
+    "ov.nudge_footer": {
+        "en": "\nComplete: /concluir <name>. Want me to help with any of them?",
+        "pt": "\nConcluir: /concluir <nome>. Quer que eu te ajude com alguma?",
+    },
+    "ov.learned_known": {"en": "🧠 What I've learned about you:", "pt": "🧠 O que já aprendi sobre você:"},
+    "ov.learned_noticing": {"en": "🧠 I'm starting to notice:", "pt": "🧠 Comecei a notar:"},
+    "ov.learned_humble": {
+        "en": "I'm still getting to know you — in a few days I'll start noticing your patterns. 🌱",
+        "pt": "Ainda estou te conhecendo — em alguns dias começo a notar seus padrões. 🌱",
+    },
+    "learn.habit_skip": {
+        "en": "I noticed a pattern: you almost always skip '{name}' on {weekday}.",
+        "pt": "Notei um padrão: você quase sempre pula '{name}' às {weekday}.",
+    },
+    "learn.habit_skip_q": {
+        "en": "Want me to give you a nudge on that day?",
+        "pt": "Quer que eu te dê um empurrãozinho nesse dia?",
+    },
+    "learn.spend_over": {
+        "en": ("You've already spent R$ {tot} on '{cat}' this month — more than the "
+               "R$ {prev} you spent all of last month."),
+        "pt": ("Você já gastou R$ {tot} em '{cat}' este mês — mais que os "
+               "R$ {prev} do mês passado inteiro."),
+    },
+    "learn.spend_over_q": {
+        "en": "Want to set a budget for this category?",
+        "pt": "Quer definir um orçamento pra essa categoria?",
+    },
+    # recurring weekday forms for the habit-skip pattern ("on Mondays")
+    "learn.wd.0": {"en": "Mondays", "pt": "segundas-feiras"},
+    "learn.wd.1": {"en": "Tuesdays", "pt": "terças-feiras"},
+    "learn.wd.2": {"en": "Wednesdays", "pt": "quartas-feiras"},
+    "learn.wd.3": {"en": "Thursdays", "pt": "quintas-feiras"},
+    "learn.wd.4": {"en": "Fridays", "pt": "sextas-feiras"},
+    "learn.wd.5": {"en": "Saturdays", "pt": "sábados"},
+    "learn.wd.6": {"en": "Sundays", "pt": "domingos"},
+    # --- base command layer (base.py) -------------------------------------
+    "pick.not_found_id": {"en": "Couldn't find {label} #{arg}.", "pt": "Não achei {label} #{arg}."},
+    "pick.need_name": {
+        "en": "I need the name or number ({label}).",
+        "pt": "Preciso do nome ou número ({label}).",
+    },
+    "pick.not_found_name": {
+        "en": "Couldn't find {label} with \"{arg}\".",
+        "pt": "Não achei {label} com \"{arg}\".",
+    },
+    "pick.ambiguous": {
+        "en": "Found more than one similar: {opts}. Which one? (tell me the number)",
+        "pt": "Achei mais de um parecido: {opts}. Qual? (me diz o número)",
+    },
+    "cmd.unknown": {
+        "en": "I don't know the command '{name}'. Commands I can run: {cmds}",
+        "pt": "Não conheço o comando '{name}'. Comandos que posso executar: {cmds}",
+    },
+    "cmd.error": {"en": "Error running {key}: {exc}", "pt": "Erro ao executar {key}: {exc}"},
+    "help.text": {
+        "en": (
+            "🕷️ E.V. — all commands\n"
+            "━━━━━━━━━━━━━━━━━━\n"
+            "🏠 General\n"
+            "   /menu · /ajuda · /modelo · /status · /silenciar\n"
+            "   /dados (storage) · /limpar (memory) · /limparchat (bubbles)\n\n"
+            "🎯 Focus & Web\n"
+            "   /foco (pomodoro) · /resumir (link)\n\n"
+            "📋 Tasks\n"
+            "   /tarefa · /tarefas · /concluir\n\n"
+            "⏰ Reminders & Calendar\n"
+            "   /lembrete · /rotina · /lembretes · /cancelar · /calendario\n\n"
+            "🧠 Memory\n"
+            "   /lembrar · /memorias · /esquecer\n\n"
+            "🔗 Links\n"
+            "   /link · /links · /linkrm\n\n"
+            "📄 Knowledge & Study\n"
+            "   send a PDF/Word/txt · /kb · /kbweb · /kbrm · /quiz\n"
+            "   /documento (create) · /exportar (data) · /transcrever (audio)\n\n"
+            "💰 Finance\n"
+            "   /gasto · /gastos · /gastorm · /relatorio\n"
+            "   /orcamento · /orcamentos · /orcamentorm\n"
+            "   /assinatura · /assinaturas · /assinaturarm\n\n"
+            "✅ Habits\n"
+            "   /habito · /feito · /habitos · /habitorm\n\n"
+            "📔 Journal\n"
+            "   /diario · /diariorm\n\n"
+            "📊 Summaries & Automation\n"
+            "   /semana · /insights · /vigiar · /vigias · /vigiarm\n\n"
+            "🔎 Search, News & Weather\n"
+            "   /buscar (web) · /procurar (your data) · /noticias · /clima\n\n"
+            "📅 Google\n"
+            "   /agenda · /evento · /email\n"
+            "━━━━━━━━━━━━━━━━━━\n"
+            "💬 Or tap /menu to use buttons. I also understand text, audio, photo and PDF!"
+        ),
+        "pt": (
+            "🕷️ E.V. — todos os comandos\n"
+            "━━━━━━━━━━━━━━━━━━\n"
+            "🏠 Geral\n"
+            "   /menu · /ajuda · /modelo · /status · /silenciar\n"
+            "   /dados (armazenamento) · /limpar (memória) · /limparchat (bolhas)\n\n"
+            "🎯 Foco & Web\n"
+            "   /foco (pomodoro) · /resumir (link)\n\n"
+            "📋 Tarefas\n"
+            "   /tarefa · /tarefas · /concluir\n\n"
+            "⏰ Lembretes & Agenda\n"
+            "   /lembrete · /rotina · /lembretes · /cancelar · /calendario\n\n"
+            "🧠 Memória\n"
+            "   /lembrar · /memorias · /esquecer\n\n"
+            "🔗 Links\n"
+            "   /link · /links · /linkrm\n\n"
+            "📄 Conhecimento & Estudo\n"
+            "   envie um PDF/Word/txt · /kb · /kbweb · /kbrm · /quiz\n"
+            "   /documento (criar) · /exportar (dados) · /transcrever (áudio)\n\n"
+            "💰 Finanças\n"
+            "   /gasto · /gastos · /gastorm · /relatorio\n"
+            "   /orcamento · /orcamentos · /orcamentorm\n"
+            "   /assinatura · /assinaturas · /assinaturarm\n\n"
+            "✅ Hábitos\n"
+            "   /habito · /feito · /habitos · /habitorm\n\n"
+            "📔 Diário\n"
+            "   /diario · /diariorm\n\n"
+            "📊 Resumos & Automação\n"
+            "   /semana · /insights · /vigiar · /vigias · /vigiarm\n\n"
+            "🔎 Busca, Notícias & Clima\n"
+            "   /buscar (web) · /procurar (seus dados) · /noticias · /clima\n\n"
+            "📅 Google\n"
+            "   /agenda · /evento · /email\n"
+            "━━━━━━━━━━━━━━━━━━\n"
+            "💬 Ou toque em /menu pra usar por botões. Também entendo mensagem, áudio, foto e PDF!"
+        ),
+    },
+    # --- web command runner (interfaces/web/context.py) -------------------
+    "web.empty_cmd": {"en": "Type a command.", "pt": "Digite um comando."},
+    "web.conv_cleared": {"en": "Conversation cleared in this folder.", "pt": "Conversa limpa nesta pasta."},
+    "web.all_clear": {
+        "en": "All caught up, Ryan — nothing overdue. 👌",
+        "pt": "Tudo em dia, Ryan — nada atrasado. 👌",
+    },
+    "web.provider_set": {"en": "Provider: {v}.", "pt": "Provedor: {v}."},
+    "web.provider_auto": {"en": "Provider: automatic.", "pt": "Provedor: automático."},
+    "web.provider_usage": {
+        "en": "Usage: /provedor auto|gemini|groq|openrouter|ollama",
+        "pt": "Uso: /provedor auto|gemini|groq|openrouter|ollama",
+    },
+    "web.model_main": {"en": "🧠 Main: {model} (Gemini)", "pt": "🧠 Principal: {model} (Gemini)"},
+    "web.model_fallback": {"en": "Fallback: {model} ({provider})", "pt": "Fallback: {model} ({provider})"},
+    "web.model_active": {"en": "Active provider: {forced}", "pt": "Provedor ativo: {forced}"},
+    "web.model_usage_today": {
+        "en": "📊 Usage today (resets at midnight UTC):",
+        "pt": "📊 Uso hoje (zera à meia-noite UTC):",
+    },
+    "web.model_line_cap": {
+        "en": "- {prov}: {used} used · ~{left} left (of ~{cap})",
+        "pt": "- {prov}: {used} usados · ~{left} restantes (de ~{cap})",
+    },
+    "web.model_line_unlimited": {
+        "en": "- ollama: {used} used · unlimited",
+        "pt": "- ollama: {used} usados · ilimitado",
+    },
+    "web.data_title": {"en": "🗄️ Your stored data:", "pt": "🗄️ Seus dados guardados:"},
+    "web.data_item": {"en": "- {label}: {count}", "pt": "- {label}: {count}"},
+    "web.data_footer": {
+        "en": ("\nTo delete by category, use the tabs (Tasks/Expenses/...) "
+               "or /dados on Telegram (with double confirmation to wipe everything)."),
+        "pt": ("\nPra apagar por categoria, use as abas (Tarefas/Gastos/...) "
+               "ou o /dados no Telegram (com dupla confirmação pra apagar tudo)."),
+    },
+    "web.summarize_usage": {"en": "Usage: /resumir <url>", "pt": "Uso: /resumir <url>"},
+    "web.page_error": {
+        "en": "Couldn't open the page ({e}).",
+        "pt": "Não consegui abrir a página ({e}).",
+    },
+    "web.summarize_fail": {
+        "en": "Couldn't summarize right now, try again?",
+        "pt": "Não consegui resumir agora, tenta de novo?",
+    },
+    "web.kb_empty_tab": {
+        "en": "Knowledge base empty. Add something in the Base tab first.",
+        "pt": "Base de conhecimento vazia. Adicione algo na aba Base primeiro.",
+    },
+    "web.quiz_fail": {
+        "en": "Couldn't generate the question right now.",
+        "pt": "Não consegui gerar a pergunta agora.",
+    },
+    "web.telegram_only": {
+        "en": ("/{name} is better on Telegram or via the interface: use the matching "
+               "tab/button (e.g. Pomodoro, export in the panel)."),
+        "pt": ("O /{name} é melhor no Telegram ou pela interface: use a aba/botão "
+               "correspondente (ex: Pomodoro, exportar no painel)."),
+    },
 }
 
 # Pluralized fragments: key -> {lang: (singular, plural)}. Both en and pt use the
@@ -109,6 +880,14 @@ _PLURALS: dict[str, dict[str, tuple[str, str]]] = {
         "pt": ("{n} lembrete", "{n} lembretes"),
     },
     "count.days": {"en": ("{n} day", "{n} days"), "pt": ("{n} dia", "{n} dias")},
+    "count.entries": {
+        "en": ("{n} entry", "{n} entries"),
+        "pt": ("{n} lançamento", "{n} lançamentos"),
+    },
+    "count.chunks": {
+        "en": ("{n} chunk", "{n} chunks"),
+        "pt": ("{n} trecho", "{n} trechos"),
+    },
 }
 
 

--- a/ev/interfaces/web/context.py
+++ b/ev/interfaces/web/context.py
@@ -101,18 +101,19 @@ class WebContext:
         """Run a slash command from the web (data + interface commands)."""
         config, memory, brain, commands, owner = (
             self.config, self.memory, self.brain, self.commands, self.owner)
+        lang = memory.assistant_lang()
         parts = (cmd_str or "").strip().split(None, 1)
         if not parts:
-            return "Digite um comando."
+            return _t(lang, "web.empty_cmd")
         name = parts[0].lstrip("/").lower()
         rest = parts[1] if len(parts) > 1 else ""
         if name in ("limpar", "limparchat"):  # clear THIS folder's conversation
             memory.clear_conversation(self.conv(thread))
-            return "Conversa limpa nesta pasta."
+            return _t(lang, "web.conv_cleared")
         if name in ("plano", "manha", "manhã"):  # agentic day plan
             return await brain.plan_day(owner)
         if name in ("pendencias", "pendências", "cobrar"):  # proactive open loops
-            return commands.nudge_text(owner) or "Tudo em dia, Ryan — nada atrasado. 👌"
+            return commands.nudge_text(owner) or _t(lang, "web.all_clear")
         if name in ("padroes", "padrões", "aprendi"):  # continuous learning view
             return commands.learned_text(owner)
         if name in ("automacoes", "automações", "automacao", "automação"):
@@ -125,8 +126,8 @@ class WebContext:
             v = rest.strip().lower()
             if v in ("", "auto", "gemini", "groq", "openrouter", "ollama"):
                 memory.set_setting("force_provider", "" if v in ("", "auto") else v)
-                return f"Provedor: {v or 'auto'}." if v else "Provedor: automático."
-            return "Uso: /provedor auto|gemini|groq|openrouter|ollama"
+                return _t(lang, "web.provider_set", v=v) if v else _t(lang, "web.provider_auto")
+            return _t(lang, "web.provider_usage")
         if name == "status":
             return self.status_text()
         if name == "modelo":
@@ -134,57 +135,57 @@ class WebContext:
             usage = memory.usage_for_day(datetime.now(timezone.utc).date().isoformat())
             caps = {"gemini": 20, "groq": 1000, "openrouter": 1000}
             forced = memory.get_setting("force_provider") or "auto"
-            out = [f"🧠 Principal: {brain.current_model()} (Gemini)"]
+            out = [_t(lang, "web.model_main", model=brain.current_model())]
             if config.groq_api_key:
-                out.append(f"Fallback: {config.groq_model} (Groq)")
+                out.append(_t(lang, "web.model_fallback", model=config.groq_model, provider="Groq"))
             if config.openrouter_api_key:
-                out.append(f"Fallback: {config.openrouter_model} (OpenRouter)")
-            out.append(f"Provedor ativo: {forced}")
+                out.append(_t(lang, "web.model_fallback", model=config.openrouter_model,
+                              provider="OpenRouter"))
+            out.append(_t(lang, "web.model_active", forced=forced))
             out.append("")
-            out.append("📊 Uso hoje (zera à meia-noite UTC):")
+            out.append(_t(lang, "web.model_usage_today"))
             for prov in ("gemini", "groq", "openrouter", "ollama"):
                 used = usage.get(prov, 0)
                 cap = caps.get(prov)
                 if cap:
-                    out.append(f"- {prov}: {used} usados · ~{max(0, cap - used)} restantes (de ~{cap})")
+                    out.append(_t(lang, "web.model_line_cap", prov=prov, used=used,
+                                  left=max(0, cap - used), cap=cap))
                 elif prov == "ollama" and config.ollama_enabled:
-                    out.append(f"- ollama: {used} usados · ilimitado")
+                    out.append(_t(lang, "web.model_line_unlimited", used=used))
             return "\n".join(out)
         if name == "ajuda":
             return commands.help()
         if name == "dados":
             summ = memory.storage_summary(owner)
-            out = ["🗄️ Seus dados guardados:", ""]
-            out += [f"- {s['label']}: {s['count']}" for s in summ]
-            out.append("\nPra apagar por categoria, use as abas (Tarefas/Gastos/...) "
-                       "ou o /dados no Telegram (com dupla confirmação pra apagar tudo).")
+            out = [_t(lang, "web.data_title"), ""]
+            out += [_t(lang, "web.data_item", label=s['label'], count=s['count']) for s in summ]
+            out.append(_t(lang, "web.data_footer"))
             return "\n".join(out)
         if name == "resumir":
             if not rest.lower().startswith("http"):
-                return "Uso: /resumir <url>"
+                return _t(lang, "web.summarize_usage")
             try:
                 text = await asyncio.to_thread(tools_mod.fetch_text, rest)
             except Exception as e:
-                return f"Não consegui abrir a página ({str(e)[:80]})."
+                return _t(lang, "web.page_error", e=str(e)[:80])
             if not text or len(text.strip()) < 80:
-                return "Não achei texto útil nessa página."
+                return _t(lang, "web.page_no_text")
             s = await brain.ask(
                 "Você é a E.V. Resuma o artigo em português: um parágrafo de contexto "
                 "e depois 3 a 6 bullets com os pontos principais.",
                 f"Conteúdo de {rest}:\n\n{text[:12000]}")
-            return s or "Não consegui resumir agora, tenta de novo?"
+            return s or _t(lang, "web.summarize_fail")
         if name == "quiz":
             chunk = memory.random_chunk(owner, rest or None)
             if not chunk:
-                return "Base de conhecimento vazia. Adicione algo na aba Base primeiro."
+                return _t(lang, "web.kb_empty_tab")
             out = await brain.ask(
                 "Você é um tutor. Com base no trecho, crie UMA pergunta de estudo "
                 "objetiva e a resposta. Formato:\nPERGUNTA: <pergunta>\nRESPOSTA: <resposta>",
                 f"Trecho de [{chunk['source']}]:\n{chunk['chunk']}")
-            return out or "Não consegui gerar a pergunta agora."
+            return out or _t(lang, "web.quiz_fail")
         if name in ("foco", "exportar", "transcrever", "documento", "insights", "menu"):
-            return (f"O /{name} é melhor no Telegram ou pela interface: use a aba/botão "
-                    "correspondente (ex: Pomodoro, exportar no painel).")
+            return _t(lang, "web.telegram_only", name=name)
         return commands.run(owner, name, rest)  # -> "não conheço"
 
     def base_url(self, request) -> str:

--- a/tests/test_ai_commands.py
+++ b/tests/test_ai_commands.py
@@ -69,8 +69,8 @@ def test_executar_comando_handles_inline_args(tmp_path):
     )
     brain = Brain(cfg, Memory(tmp_path / "t.db"))
     ec = brain._tool_callables("u")["executar_comando"]
-    assert "adicionada" in ec("tarefa comprar pão #casa")   # args inside comando
-    assert "adicionada" in ec("tarefa", "estudar #faculdade")  # normal form
+    assert "added" in ec("tarefa comprar pão #casa")   # args inside comando
+    assert "added" in ec("tarefa", "estudar #faculdade")  # normal form
     assert "comprar pão" in brain._commands.tarefas("u")
 
 

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -27,11 +27,19 @@ def test_expense_matches():
 
 
 def test_describe():
+    # English is the default language
     a = {"id": 1, "trig": "expense_over", "trig_cfg": {"amount": 200},
          "act": "notify", "act_cfg": {"message": "alto"}, "enabled": True}
     d = au.describe(a)
-    assert "200" in d and "avisar" in d
+    assert "200" in d and "warn me" in d
     t = {"id": 2, "trig": "time", "trig_cfg": {"hour": 18, "minute": 0, "weekday": 4},
          "act": "command", "act_cfg": {"command": "semana"}, "enabled": False}
     dt = au.describe(t)
+    assert "Friday" in dt and "18:00" in dt and "semana" in dt and "paused" in dt
+
+
+def test_describe_pt():
+    t = {"id": 2, "trig": "time", "trig_cfg": {"hour": 18, "minute": 0, "weekday": 4},
+         "act": "command", "act_cfg": {"command": "semana"}, "enabled": False}
+    dt = au.describe(t, "pt")
     assert "sexta" in dt and "18:00" in dt and "semana" in dt and "pausada" in dt

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -37,7 +37,7 @@ def test_open_loops_and_nudge(tmp_path):
     assert any("Netflix" in s for s in loops["subs"])
     assert not any("Spotify" in s for s in loops["subs"])
     msg = c.nudge_text("u", now=now)
-    assert "atrasada" in msg and "entregar relatório" in msg and "Netflix" in msg
+    assert "Overdue" in msg and "entregar relatório" in msg and "Netflix" in msg
     # clean slate → empty nudge (E.V. stays silent when nothing is slipping)
     assert c.nudge_text("v", now=now) == ""
 
@@ -105,11 +105,11 @@ def test_automations_crud(tmp_path):
                                    message="Gasto alto")
     assert aid and "200" in msg
     listing = c.automacoes("u")
-    assert "200" in listing and "avisar" in listing
+    assert "200" in listing and "warn me" in listing
     # a time+command automation
     aid2, _ = c.create_automation("u", "time", "command", hour=18, weekday=4,
                                   command="semana")
-    assert aid2 and "sexta" in c.automacoes("u")
+    assert aid2 and "Friday" in c.automacoes("u")
     # validation: bad trigger / missing field
     assert c.create_automation("u", "bogus", "notify")[0] is None
     assert c.create_automation("u", "expense_over", "notify")[0] is None  # no amount
@@ -118,8 +118,8 @@ def test_automations_crud(tmp_path):
     assert aid3 and "Foco" in m3
     assert c.create_automation("u", "time", "play", hour=8)[0] is None  # no target
     # remove
-    assert "removida" in c.automacao_rm("u", str(aid))
-    assert c.automacao_rm("u", "999") == "Não achei essa automação."
+    assert "removed" in c.automacao_rm("u", str(aid))
+    assert c.automacao_rm("u", "999") == "Couldn't find that automation."
 
 
 def test_learned_patterns_and_persistence(tmp_path):
@@ -136,7 +136,7 @@ def test_learned_patterns_and_persistence(tmp_path):
             m.log_habit(hid, d.isoformat())
     pats = c.learned_patterns("u", now=now)
     skip = [p for p in pats if p["key"].startswith("habit-skip:")]
-    assert skip and "academia" in skip[0]["text"] and "segunda" in skip[0]["text"]
+    assert skip and "academia" in skip[0]["text"] and "Monday" in skip[0]["text"]
 
     # spending: this month already exceeds last month's total for a category
     conn = m._conn
@@ -154,11 +154,11 @@ def test_learned_patterns_and_persistence(tmp_path):
     assert m.add_learned("u", key, skip[0]["text"]) is True
     assert m.learned_seen("u", key) is True
     assert m.add_learned("u", key, skip[0]["text"]) is False
-    assert "aprendi" in c.learned_text("u").lower()
+    assert "learned" in c.learned_text("u").lower()
 
     # a fresh user with no history → E.V. stays humble, no false patterns
     assert c.learned_patterns("v", now=now) == []
-    assert "conhecendo" in c.learned_text("v").lower()
+    assert "getting to know" in c.learned_text("v").lower()
 
 
 def test_budget_alerts(tmp_path):
@@ -192,10 +192,10 @@ def test_subscriptions_due(tmp_path):
 
 def test_task_flow(tmp_path):
     c = _commands(tmp_path)
-    assert "adicionada" in c.tarefa("u", "comprar pão")
+    assert "added" in c.tarefa("u", "comprar pão")
     assert "comprar pão" in c.tarefas("u")
-    assert "concluída" in c.concluir("u", "1")
-    assert "vazia" in c.tarefas("u")
+    assert "completed" in c.concluir("u", "1")
+    assert "empty" in c.tarefas("u")
 
 
 def test_task_category(tmp_path):
@@ -205,22 +205,22 @@ def test_task_category(tmp_path):
     listing = c.tarefas("u", "faculdade")
     assert "estudar cálculo" in listing
     assert "#faculdade" not in listing  # tag stripped from the stored text
-    assert "Nenhuma" in c.tarefas("u", "trabalho")
+    assert "No tasks" in c.tarefas("u", "trabalho")
 
 
 def test_buscar_usage(tmp_path):
     c = _commands(tmp_path)
-    assert "Uso:" in c.buscar("")
+    assert "Usage:" in c.buscar("")
 
 
 def test_unified_search(tmp_path):
     c = _commands(tmp_path)
     c.tarefa("u", "estudar cálculo #faculdade")
     c.link("u", "faculdade | grade | http://x")
-    assert "Uso:" in c.procurar("u", "")
+    assert "Usage:" in c.procurar("u", "")
     out = c.procurar("u", "cálculo")
     assert "estudar cálculo" in out
-    assert "nada encontrado" in c.procurar("u", "zzzznada").lower()
+    assert "nothing found" in c.procurar("u", "zzzznada").lower()
 
 
 def test_expenses(tmp_path):
@@ -233,17 +233,17 @@ def test_expenses(tmp_path):
 
 def test_habits(tmp_path):
     c = _commands(tmp_path)
-    assert "criado" in c.habito("u", "treino")
-    assert "já existe" in c.habito("u", "treino")
-    assert "feito hoje" in c.feito("u", "treino")
-    assert "Sequência: 1" in c.feito("u", "treino")  # already marked today
+    assert "created" in c.habito("u", "treino")
+    assert "already exists" in c.habito("u", "treino")
+    assert "done today" in c.feito("u", "treino")
+    assert "Streak: 1" in c.feito("u", "treino")  # already marked today
     assert "[x] treino" in c.habitos("u")
 
 
 def test_journal(tmp_path):
     c = _commands(tmp_path)
-    assert "vazio" in c.diario("u", "")
-    assert "Anotado" in c.diario("u", "hoje foi um bom dia")
+    assert "empty" in c.diario("u", "")
+    assert "Noted" in c.diario("u", "hoje foi um bom dia")
     assert "bom dia" in c.diario("u", "")
 
 
@@ -253,21 +253,21 @@ def test_weekly_review(tmp_path):
     c.concluir("u", "1")
     c.gasto("u", "30 mercado")
     out = c.semana("u")
-    assert "Sua semana" in out
-    assert "concluídas: 1" in out
+    assert "Your week" in out
+    assert "completed: 1" in out
 
 
 def test_report_current_vs_previous_month(tmp_path):
     c = _commands(tmp_path)
     # empty month -> friendly message
-    assert "nenhum gasto" in c.relatorio("u").lower()
+    assert "no expenses" in c.relatorio("u").lower()
     c.gasto("u", "50 mercado #comida")
     # default report = CURRENT month, so a just-added expense shows up
     cur = c.relatorio("u")
-    assert "Relatório" in cur and "50" in cur and "comida" in cur
+    assert "report" in cur and "50" in cur and "comida" in cur
     # previous month (offset=-1) has nothing yet, and its label differs
     prev = c.relatorio("u", offset=-1)
-    assert "nenhum gasto" in prev.lower()
+    assert "no expenses" in prev.lower()
     assert c._month_bounds(0)[0] != c._month_bounds(-1)[0]
 
 
@@ -284,112 +284,128 @@ def test_edit_by_name_expense_and_reminder(tmp_path):
     c = _commands(tmp_path)
     c.gasto("u", "50 mercado #casa")
     out = c.gastoeditar("u", "mercado | 65 mercado grande #lazer")
-    assert "atualizado" in out
+    assert "updated" in out
     e = c._memory.expenses_since("u", "2000-01-01")[0]
     assert e["amount"] == 65.0 and e["description"] == "mercado grande" and e["category"] == "lazer"
     c.lembrete("u", "amanhã 09:00 pagar conta")
-    assert "atualizado" in c.lembreteeditar("u", "pagar conta | pagar aluguel")
+    assert "updated" in c.lembreteeditar("u", "pagar conta | pagar aluguel")
     assert c._memory.open_reminders("u")[0]["text"] == "pagar aluguel"
-    assert "não achei" in c.gastoeditar("u", "inexistente | 10").lower()
+    assert "couldn't find" in c.gastoeditar("u", "inexistente | 10").lower()
 
 
 def test_delete_by_name_across_types(tmp_path):
     c = _commands(tmp_path)
     c.gasto("u", "50 mercado #casa")
-    assert "apagado" in c.gastorm("u", "mercado")
+    assert "deleted" in c.gastorm("u", "mercado")
     c.lembrete("u", "10m tomar remédio")
-    assert "cancelado" in c.cancelar("u", "remédio")
+    assert "canceled" in c.cancelar("u", "remédio")
     c.lembrar("u", "gosto de café")
-    assert "Esqueci" in c.esquecer("u", "café")
+    assert "Forgot" in c.esquecer("u", "café")
     c.link("u", "dev | github | http://x")
-    assert "removido" in c.linkrm("u", "github")
+    assert "removed" in c.linkrm("u", "github")
     # name that doesn't exist -> friendly message, not a crash
-    assert "não achei" in c.gastorm("u", "inexistente").lower()
+    assert "couldn't find" in c.gastorm("u", "inexistente").lower()
 
 
 def test_task_crud_by_name(tmp_path):
     c = _commands(tmp_path)
     c.tarefa("u", "comprar leite #mercado")
     # complete by name (not id)
-    assert "concluída" in c.concluir("u", "comprar leite")
+    assert "completed" in c.concluir("u", "comprar leite")
     assert c._memory.open_tasks("u") == []
     # edit by name
     c.tarefa("u", "estudar")
-    assert "atualizada" in c.tarefaeditar("u", "estudar | estudar cálculo #faculdade")
+    assert "updated" in c.tarefaeditar("u", "estudar | estudar cálculo #faculdade")
     t = c._memory.open_tasks("u")[0]
     assert t["text"] == "estudar cálculo" and t["category"] == "faculdade"
     # delete by name
-    assert "apagada" in c.tarefarm("u", "estudar")
+    assert "deleted" in c.tarefarm("u", "estudar")
     assert c._memory.open_tasks("u") == []
     # ambiguous name -> asks which
     c.tarefa("u", "reunião manhã"); c.tarefa("u", "reunião tarde")
-    assert "mais de uma" in c.concluir("u", "reunião").lower()
+    assert "more than one" in c.concluir("u", "reunião").lower()
 
 
 def test_watches(tmp_path):
     c = _commands(tmp_path)
-    assert "criado" in c.vigiar("u", "https://exemplo.com | vaga aberta")
+    assert "created" in c.vigiar("u", "https://exemplo.com | vaga aberta")
     assert "exemplo.com" in c.vigias("u")
-    assert "removido" in c.vigiarm("u", "1")
+    assert "removed" in c.vigiarm("u", "1")
+
+
+def test_command_output_follows_language(tmp_path):
+    # deterministic command replies follow assistant_lang (English default / PT)
+    c = _commands(tmp_path)
+    # English default
+    assert "Your task list is empty." in c.tarefas("u")
+    assert "monitors" in c.vigias("u").lower()
+    assert "Your week" in c.semana("u")
+    assert "knowledge base empty" in c.kb("u").lower()
+    # Portuguese
+    c._memory.set_assistant_lang("pt")
+    assert "vazia" in c.tarefas("u").lower()
+    assert "monitores" in c.vigias("u").lower()
+    assert "Sua semana" in c.semana("u")
+    assert "base de conhecimento vazia" in c.kb("u").lower()
 
 
 def test_budget_alert(tmp_path):
     c = _commands(tmp_path)
-    assert "definido" in c.orcamento("u", "comida 100")
+    assert "set" in c.orcamento("u", "comida 100")
     warn = c.gasto("u", "85 mercado #comida")  # 85% of the limit
-    assert "orçamento" in warn.lower()
+    assert "budget" in warn.lower()
     # the alert is also recorded in the notification center
     notifs = c._memory.list_notifications("u")
-    assert notifs and "rçamento" in notifs[0]["title"]
+    assert notifs and "Budget" in notifs[0]["title"]
     assert "comida" in c.orcamentos("u")
-    assert "removido" in c.orcamentorm("u", "comida")
+    assert "removed" in c.orcamentorm("u", "comida")
 
 
 def test_recurring_expense(tmp_path):
     c = _commands(tmp_path)
     out = c.assinatura("u", "39,90 Netflix 15")
-    assert "Netflix" in out and "dia 15" in out
+    assert "Netflix" in out and "day 15" in out
     assert "Netflix" in c.assinaturas("u")
-    assert "removida" in c.assinaturarm("u", "1")
+    assert "removed" in c.assinaturarm("u", "1")
 
 
 def test_delete_operations(tmp_path):
     c = _commands(tmp_path)
     c._memory.add_fact("u", "gosto de café")
     assert "#1" in c.memorias("u")
-    assert "Esqueci" in c.esquecer("u", "1")
-    assert "não achei" in c.esquecer("u", "1").lower()
+    assert "Forgot" in c.esquecer("u", "1")
+    assert "couldn't find" in c.esquecer("u", "1").lower()
 
     c.gasto("u", "10 pão")
-    assert "apagado" in c.gastorm("u", "1")
+    assert "deleted" in c.gastorm("u", "1")
 
     c.habito("u", "treino")
-    assert "removido" in c.habitorm("u", "treino")
+    assert "removed" in c.habitorm("u", "treino")
 
     c.diario("u", "entrada teste")
-    assert "apagada" in c.diariorm("u", "1")
+    assert "deleted" in c.diariorm("u", "1")
 
 
 def test_reminder_command(tmp_path):
     c = _commands(tmp_path)
     out = c.lembrete("u", "10m tomar água")
-    assert "criado" in out
+    assert "created" in out
     assert "tomar água" in c.lembretes("u")
 
 
 def test_link_flow(tmp_path):
     c = _commands(tmp_path)
-    assert "salvo" in c.link("u", "faculdade | grade | http://x")
+    assert "saved" in c.link("u", "faculdade | grade | http://x")
     listing = c.links("u", "")
     assert "grade" in listing and "faculdade" in listing
 
 
 def test_google_disabled(tmp_path):
     c = _commands(tmp_path)
-    assert "não configurada" in c.agenda()
-    assert "não configurado" in c.email("a@b.com | oi | teste")
+    assert "isn't set up" in c.agenda()
+    assert "isn't set up" in c.email("a@b.com | oi | teste")
     # reading needs IMAP creds, not Google
-    assert "não configurada" in c.emails().lower()
+    assert "isn't set up" in c.emails().lower()
 
 
 def test_inbox_summary_formatting(monkeypatch):
@@ -417,8 +433,8 @@ def test_imap_query_mapping():
 
 def test_bad_input(tmp_path):
     c = _commands(tmp_path)
-    assert "Uso:" in c.tarefa("u", "")
-    assert "horário" in c.lembrete("u", "sem tempo aqui")
+    assert "Usage:" in c.tarefa("u", "")
+    assert "time" in c.lembrete("u", "sem tempo aqui")
 
 
 def test_resolve_account(tmp_path):
@@ -438,16 +454,16 @@ def test_resolve_account(tmp_path):
 def test_cancel_reminder(tmp_path):
     c = _commands(tmp_path)
     c.lembrete("u", "10m tomar água")
-    assert "cancelado" in c.cancelar("u", "1")
-    assert "não achei" in c.cancelar("u", "1").lower()
+    assert "canceled" in c.cancelar("u", "1")
+    assert "couldn't find" in c.cancelar("u", "1").lower()
 
 
 def test_rotina(tmp_path):
     c = _commands(tmp_path)
     out = c.rotina("u", "diario 08:00 tomar remédio")
-    assert "Rotina" in out and "todo dia" in out
-    assert "[todo dia]" in c.lembretes("u")
-    assert "inválida" in c.rotina("u", "anual 08:00 x").lower()
+    assert "Routine" in out and "every day" in out
+    assert "[every day]" in c.lembretes("u")
+    assert "invalid" in c.rotina("u", "anual 08:00 x").lower()
 
 
 def test_receipt_json_parsing():
@@ -465,8 +481,8 @@ def test_receipt_json_parsing():
 
 def test_people_memory_and_birthdays(tmp_path):
     c = _commands(tmp_path)
-    assert "Nenhuma pessoa" in c.pessoas("u")
-    assert "Anotado" in c.pessoa("u", "Ana | irmã, ama café | 12/03")
+    assert "No people" in c.pessoas("u")
+    assert "Noted" in c.pessoa("u", "Ana | irmã, ama café | 12/03")
     out = c.pessoas("u")
     assert "Ana" in out and "irmã" in out and "03-12" in out
     # view by name

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -19,7 +19,7 @@ def _commands(tmp_path):
 def test_run_creates_task(tmp_path):
     c = _commands(tmp_path)
     out = c.run("u", "tarefa", "comprar pão #casa")
-    assert "adicionada" in out
+    assert "added" in out
     assert "comprar pão" in c.run("u", "tarefas", "")
 
 
@@ -34,18 +34,18 @@ def test_run_save_and_forget_memory(tmp_path):
     c = _commands(tmp_path)
     c.run("u", "lembrar", "meu carro é um Civic")
     assert "Civic" in c.run("u", "memorias", "")
-    assert "esquec" in c.run("u", "esquecer", "1").lower()
+    assert "forgot" in c.run("u", "esquecer", "1").lower()
 
 
 def test_run_strips_leading_slash(tmp_path):
     c = _commands(tmp_path)
-    assert "adicionada" in c.run("u", "/tarefa", "estudar")
+    assert "added" in c.run("u", "/tarefa", "estudar")
 
 
 def test_run_unknown_command(tmp_path):
     c = _commands(tmp_path)
     out = c.run("u", "voar", "")
-    assert "não conheço" in out.lower()
+    assert "don't know" in out.lower()
 
 
 def test_runnable_lists_core_commands(tmp_path):

--- a/tests/test_files_features.py
+++ b/tests/test_files_features.py
@@ -35,7 +35,7 @@ def test_add_months_crosses_year():
 def test_rotina_monthly(tmp_path):
     c = _commands(tmp_path)
     out = c.rotina("u", "mensal 5 10:00 pagar aluguel")
-    assert "todo dia 5" in out
+    assert "every 5" in out
     rems = c._memory.open_reminders("u")
     assert rems and rems[0]["recur"] == "monthly"
     assert datetime.fromisoformat(rems[0]["when_iso"]).day == 5
@@ -48,7 +48,7 @@ def test_rotina_monthly_requires_day(tmp_path):
 
 def test_rotina_still_supports_daily(tmp_path):
     c = _commands(tmp_path)
-    assert "todo dia" in c.rotina("u", "diario 08:00 remédio")
+    assert "every day" in c.rotina("u", "diario 08:00 remédio")
 
 
 # --- text extraction (feature A) --------------------------------------------
@@ -86,5 +86,5 @@ def test_data_digest(tmp_path):
     c._memory.add_task("u", "estudar", "faculdade")
     c._memory.add_fact("u", "gosto de café")
     title, content = c.data_digest("u")
-    assert "Meus dados" in title
+    assert "My data" in title
     assert "estudar" in content and "café" in content

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -219,7 +219,7 @@ def test_cmd_provider_works(tmp_path):
 def test_cmd_data_command(tmp_path):
     client, _ = _client(tmp_path)
     r = client.post("/api/cmd", json={"command": "tarefa comprar pão"}, headers=_auth())
-    assert "adicionada" in r.json()["reply"].lower()
+    assert "added" in r.json()["reply"].lower()
 
 
 def test_folder_rename_and_delete(tmp_path):
@@ -284,7 +284,7 @@ def test_limparchat_clears_folder(tmp_path):
     client.post("/api/cmd", json={"command": "tarefas", "thread": "work"}, headers=_auth())
     assert client.get("/api/history?thread=work", headers=_auth()).json()["messages"]
     r = client.post("/api/cmd", json={"command": "limparchat", "thread": "work"}, headers=_auth())
-    assert "limpa" in r.json()["reply"].lower()
+    assert "cleared" in r.json()["reply"].lower()
     assert client.get("/api/history?thread=work", headers=_auth()).json()["messages"] == []
 
 
@@ -331,7 +331,7 @@ def test_dados_shows_summary_on_web(tmp_path):
     # was returning "funciona no Telegram" — must show the storage summary now.
     client, _ = _client(tmp_path)
     reply = client.post("/api/cmd", json={"command": "dados"}, headers=_auth()).json()["reply"]
-    assert "guardados" in reply.lower()
+    assert "stored" in reply.lower()
     assert "funciona no telegram" not in reply.lower()
 
 


### PR DESCRIPTION
## 🤔 Context

Completes the assistant-language i18n effort: every deterministic slash-command reply now follows `assistant_lang` (English default / Portuguese) via the backend `t()` / `plural()` helpers in `ev/core/i18n.py`, instead of being hardcoded Portuguese.

This finishes the remaining command modules and shared plumbing:
- `weekly_summary.py`, `watches.py`, `search_news_weather.py`, `people.py`, `kb_docs.py` (incl. export/digest), `google_integration.py`, `automations.py`
- `ev/core/automations.py::describe()` (now `describe(auto, lang)`), the weekday/trigger/action fragments
- `overview.py`: `nudge_text` (`/pendencias`), `learned_patterns` + `learned_text` (`/padrões`/`/aprendi`)
- `ev/interfaces/web/context.py::run_command` (`/status`, `/modelo`, `/dados`, `/limparchat`, `/provedor`, `/resumir`, `/quiz`, …)
- `ev/core/commands/base.py`: the shared `_pick` not-found/ambiguous messages, `help()`, and the generic `run()` unknown-command / error strings

Command tests were updated to the new English default (with a few explicit Portuguese assertions and new en-vs-pt tests for representative commands). Full suite: 202 passing.

> [!NOTE]
> This finishes the whole assistant-language i18n effort (UI chrome, LLM chat, voice, dashboard text, and now command outputs). Input parsing, keywords, categories, and data are unchanged — only the human-readable reply text is localized. LLM-generated summaries (`/resumir`, `/quiz`) still use Portuguese prompts, which are out of scope for the deterministic-output work.