### PR TITLE
feat: localize the last non-command i18n paths (rain alert, dashboard weather)

### DIFF
--- a/ev/core/i18n.py
+++ b/ev/core/i18n.py
@@ -946,6 +946,27 @@ _CATALOG: dict[str, dict[str, str]] = {
         "en": "couldn't get the weather right now ({exc})",
         "pt": "não consegui o clima agora ({exc})",
     },
+    "web.wx_no_city": {
+        "en": "set a city (EV_CITY) or search for one in the field above",
+        "pt": "defina uma cidade (EV_CITY) ou busque uma no campo acima",
+    },
+    "web.wx_error_city": {
+        "en": "couldn't get the weather for '{city}'",
+        "pt": "não consegui o clima de '{city}'",
+    },
+    "web.gcal_not_authorized": {"en": "Google not authorized.", "pt": "Google não autorizado."},
+    "web.gcal_missing_fields": {
+        "en": "Title or start time missing.",
+        "pt": "Faltou título ou início.",
+    },
+    "web.email_missing_fields": {
+        "en": "Fill in recipient and message.",
+        "pt": "Preencha destinatário e mensagem.",
+    },
+    "web.email_send_error": {
+        "en": "Failed to send the email: {exc}",
+        "pt": "Falha ao enviar o email: {exc}",
+    },
     "tool.wx_current": {
         "en": "{name}: {temp}°C, {desc} (min {tmin}° / max {tmax}°)",
         "pt": "{name}: {temp}°C, {desc} (min {tmin}° / máx {tmax}°)",
@@ -990,6 +1011,17 @@ _CATALOG: dict[str, dict[str, str]] = {
     "wx.code.95": {"en": "thunderstorm", "pt": "tempestade"},
     "wx.code.96": {"en": "thunderstorm with hail", "pt": "tempestade com granizo"},
     "wx.code.99": {"en": "thunderstorm with hail", "pt": "tempestade com granizo"},
+    # compass wind directions shown on the dashboard weather detail
+    "wx.dir.0": {"en": "N", "pt": "N"},
+    "wx.dir.1": {"en": "NE", "pt": "NE"},
+    "wx.dir.2": {"en": "E", "pt": "L"},
+    "wx.dir.3": {"en": "SE", "pt": "SE"},
+    "wx.dir.4": {"en": "S", "pt": "S"},
+    "wx.dir.5": {"en": "SW", "pt": "SO"},
+    "wx.dir.6": {"en": "W", "pt": "O"},
+    "wx.dir.7": {"en": "NW", "pt": "NO"},
+    # web notification-center title for the daily rain alert
+    "notif.rain_title": {"en": "🌧️ Rain alert", "pt": "🌧️ Alerta de chuva"},
 }
 
 # Pluralized fragments: key -> {lang: (singular, plural)}. Both en and pt use the

--- a/ev/interfaces/telegram_bot/background_loops.py
+++ b/ev/interfaces/telegram_bot/background_loops.py
@@ -18,6 +18,7 @@ except Exception:  # pragma: no cover
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import Application, ContextTypes
 
+from ...core.i18n import t as _t
 from ...core.timeparse import add_months
 
 log = logging.getLogger("ev.telegram")
@@ -166,7 +167,8 @@ class BackgroundLoopsMixin:
             from ...providers import tools
             events = await asyncio.to_thread(
                 tools.calendar_list_range, cfg, cfg.default_account,
-                now.isoformat(), (now + timedelta(minutes=lead)).isoformat())
+                now.isoformat(), (now + timedelta(minutes=lead)).isoformat(),
+                250, self._memory.assistant_lang())
         except Exception:
             log.warning("event alert fetch failed", exc_info=True)
             return
@@ -254,10 +256,11 @@ class BackgroundLoopsMixin:
         if now.hour == cfg.rain_hour and self._last_rain != today:
             self._last_rain = today
             from ...providers import tools
-            msg = await asyncio.to_thread(tools.rain_tomorrow, cfg.city)
+            lang = self._memory.assistant_lang()
+            msg = await asyncio.to_thread(tools.rain_tomorrow, cfg.city, lang)
             if msg:
                 await self._bot_send(app.bot, cfg.owner_id, msg, self._quick_kb())
