### PR TITLE
ci: fix deploy race — serialize deploys + unique artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,13 @@ jobs:
     needs: [test, lint]  # only runs if tests + lint pass
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    # Serialize deploys: a burst of merges (e.g. several Dependabot PRs at once)
+    # must NOT run this job in parallel — concurrent deploys raced on the shared
+    # ~/ev.tgz on the VM and corrupted the tarball mid-transfer. Queue them
+    # instead (cancel-in-progress: false → never abort a deploy mid scp/ssh).
+    concurrency:
+      group: deploy-ev-vm
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v7
 
@@ -49,15 +56,20 @@ jobs:
         env:
           VM: ${{ secrets.VM_USER }}@${{ secrets.VM_IP }}
         run: |
-          tar czf /tmp/ev.tgz ev run_telegram.py run_terminal.py run_web.py \
+          # Unique artifact name per run so overlapping deploys can never read a
+          # tarball another job is still writing (belt-and-suspenders alongside
+          # the concurrency guard above). Cleaned up on the VM after extraction.
+          PKG="ev-${GITHUB_SHA}.tgz"
+          tar czf "/tmp/${PKG}" ev run_telegram.py run_terminal.py run_web.py \
             requirements.txt deploy docs tests authorize_google.py README.md
           scp -i ~/.ssh/id_key -o StrictHostKeyChecking=accept-new \
-            /tmp/ev.tgz "$VM:~/ev.tgz"
-          ssh -i ~/.ssh/id_key -o StrictHostKeyChecking=accept-new "$VM" '
+            "/tmp/${PKG}" "$VM:~/${PKG}"
+          ssh -i ~/.ssh/id_key -o StrictHostKeyChecking=accept-new "$VM" "
             cd ~/ev &&
-            tar xzf ~/ev.tgz &&
+            tar xzf ~/${PKG} &&
+            rm -f ~/${PKG} &&
             ./.venv/bin/pip install -q -r requirements.txt &&
             sudo systemctl restart ev &&
             (sudo systemctl restart ev-web 2>/dev/null || true) &&
             sleep 5 &&
-            systemctl is-active ev'
+            systemctl is-active ev"


### PR DESCRIPTION
## 🤔 Context

Three deploy runs failed on 2026-08-21 (#198, #199, #201) with a corrupt tarball on the VM:

```
tar: Skipping to next header
gzip: stdin: invalid compressed data--crc error
tar: Error is not recoverable: exiting now
```

**Root cause: a race between concurrent deploys, not the app code.** Dependabot merged 5 PRs into `main` within ~45s. Each merge triggers the deploy job, so 5 deploy jobs ran in parallel — and every one of them `scp`'d to the **same fixed path** `~/ev.tgz` on the VM and then `tar xzf`'d it. One job extracted the file while another was still overwriting it → truncated gzip stream. The runs that happened to hit a clean window (#197, #200) passed.

The service stayed up the whole time: the corrupt `tar` aborts *before* `systemctl restart` (the commands are chained with `&&`), so no failed run restarted E.V. with broken code, and the watchdog kept reporting healthy.

## What this PR does

1. **`concurrency` guard on the deploy job** (`group: deploy-ev-vm`, `cancel-in-progress: false`) — deploys now queue and run one at a time, so a burst of merges can't race. `cancel-in-progress: false` so a running deploy is never aborted mid `scp`/`ssh`.
2. **Unique artifact name per run** (`ev-<sha>.tgz`, removed after extraction) — belt-and-suspenders so overlapping jobs can never touch the same file even if the guard is ever bypassed.

No application code touched; only `.github/workflows/deploy.yml`.

> [!NOTE]
> This doesn't change *what* is deployed, only how the transfer is coordinated. Path/method/restart logic are unchanged.