### PR TITLE
fix: command dispatcher crashed on its own error handler

### DIFF
--- a/ev/core/commands/base.py
+++ b/ev/core/commands/base.py
@@ -477,4 +477,4 @@ class Commands(
         try:
             return fn(user_id, argstr or "")
         except Exception as exc:  # never crash the chat turn
-            return _t(lang, "cmd.error", key=key, exc=exc)
+            return _t(lang, "cmd.error", cmd=key, exc=exc)

--- a/ev/core/i18n.py
+++ b/ev/core/i18n.py
@@ -736,7 +736,7 @@ _CATALOG: dict[str, dict[str, str]] = {
         "en": "I don't know the command '{name}'. Commands I can run: {cmds}",
         "pt": "Não conheço o comando '{name}'. Comandos que posso executar: {cmds}",
     },
-    "cmd.error": {"en": "Error running {key}: {exc}", "pt": "Erro ao executar {key}: {exc}"},
+    "cmd.error": {"en": "Error running {cmd}: {exc}", "pt": "Erro ao executar {cmd}: {exc}"},
     "help.text": {
         "en": (
             "🕷️ E.V. — all commands\n"

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -48,6 +48,18 @@ def test_run_unknown_command(tmp_path):
     assert "don't know" in out.lower()
 
 
+def test_run_never_crashes_on_internal_exception(tmp_path, monkeypatch):
+    """A command raising internally must produce a friendly cmd.error message,
+    not propagate — regression test for a `_t(..., key=key, ...)` kwarg
+    collision with t()'s own `key` parameter that made the error handler
+    itself raise TypeError, crashing the whole chat/voice turn."""
+    c = _commands(tmp_path)
+    monkeypatch.setattr(c, "tarefa", lambda u, a: (_ for _ in ()).throw(ValueError("boom")))
+    out = c.run("u", "tarefa", "x")
+    assert "tarefa" in out
+    assert "boom" in out
+
+
 def test_runnable_lists_core_commands(tmp_path):
     names = _commands(tmp_path).runnable()
     for expected in ("tarefa", "gasto", "habito", "lembrete", "esquecer", "diario"):


### PR DESCRIPTION
## 🤔 Context

While doing a broader functional sweep of E.V.'s commands (in response to "will all the features actually work"), I ran every dispatchable command through `Commands.run()` directly (not just the ones with dedicated unit tests) and found that **any command raising a real internal exception crashes the whole turn** instead of degrading gracefully.

Root cause: `Commands.run()`'s except-branch does
```python
except Exception as exc:
    return _t(lang, "cmd.error", key=key, exc=exc)
```
but `i18n.t(lang: str, key: str, **kwargs)` already has a positional parameter named `key` — so the `key=key` kwarg collides with it:
```
TypeError: t() got multiple values for argument 'key'
```
This means the "never crash the chat turn" comment right above that line wasn't true: any command failing for a legitimate reason (bad date input, a flaky external API, a missing config value) blew up the request instead of returning `"Error running X: ..."`. This is the exact code path the AI's hands-free `executar_comando` tool and the web console's `/api/cmd` endpoint depend on.

It was never caught by tests because no existing test forces a command to raise mid-execution — they only test the happy path and the "unknown command" path.

## Fix

- Renamed the collision: template placeholder + kwarg `key` → `cmd` (`cmd.error` string in `ev/core/i18n.py`, call site in `ev/core/commands/base.py`). `t()`'s signature is untouched — this was the only call site using `key=` as a kwarg.
- Added `test_run_never_crashes_on_internal_exception` in `tests/test_dispatch.py`: monkeypatches a command to raise and asserts `run()` still returns a normal string instead of propagating.

215/215 tests pass, ruff clean.