### PR TITLE
fix: English commands silently falling back to Portuguese output

### DIFF
--- a/ev/core/commands/overview.py
+++ b/ev/core/commands/overview.py
@@ -165,8 +165,8 @@ class OverviewMixin:
         else:
             on = not cur
         self._memory.set_setting("serious_mode", "1" if on else "0")
-        return ("🔴 Modo foco ativado. Foco total."
-                if on else "Modo foco desativado. De volta ao normal.")
+        lang = self._memory.assistant_lang()
+        return _t(lang, "ov.focus_on") if on else _t(lang, "ov.focus_off")
 
     def budget_alerts(self, user_id: str, warn_pct: int = 80) -> list:
         """Budgets at/over threshold this month. level='over' (>=100%) or

--- a/ev/interfaces/telegram_bot/commands_wrappers.py
+++ b/ev/interfaces/telegram_bot/commands_wrappers.py
@@ -10,10 +10,11 @@ import html
 import re
 from datetime import datetime, timedelta, timezone
 
-from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram import BotCommand, InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import ContextTypes
 
 from ...core import health
+from ...core.commands import command_list
 from ...core.memory import Memory
 from ...providers import tools as tools_mod
 
@@ -229,6 +230,14 @@ class CommandsWrappersMixin:
             await update.message.reply_text("Opções: en, pt.")
             return
         lang = self._memory.set_assistant_lang(arg)
+        # Refresh the "/" command menu so it shows names in the new language too
+        # (set_my_commands is otherwise only called once, at bot startup).
+        try:
+            await c.bot.set_my_commands(
+                [BotCommand(n, d) for n, d in command_list(lang)]
+            )
+        except Exception:
+            pass
         await update.message.reply_text(
             f"🌐 Pronto — agora respondo e falo em <b>{self._LANG_LABELS.get(lang, lang)}</b>.",
             parse_mode="HTML",

--- a/ev/interfaces/web/context.py
+++ b/ev/interfaces/web/context.py
@@ -20,7 +20,7 @@ import logging
 from ...core import health
 from ...core.brain import Brain
 from ...core.i18n import t as _t
-from ...core.commands import Commands, portuguese_name
+from ...core.commands import Commands, english_name, portuguese_name
 from ...core.memory import Memory
 from ...providers import tools as tools_mod
 
@@ -186,7 +186,8 @@ class WebContext:
                 f"Trecho de [{chunk['source']}]:\n{chunk['chunk']}")
             return out or _t(lang, "web.quiz_fail")
         if name in ("foco", "exportar", "transcrever", "documento", "insights", "menu"):
-            return _t(lang, "web.telegram_only", name=name)
+            shown = english_name(name) if lang == "en" else name
+            return _t(lang, "web.telegram_only", name=shown)
         return commands.run(owner, name, rest)  # -> "não conheço"
 
     def base_url(self, request) -> str:

--- a/ev/interfaces/web/frontend.py
+++ b/ev/interfaces/web/frontend.py
@@ -1386,6 +1386,9 @@ function applyLang(lang,initial){_lang=I18N[lang]?lang:'en';localStorage.setItem
     // Unified control: choosing the UI language also sets how E.V. talks
     // (LLM replies + TTS voice). Fire-and-forget, like the focus-mode toggle.
     try{fetch('/api/lang',{method:'POST',headers:H(),body:JSON.stringify({lang:_lang})}).catch(()=>{});}catch(e){}
+    // Refresh the slash-command palette so it shows names in the new language
+    // right away (it's otherwise only fetched once, at page load).
+    try{fetch('/api/commands',{headers:H()}).then(r=>r.json()).then(d=>{if(d&&d.commands)COMMANDS=d.commands;}).catch(()=>{});}catch(e){}
     try{if(typeof renderTabs==='function')renderTabs();}catch(e){}
     try{if(typeof renderActs==='function')renderActs();}catch(e){}
     try{if(typeof renderStats==='function')renderStats();}catch(e){}

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -64,6 +64,31 @@ def test_serious_mode(tmp_path):
     assert client.get("/api/panel", headers=_auth()).json()["serious"] is False
 
 
+def test_focus_command_localized(tmp_path):
+    """Regression: /focus (and /modo) hardcoded Portuguese output regardless of
+    assistant_lang, even though the i18n keys already existed."""
+    client, _ = _client(tmp_path)
+    client.post("/api/lang", json={"lang": "en"}, headers=_auth())
+    on = client.post("/api/cmd", json={"command": "focus"}, headers=_auth()).json()
+    assert "Focus mode on" in on["reply"]
+    off = client.post("/api/cmd", json={"command": "focus"}, headers=_auth()).json()
+    assert "Focus mode off" in off["reply"]
+    client.post("/api/lang", json={"lang": "pt"}, headers=_auth())
+    pt = client.post("/api/cmd", json={"command": "modo"}, headers=_auth()).json()
+    assert "Modo foco ativado" in pt["reply"]
+
+
+def test_telegram_only_redirect_shows_localized_command_name(tmp_path):
+    """Regression: the web console's redirect message for Telegram-only
+    commands (/export, /document, ...) always named the command in Portuguese
+    (e.g. "/exportar is better...") even when the reply itself was in English."""
+    client, _ = _client(tmp_path)
+    client.post("/api/lang", json={"lang": "en"}, headers=_auth())
+    r = client.post("/api/cmd", json={"command": "export"}, headers=_auth()).json()
+    assert "/export " in r["reply"]
+    assert "exportar" not in r["reply"]
+
+
 def test_lang_setting(tmp_path):
     client, _ = _client(tmp_path)
     # default is English when unset


### PR DESCRIPTION
## 🤔 Context

Following up on "are all of E.V.'s features actually working" — instead of trusting unit tests alone, I ran **every command through the real dispatch/web/Telegram code paths, in both languages**, using the actual `Commands.run()`, the FastAPI `TestClient`, and a real `telegram.ext.Application` with polling stubbed out.

Routing itself was already correct everywhere (English alias → Portuguese canonical name → handler — 0 missing aliases across 129 registered Telegram command strings). But three real **output/UI-language gaps** surfaced:

1. **`/focus` always replied in Portuguese** regardless of `assistant_lang` — `modo()` in `overview.py` hardcoded `"🔴 Modo foco ativado..."` directly instead of using the `ov.focus_on`/`ov.focus_off` i18n keys that already existed unused.
2. **The "this command is better on Telegram" redirect** (for `/document`, `/export`, `/transcribe`, `/insights`, `/menu`) always named the command in Portuguese in the message, even when replying in English and even when the user typed the English alias.
3. **Neither command menu refreshes on a language switch.** Telegram's "/" autocomplete is set once at bot startup (`set_my_commands`); the web console's slash-command palette is fetched once at page load. Switching language via `/idioma` (Telegram) or the globe picker (web) never refreshed either, so the visible command list kept showing the old language until a restart/reload — even though typing the command manually in the new language always worked.

> [!NOTE]
> This is likely what looked like "English commands don't work" — the palette/menu kept *showing* Portuguese names after a language switch, making it look like English wasn't supported, and `/focus` replying in Portuguese reinforced that impression.
>
> Separately noted, **not fixed here** (pre-existing, unrelated to i18n): `/mute` (`silenciar`) was never implemented in the web console at all, in either language.

## Fix

- `ev/core/commands/overview.py`: `modo()` now returns `_t(lang, "ov.focus_on"/"ov.focus_off")`.
- `ev/interfaces/web/context.py`: the Telegram-only redirect now shows `english_name(name)` when `lang == "en"`.
- `ev/interfaces/telegram_bot/commands_wrappers.py`: `/idioma` now re-calls `bot.set_my_commands(...)` after switching, so the Telegram menu updates immediately.
- `ev/interfaces/web/frontend.py`: `applyLang()` now refetches `/api/commands` so the web command palette updates immediately.

Added regression tests (`test_focus_command_localized`, `test_telegram_only_redirect_shows_localized_command_name`). The Telegram menu refresh was verified manually (built a real `Application`, inspected registered `BotCommand` sets) rather than unit-tested — mocking `Update`/`Context` for one wrapper wasn't worth the added complexity.

217/217 tests pass, ruff clean, full console audit (48 view×lang checks) still clean.