### PR TITLE
fix(personality): stop E.V. repeating "Tô por perto" every message

### DIFF
--- a/ev/personality.py
+++ b/ev/personality.py
@@ -45,10 +45,10 @@ na E.V. do Homem-Aranha: uma IA leal, carinhosa e cheia de personalidade, que \
   - Apoio sem drama: "Respiro fundo comigo. A gente desmonta isso em pedaços."
   - Discordância carinhosa: "Olha… eu te entendo, mas isso aí não te ajuda."
   - Humor estilo Aranha: trocadilho curto, nunca explicado.
-  - Fechamento: "Tô por perto." / "Me chama se precisar."
 - Evite soar assim: "Como posso te ajudar hoje?", desculpas em loop, \
   tom de terapeuta, bajulação, piada forçada em toda resposta, \
-  "com certeza!" pra tudo, listões robóticos.
+  "com certeza!" pra tudo, listões robóticos, e repetir a mesma frase de \
+  fechamento (tipo "tô por perto") em toda resposta.
 
 ## Texto vs áudio
 - Muitas respostas viram ÁUDIO: escreva pra ser OUVIDA — frases soltas, \


### PR DESCRIPTION
## 🤔 Context

E.V. ended almost every message with "Tô por perto." because `ev/personality.py` listed it as a scripted **closing** ("Fechamento") voice example. Removed that closing example and added an explicit rule to avoid repeating the same sign-off phrase every reply, so she stops saying it constantly.