-                self._log_notif("🌧️ Alerta de chuva", msg)
+                self._log_notif(_t(lang, "notif.rain_title"), msg)
                 log.info("Sent rain alert.")
 
     async def _maybe_run_recurring(self, app: Application) -> None:

--- a/ev/interfaces/web/routes/email.py
+++ b/ev/interfaces/web/routes/email.py
@@ -10,6 +10,7 @@ import asyncio
 
 from fastapi import APIRouter, Request
 
+from ....core.i18n import t
 from ..context import WebContext
 
 
@@ -20,20 +21,21 @@ def build_router(ctx: WebContext) -> APIRouter:
     @router.post("/api/email")
     async def api_email(request: Request):
         ctx.check(request.headers.get("authorization"))
+        lang = ctx.memory.assistant_lang()
         from ....providers import tools
         d = await ctx.body(request)
         to = (d.get("to") or "").strip()
         subject = (d.get("subject") or "").strip()
         body = (d.get("body") or "").strip()
         if not to or not body:
-            return {"ok": False, "msg": "Preencha destinatário e mensagem."}
+            return {"ok": False, "msg": t(lang, "web.email_missing_fields")}
         account = (d.get("account") or "").strip() or config.default_account
         try:
             msg = await asyncio.to_thread(
-                tools.send_email, config, account, to, subject, body
+                tools.send_email, config, account, to, subject, body, lang
             )
             return {"ok": True, "msg": msg}
         except Exception as exc:
-            return {"ok": False, "msg": f"Falha ao enviar o email: {exc}"}
+            return {"ok": False, "msg": t(lang, "web.email_send_error", exc=exc)}
 
     return router

--- a/ev/interfaces/web/routes/gcal.py
+++ b/ev/interfaces/web/routes/gcal.py
@@ -12,6 +12,7 @@ import asyncio
 
 from fastapi import APIRouter, Request
 
+from ....core.i18n import t
 from ..context import WebContext
 
 
@@ -34,14 +35,16 @@ def build_router(ctx: WebContext) -> APIRouter:
     @router.get("/api/gcal")
     async def gcal_list(request: Request):
         ctx.check(request.headers.get("authorization"))
+        lang = ctx.memory.assistant_lang()
         if not config.google_ready() or not config.google_authorized():
-            return {"ok": False, "events": [], "msg": "Google não autorizado."}
+            return {"ok": False, "events": [], "msg": t(lang, "web.gcal_not_authorized")}
         start = request.query_params.get("start") or ""
         end = request.query_params.get("end") or ""
         from ....providers import tools
         try:
             events = await asyncio.to_thread(
-                tools.calendar_list_range, config, config.default_account, start, end)
+                tools.calendar_list_range, config, config.default_account, start, end,
+                250, lang)
             return {"ok": True, "events": events}
         except Exception as exc:
             return {"ok": False, "events": [], "msg": str(exc)}
@@ -49,12 +52,13 @@ def build_router(ctx: WebContext) -> APIRouter:
     @router.post("/api/gcal/create")
     async def gcal_create(request: Request):
         ctx.check(request.headers.get("authorization"))
+        lang = ctx.memory.assistant_lang()
         d = await ctx.body(request)
         summary = (d.get("summary") or "").strip()
         start = (d.get("start") or "").strip()
         end = (d.get("end") or "").strip()
         if not summary or not start:
-            return {"ok": False, "msg": "Faltou título ou início."}
+            return {"ok": False, "msg": t(lang, "web.gcal_missing_fields")}
         start_iso = _tz_iso(start)
         if end:
             end_iso = _tz_iso(end)
@@ -68,8 +72,9 @@ def build_router(ctx: WebContext) -> APIRouter:
         try:
             msg = await asyncio.to_thread(
                 tools.calendar_create, config, config.default_account,
-                summary, start_iso, end_iso)
-            ok = "criei" in msg.lower() or "criado" in msg.lower() or "http" in msg.lower()
+                summary, start_iso, end_iso, lang)
+            ml = msg.lower()
+            ok = "criei" in ml or "criado" in ml or "created" in ml or "http" in ml
             return {"ok": ok, "msg": msg}
         except Exception as exc:
             return {"ok": False, "msg": str(exc)}

