### PR TITLE
fix: boot greeting spoken in the wrong language voice

### DIFF
--- a/ev/interfaces/web/routes/chat.py
+++ b/ev/interfaces/web/routes/chat.py
@@ -50,7 +50,11 @@ def build_router(ctx: WebContext) -> APIRouter:
         except Exception:
             phrase = _t(memory.assistant_lang(), "greeting.welcome_back", name="Ryan")
         try:
-            audio, mime = await voice_mod.synth_web(config, phrase)
+            # Pass the assistant language so the boot briefing is SPOKEN in the
+            # right voice (en-US when English) — the phrase text already honors
+            # it via spoken_status; without this it fell back to the pt-BR voice.
+            audio, mime = await voice_mod.synth_web(
+                config, phrase, lang=memory.assistant_lang())
         except Exception:
             audio, mime = b"", "audio/mpeg"
         return R(content=audio, media_type=mime)


### PR DESCRIPTION
## 🤔 Context

E.V.'s **voice was pt-BR even with the UI/mode in English** — most audible on the boot briefing that plays when the web console loads.

Root cause: the `/api/greeting` route built the phrase in the correct language (`spoken_status` already honors `assistant_lang`) but called `synth_web(config, phrase)` **without `lang`**, so the synthesizer fell back to the default pt-BR voice (`config.voice`) — a Brazilian voice reading English text.

Every other TTS caller already forwarded the language (`/api/tts`, the Telegram path). This was the one gap.

## Fix

Forward `lang=memory.assistant_lang()` to `synth_web` in the greeting endpoint, so the spoken briefing uses the en-US voice when the assistant language is English.

```diff
- audio, mime = await voice_mod.synth_web(config, phrase)
+ audio, mime = await voice_mod.synth_web(config, phrase, lang=memory.assistant_lang())
```

One-line change in `ev/interfaces/web/routes/chat.py`; no other behavior touched. Audited all `synth_web`/`synthesize` callers — the remaining ones already pass `lang` or an explicit voice.