--- a/ev/interfaces/web/routes/weather.py
+++ b/ev/interfaces/web/routes/weather.py
@@ -10,6 +10,7 @@ import asyncio
 
 from fastapi import APIRouter, Request
 
+from ....core.i18n import t
 from ....providers import tools as tools_mod
 from ..context import WebContext
 
@@ -27,9 +28,10 @@ def build_router(ctx: WebContext) -> APIRouter:
         sun = {}
         if city:
             try:
-                wf = await asyncio.to_thread(tools_mod.weather_full, city)
-                t = wf.get("today", {})
-                sun = {"sunrise": t.get("sunrise"), "sunset": t.get("sunset")}
+                lang = ctx.memory.assistant_lang()
+                wf = await asyncio.to_thread(tools_mod.weather_full, city, lang)
+                today = wf.get("today", {})
+                sun = {"sunrise": today.get("sunrise"), "sunset": today.get("sunset")}
             except Exception:
                 pass
         iss = {}
@@ -78,10 +80,11 @@ def build_router(ctx: WebContext) -> APIRouter:
     @router.get("/api/weather")
     async def weather_ep(request: Request):
         ctx.check(request.headers.get("authorization"))
+        lang = ctx.memory.assistant_lang()
         city = (request.query_params.get("city") or getattr(config, "city", "") or "").strip()
         if not city:
-            return {"error": "defina uma cidade (EV_CITY) ou busque uma no campo acima"}
-        data = await asyncio.to_thread(tools_mod.weather_full, city)
-        return data or {"error": f"não consegui o clima de '{city}'"}
+            return {"error": t(lang, "web.wx_no_city")}
+        data = await asyncio.to_thread(tools_mod.weather_full, city, lang)
+        return data or {"error": t(lang, "web.wx_error_city", city=city)}
 
     return router

--- a/ev/providers/tools/__init__.py
+++ b/ev/providers/tools/__init__.py
@@ -17,7 +17,6 @@ This package re-exports every public name that used to live directly in
 from __future__ import annotations
 
 from .weather import (
-    _WEATHER_CODES,
     weather,
     moon_phase,
     _wicon,

--- a/ev/providers/tools/calendar.py
+++ b/ev/providers/tools/calendar.py
@@ -45,7 +45,8 @@ def calendar_upcoming(config, account: str, max_results: int = 5,
 
 
 def calendar_list_range(
-    config, account: str, start_iso: str, end_iso: str, max_results: int = 250
+    config, account: str, start_iso: str, end_iso: str, max_results: int = 250,
+    lang: str = "en",
 ) -> list[dict]:
     """List Google Calendar events between start and end as structured dicts."""
     service = _google_service(config, account, "calendar", "v3")
@@ -58,12 +59,13 @@ def calendar_list_range(
         .execute()
         .get("items", [])
     )
+    no_title = t(lang, "tool.cal_no_title")
     out = []
     for e in events:
         s, en = e.get("start", {}), e.get("end", {})
         out.append({
             "id": e.get("id"),
-            "summary": e.get("summary", "(sem título)"),
+            "summary": e.get("summary", no_title),
             "start": s.get("dateTime") or s.get("date"),
             "end": en.get("dateTime") or en.get("date"),
             "all_day": "date" in s and "dateTime" not in s,

--- a/ev/providers/tools/weather.py
+++ b/ev/providers/tools/weather.py
@@ -8,15 +8,6 @@ from ...core.i18n import t
 
 log = logging.getLogger("ev.tools")
 
-_WEATHER_CODES = {
-    0: "céu limpo", 1: "predominância de sol", 2: "parcialmente nublado",
-    3: "nublado", 45: "névoa", 48: "névoa gelada", 51: "garoa fraca",
-    53: "garoa", 55: "garoa forte", 61: "chuva fraca", 63: "chuva",
-    65: "chuva forte", 71: "neve fraca", 73: "neve", 75: "neve forte",
-    80: "pancadas de chuva", 81: "pancadas de chuva", 82: "temporal",
-    95: "tempestade", 96: "tempestade com granizo", 99: "tempestade com granizo",
-}
-
 
 def _weather_desc(code, lang: str = "en") -> str:
     """Localized human-readable condition for an open-meteo weather code."""
@@ -96,7 +87,7 @@ def _wicon(code: int, is_day: bool = True) -> str:
     return "cloud"
 
 
-def weather_full(city: str) -> dict:
+def weather_full(city: str, lang: str = "en") -> dict:
     """Rich structured weather for a dashboard (open-meteo, no key).
     Returns {} on failure. Current + next hours + 10-day forecast."""
     import httpx
@@ -137,12 +128,12 @@ def weather_full(city: str) -> dict:
             hh = htimes[i][11:16]
             hourly.append({"time": hh, "temp": round(htemp[i]),
                            "icon": _wicon(int(hcode[i]), day)})
-        _WD = ["seg", "ter", "qua", "qui", "sex", "sáb", "dom"]
         days = []
         dt = daily.get("time", [])
         for i in range(len(dt)):
             try:
-                lbl = "Hoje" if i == 0 else _WD[datetime.fromisoformat(dt[i]).weekday()]
+                lbl = (t(lang, "tool.wx_today") if i == 0
+                       else t(lang, f"cal.wd.{datetime.fromisoformat(dt[i]).weekday()}"))
             except Exception:
                 lbl = dt[i][5:]
             days.append({"day": lbl,
@@ -150,7 +141,7 @@ def weather_full(city: str) -> dict:
                          "max": round(daily["temperature_2m_max"][i]),
                          "icon": _wicon(int(daily["weather_code"][i]), True)})
         name = loc["name"] + (f", {loc.get('admin1')}" if loc.get("admin1") else "")
-        _DIRS = ["N", "NE", "L", "SE", "S", "SO", "O", "NO"]
+        _DIRS = [t(lang, f"wx.dir.{i}") for i in range(8)]
         wdeg = cur.get("wind_direction_10m", 0)
         uvnow = round(hcode and (r.get("hourly", {}).get("uv_index", []) or [0])[start] or 0, 1) if htimes else 0
         prob = ((r.get("hourly", {}).get("precipitation_probability", []) or [0])[start]) if htimes else 0
@@ -159,7 +150,7 @@ def weather_full(city: str) -> dict:
             "current": {
                 "temp": round(cur.get("temperature_2m", 0)),
                 "feels": round(cur.get("apparent_temperature", 0)),
-                "desc": _WEATHER_CODES.get(code, ""),
+                "desc": _weather_desc(code, lang),
                 "icon": _wicon(code, day),
                 "high": round(daily["temperature_2m_max"][0]) if dt else None,
                 "low": round(daily["temperature_2m_min"][0]) if dt else None,

--- a/tests/test_weather_i18n.py
+++ b/tests/test_weather_i18n.py
@@ -1,0 +1,76 @@
+"""Weather-provider i18n: the dashboard/rain paths must follow the language,
+using the shared wx.code.* keys instead of a hardcoded Portuguese map."""
+
+import httpx
+
+from ev.providers.tools.weather import (
+    _weather_desc, rain_tomorrow, weather_full,
+)
+
+
+def test_weather_desc_switches_language():
+    assert _weather_desc(63, "en") == "rain"
+    assert _weather_desc(63, "pt") == "chuva"
+    assert _weather_desc(999, "en") == ""  # unknown code -> ""
+
+
+class _Resp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def _fake_get(geo, forecast):
+    def _get(url, *args, **kwargs):
+        return _Resp(geo if "geocoding" in url else forecast)
+    return _get
+
+
+def test_rain_tomorrow_switches_language(monkeypatch):
+    geo = {"results": [{"name": "Sampa", "latitude": 1, "longitude": 2}]}
+    forecast = {"daily": {"precipitation_probability_max": [10, 80],
+                          "weather_code": [1, 63]}}
+    monkeypatch.setattr(httpx, "get", _fake_get(geo, forecast))
+
+    en = rain_tomorrow("Sampa", "en")
+    pt = rain_tomorrow("Sampa", "pt")
+    assert en and "rain" in en.lower() and "umbrella" in en.lower()
+    assert pt and "chuva" in pt.lower() and "guarda-chuva" in pt.lower()
+
+
+def test_weather_full_switches_language(monkeypatch):
+    geo = {"results": [{"name": "Sampa", "latitude": 1, "longitude": 2,
+                        "admin1": "SP"}]}
+    forecast = {
+        "current": {
+            "time": "2026-08-20T10:00", "temperature_2m": 20,
+            "apparent_temperature": 19, "weather_code": 63, "is_day": 1,
+            "relative_humidity_2m": 70, "wind_speed_10m": 5,
+            "wind_direction_10m": 90, "wind_gusts_10m": 8,
+            "surface_pressure": 1012, "cloud_cover": 40,
+        },
+        "hourly": {
+            "time": ["2026-08-20T10:00"], "temperature_2m": [20],
+            "weather_code": [63], "precipitation_probability": [40],
+            "uv_index": [3],
+        },
+        "daily": {
+            "time": ["2026-08-20"], "temperature_2m_max": [25],
+            "temperature_2m_min": [15], "weather_code": [63],
+            "sunrise": ["2026-08-20T06:00"], "sunset": ["2026-08-20T18:00"],
+            "uv_index_max": [5], "precipitation_probability_max": [40],
+        },
+    }
+    monkeypatch.setattr(httpx, "get", _fake_get(geo, forecast))
+
+    en = weather_full("Sampa", "en")
+    pt = weather_full("Sampa", "pt")
+    assert en["current"]["desc"] == "rain"
+    assert pt["current"]["desc"] == "chuva"
+    # today label + wind direction (90deg -> East) also localize
+    assert en["daily"][0]["day"] == "Today"
+    assert pt["daily"][0]["day"] == "Hoje"
+    assert en["current"]["wind_dir"] == "E"
+    assert pt["current"]["wind_dir"] == "L"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -562,7 +562,8 @@ def test_kb_upload_recognizes_multipart_file(tmp_path):
 def test_email_endpoint_validates(tmp_path):
     client, _ = _client(tmp_path)
     r = client.post("/api/email", headers=_auth(), json={"to": "", "body": ""}).json()
-    assert r["ok"] is False and "destinat" in r["msg"].lower()
+    # localized (defaults to English); message follows assistant_lang
+    assert r["ok"] is False and "recipient" in r["msg"].lower()
 
 
 def test_notify_endpoint_validates(tmp_path):


### PR DESCRIPTION
## 🤔 Context

The tools-localization work (#186) taught the provider tool functions (calendar/email/websearch/weather) to accept a `lang` param and localize via `ev/core/i18n.py`, and wired the brain's tool callables + command callers to pass the real `assistant_lang()`. But a handful of **non-command** callers still passed the `"en"` default, so their output stayed English even when the user picked Portuguese — and `weather_full` kept its own hardcoded Portuguese weather-code map.

This PR closes those last edge gaps so there are no user-facing Portuguese strings regardless of language:

- **Telegram rain alert** (`background_loops.py`): `rain_tomorrow` and the notification title now use `self._memory.assistant_lang()`. The event-alert `calendar_list_range` call is threaded too.
- **Dashboard weather detail** (`weather_full` + `routes/weather.py`): `weather_full` now takes `lang`, uses the shared `_weather_desc`/`wx.code.*` keys instead of its own PT `_WEATHER_CODES` map, and localizes its today/weekday labels (`tool.wx_today`, `cal.wd.*`) and wind directions (new `wx.dir.*` keys). The route passes `ctx.memory.assistant_lang()`.
- **Web calendar/email direct routes** (`routes/gcal.py`, `routes/email.py`): `calendar_list_range`, `calendar_create`, and `send_email` receive `assistant_lang()`, and their inline validation/error strings are localized via new `web.*` keys.

`calendar_list_range` gained a `lang` param (it previously had none) to localize its `(sem título)` default.

> [!NOTE]
> LLM tool schemas, command behavior, and everything already localized by #186 are untouched — this only threads language into the remaining non-command callers.

Tests: 206 passed (incl. `test_brain_tools_sync.py`); added `tests/test_weather_i18n.py` asserting `weather_full`/`rain_tomorrow`/`_weather_desc` switch EN↔PT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)